### PR TITLE
clippy: ptr_as_ptr

### DIFF
--- a/src/runtime/buffer/circular.rs
+++ b/src/runtime/buffer/circular.rs
@@ -112,7 +112,7 @@ impl BufferWriterHost for Writer {
         let (space, offset) = self.space_available();
         unsafe {
             (
-                self.buffer.addr().add(offset * self.item_size) as *mut u8,
+                self.buffer.addr().add(offset * self.item_size).cast::<u8>(),
                 space * self.item_size,
             )
         }
@@ -250,7 +250,7 @@ impl BufferReaderHost for Reader {
 
         unsafe {
             (
-                self.ptr.add(reader_offset * self.item_size) as *const u8,
+                self.ptr.add(reader_offset * self.item_size).cast::<u8>(),
                 space * self.item_size,
             )
         }
@@ -328,7 +328,7 @@ mod tests {
             let (buff, size) = w.bytes();
 
             unsafe {
-                let buff = slice::from_raw_parts_mut::<u64>(buff as *mut u64, size / item_size);
+                let buff = slice::from_raw_parts_mut::<u64>(buff.cast::<u64>(), size / item_size);
                 for i in 0..10 {
                     buff[i] = i as u64;
                 }

--- a/src/runtime/buffer/double_mapped_temp_file.rs
+++ b/src/runtime/buffer/double_mapped_temp_file.rs
@@ -46,7 +46,7 @@ impl DoubleMappedTempFile {
             fd = libc::mkstemp(path as *mut libc::c_char);
             ensure!(fd >= 0, "tempfile could not be created");
 
-            let ret = libc::unlink(path as *const libc::c_char);
+            let ret = libc::unlink(path.cast::<i8>());
             if ret < 0 {
                 libc::close(fd);
                 bail!("unlinking failed");
@@ -137,9 +137,9 @@ mod test {
 
         unsafe {
             let b1 =
-                slice::from_raw_parts_mut::<u64>(b.addr as *mut u64, ps / mem::size_of::<u64>());
+                slice::from_raw_parts_mut::<u64>(b.addr.cast::<u64>(), ps / mem::size_of::<u64>());
             let b2 = slice::from_raw_parts_mut::<u64>(
-                b.addr.add(b.size) as *mut u64,
+                b.addr.add(b.size).cast::<u64>(),
                 ps / mem::size_of::<u64>(),
             );
             for (i, v) in b1.iter_mut().enumerate() {

--- a/src/runtime/stream_io.rs
+++ b/src/runtime/stream_io.rs
@@ -122,7 +122,7 @@ impl StreamOutput {
     pub fn slice<T>(&mut self) -> &'static mut [T] {
         let (ptr, len) = self.writer.as_mut().unwrap().bytes();
 
-        unsafe { slice::from_raw_parts_mut(ptr as *mut T, len / mem::size_of::<T>()) }
+        unsafe { slice::from_raw_parts_mut(ptr.cast::<T>(), len / mem::size_of::<T>()) }
     }
 
     pub async fn notify_finished(&mut self) {


### PR DESCRIPTION
## Motivation

Change casts that don't change mut to `.cast<T>()`.

