### PR TITLE
feature/ZeroMQ

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ members = [
     "examples/android",
     "examples/logging",
     "examples/wasm",
+    "examples/zmq",
     "perf/msg",
     "perf/null_rand",
 ]
@@ -37,6 +38,7 @@ anyhow = "1.0.38"
 async-trait = "0.1.41"
 clap = "2.33.1"
 config = "0.11.0"
+cpal="0.13.4"
 dirs = "3.0.1"
 futures = "0.3.5"
 futures-lite = "1.10.0"
@@ -49,6 +51,7 @@ rand = "0.8.0"
 slab = "0.4.4"
 spin = "0.9.0"
 serde = { version = "1.0", features = ["derive"] }
+zmq = "0.9"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 wasm-rs-async-executor = "0.9.0"
@@ -91,6 +94,7 @@ winapi = { version = "0.3", features = ["sysinfoapi", "winbase", "handleapi", "m
 async-channel = "1.6.1"
 async-executor = "1.3.0"
 easy-parallel = "3.1.0"
+#clang-sys = "1.2.1"
 
 [profile.release]
 codegen-units = 1
@@ -98,3 +102,7 @@ debug = true
 lto = "fat"
 opt-level = 3
 panic = "abort"
+
+[build-dependencies]
+bindgen = "0.57.0"
+clang = { version = "1.0.3", features = ["runtime"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,10 +25,11 @@ members = [
 ]
 
 [features]
-default = ["soapy", "vulkan"]
+default = ["soapy", "vulkan", "zeromq"]
 soapy = ["soapysdr"]
 vulkan = ["vulkano", "vulkano-shaders"]
 zynq = ["xilinx-dma"]
+zeromq = ["zmq"]
 
 [package.metadata.docs.rs]
 no-default-features = true
@@ -51,7 +52,7 @@ rand = "0.8.0"
 slab = "0.4.4"
 spin = "0.9.0"
 serde = { version = "1.0", features = ["derive"] }
-zmq = "0.9"
+zmq = {version = "0.9", optional = true}
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 wasm-rs-async-executor = "0.9.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ members = [
     "examples/android",
     "examples/logging",
     "examples/wasm",
-    "examples/zmq",
+    "examples/zeromq",
     "perf/msg",
     "perf/null_rand",
 ]

--- a/examples/zeromq/Cargo.toml
+++ b/examples/zeromq/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "zeromq"
+version = "0.1.0"
+edition = "2018"
+
+[dependencies]
+futuresdr = { path = "../..", default-features = false }
+log = "0.4.14"
+anyhow = "1.0.38"
+env_logger = "0.9.0"
+
+[[bin]]
+name = "zmq-receiver"
+path = "zmq_receiver.rs"
+
+[[bin]]
+name = "zmq-emitter"
+path = "zmq_emitter.rs"

--- a/examples/zeromq/Cargo.toml
+++ b/examples/zeromq/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-futuresdr = { path = "../..", default-features = false }
+futuresdr = { path = "../..", default-features = false, features=["zeromq"] }
 log = "0.4.14"
 anyhow = "1.0.38"
 env_logger = "0.9.0"

--- a/examples/zeromq/zmq_emitter.rs
+++ b/examples/zeromq/zmq_emitter.rs
@@ -1,11 +1,17 @@
 use anyhow::Result;
-
+use env_logger::Builder;
 use futuresdr::blocks::NullSource;
 use futuresdr::blocks::ZMQPubSinkBuilder;
 use futuresdr::runtime::Flowgraph;
 use futuresdr::runtime::Runtime;
+use log::LevelFilter;
 
 fn main() -> Result<()> {
+    let mut builder = Builder::from_default_env();
+    builder
+        .filter(Some("futuresdr::blocks"), LevelFilter::Info)
+        .init();
+
     let mut fg = Flowgraph::new();
 
     let src = fg.add_block(NullSource::new(4));

--- a/examples/zeromq/zmq_emitter.rs
+++ b/examples/zeromq/zmq_emitter.rs
@@ -1,0 +1,19 @@
+use anyhow::Result;
+
+use futuresdr::blocks::NullSource;
+use futuresdr::blocks::ZMQPubSinkBuilder;
+use futuresdr::runtime::Flowgraph;
+use futuresdr::runtime::Runtime;
+
+fn main() -> Result<()> {
+    let mut fg = Flowgraph::new();
+
+    let src = fg.add_block(NullSource::new(4));
+    let snk = fg.add_block(ZMQPubSinkBuilder::new(4).address("tcp://*:50001").build());
+
+    fg.connect_stream(src, "out", snk, "in")?;
+
+    Runtime::new().run(fg)?;
+
+    Ok(())
+}

--- a/examples/zeromq/zmq_receiver.rs
+++ b/examples/zeromq/zmq_receiver.rs
@@ -1,13 +1,22 @@
 use anyhow::Result;
+use env_logger::Builder;
 use futuresdr::blocks::FileSink;
 use futuresdr::blocks::ZMQSubSourceBuilder;
 use futuresdr::runtime::Flowgraph;
 use futuresdr::runtime::Runtime;
+use log::LevelFilter;
 
 fn main() -> Result<()> {
+    let mut builder = Builder::from_default_env();
+    builder.filter(None, LevelFilter::Debug).init();
+
     let mut fg = Flowgraph::new();
 
-    let zmq_src = fg.add_block(ZMQSubSourceBuilder::new(1).address("tcp://localhost:50001").build());
+    let zmq_src = fg.add_block(
+        ZMQSubSourceBuilder::new(1)
+            .address("tcp://localhost:50001")
+            .build(),
+    );
     let snk = fg.add_block(FileSink::new(1, "/tmp/zmq-log.bin".to_string()));
 
     fg.connect_stream(zmq_src, "out", snk, "in")?;

--- a/examples/zeromq/zmq_receiver.rs
+++ b/examples/zeromq/zmq_receiver.rs
@@ -1,0 +1,18 @@
+use anyhow::Result;
+use futuresdr::blocks::FileSink;
+use futuresdr::blocks::ZMQSubSourceBuilder;
+use futuresdr::runtime::Flowgraph;
+use futuresdr::runtime::Runtime;
+
+fn main() -> Result<()> {
+    let mut fg = Flowgraph::new();
+
+    let zmq_src = fg.add_block(ZMQSubSourceBuilder::new(1).address("tcp://localhost:50001").build());
+    let snk = fg.add_block(FileSink::new(1, "/tmp/zmq-log.bin".to_string()));
+
+    fg.connect_stream(zmq_src, "out", snk, "in")?;
+
+    Runtime::new().run(fg)?;
+
+    Ok(())
+}

--- a/src/blocks/mod.rs
+++ b/src/blocks/mod.rs
@@ -73,6 +73,12 @@ mod websocket_sink;
 #[cfg(not(target_arch = "wasm32"))]
 pub use websocket_sink::{WebsocketSink, WebsocketSinkBuilder, WebsocketSinkMode};
 
+mod zmq_pub_sink;
+pub use zmq_pub_sink::{ZMQPubSink, ZMQPubSinkBuilder};
+
+mod zmq_sub_source;
+pub use zmq_sub_source::{ZMQSubSource, ZMQSubSourceBuilder};
+
 #[cfg(feature = "zynq")]
 mod zynq;
 #[cfg(feature = "zynq")]

--- a/src/blocks/mod.rs
+++ b/src/blocks/mod.rs
@@ -73,10 +73,14 @@ mod websocket_sink;
 #[cfg(not(target_arch = "wasm32"))]
 pub use websocket_sink::{WebsocketSink, WebsocketSinkBuilder, WebsocketSinkMode};
 
+#[cfg(feature = "zeromq")]
 mod zmq_pub_sink;
+#[cfg(feature = "zeromq")]
 pub use zmq_pub_sink::{ZMQPubSink, ZMQPubSinkBuilder};
 
+#[cfg(feature = "zeromq")]
 mod zmq_sub_source;
+#[cfg(feature = "zeromq")]
 pub use zmq_sub_source::{ZMQSubSource, ZMQSubSourceBuilder};
 
 #[cfg(feature = "zynq")]

--- a/src/blocks/zmq_pub_sink.rs
+++ b/src/blocks/zmq_pub_sink.rs
@@ -43,7 +43,7 @@ impl AsyncKernel for ZMQPubSink {
 
         let n = i.len() / self.item_size;
         if n > 0 {
-            print!("pushing");
+            print!(".");
             self.publisher.as_mut().unwrap().send(&*i, 0).unwrap();
             sio.input(0).consume(n);
         }

--- a/src/blocks/zmq_pub_sink.rs
+++ b/src/blocks/zmq_pub_sink.rs
@@ -19,7 +19,7 @@ pub struct ZMQPubSink {
 impl ZMQPubSink {
     pub fn new(item_size: usize, address: &str) -> Block {
         Block::new_async(
-            BlockMetaBuilder::new("ZMQPubSink").build(),
+            BlockMetaBuilder::new("ZMQPubSink").blocking().build(),
             StreamIoBuilder::new()
                 .add_stream_input("in", item_size)
                 .build(),

--- a/src/blocks/zmq_pub_sink.rs
+++ b/src/blocks/zmq_pub_sink.rs
@@ -1,0 +1,93 @@
+use anyhow::Result;
+
+use crate::runtime::AsyncKernel;
+use crate::runtime::Block;
+use crate::runtime::BlockMeta;
+use crate::runtime::BlockMetaBuilder;
+use crate::runtime::MessageIo;
+use crate::runtime::MessageIoBuilder;
+use crate::runtime::StreamIo;
+use crate::runtime::StreamIoBuilder;
+use crate::runtime::WorkIo;
+
+pub struct ZMQPubSink {
+    item_size: usize,
+    address: String,
+    publisher: Option<zmq::Socket>,
+}
+
+impl ZMQPubSink {
+    pub fn new(item_size: usize, address: &str) -> Block {
+        Block::new_async(
+            BlockMetaBuilder::new("ZMQPubSink").build(),
+            StreamIoBuilder::new()
+                .add_stream_input("in", item_size)
+                .build(),
+            MessageIoBuilder::new().build(),
+            ZMQPubSink { item_size, address: address.to_string(), publisher: None },
+        )
+    }
+}
+
+#[async_trait]
+impl AsyncKernel for ZMQPubSink {
+    async fn work(
+        &mut self,
+        io: &mut WorkIo,
+        sio: &mut StreamIo,
+        _mio: &mut MessageIo<Self>,
+        _meta: &mut BlockMeta,
+    ) -> Result<()> {
+        let i = sio.input(0).slice::<u8>();
+        debug_assert_eq!(i.len() % self.item_size, 0);
+
+        let n = i.len() / self.item_size;
+        if n > 0 {
+            print!("pushing");
+            self.publisher.as_mut().unwrap().send(&*i, 0).unwrap();
+            sio.input(0).consume(n);
+        }
+
+        if sio.input(0).finished() {
+            io.finished = true;
+        }
+
+        Ok(())
+    }
+
+    async fn init(
+        &mut self,
+        _sio: &mut StreamIo,
+        _mio: &mut MessageIo<Self>,
+        _meta: &mut BlockMeta,
+    ) -> Result<()> {
+        let context = zmq::Context::new();
+        let publisher = context.socket(zmq::PUB).unwrap();
+        assert!(publisher.bind(&self.address).is_ok());
+        self.publisher = Some(publisher.into());
+        Ok(())
+    }
+}
+
+pub struct ZMQPubSinkBuilder {
+    item_size: usize,
+    address: String,
+}
+
+impl ZMQPubSinkBuilder {
+    pub fn new(item_size: usize) -> ZMQPubSinkBuilder {
+        ZMQPubSinkBuilder {
+            item_size,
+            address: "tcp://*:5555".into(),
+        }
+    }
+
+    pub fn address(mut self, address: &str) -> ZMQPubSinkBuilder {
+        self.address = address.to_string();
+        self
+    }
+
+    pub fn build(&mut self) -> Block {
+        ZMQPubSink::new(self.item_size, &*self.address)
+    }
+}

--- a/src/blocks/zmq_sub_source.rs
+++ b/src/blocks/zmq_sub_source.rs
@@ -47,6 +47,7 @@ impl AsyncKernel for ZMQSubSource {
             for (place, element) in o.iter_mut().zip(data.iter()) {
                 *place = *element;
             }
+            print!("Received");
     
             sio.output(0).produce(n);
     
@@ -63,7 +64,7 @@ impl AsyncKernel for ZMQSubSource {
     ) -> Result<()> {
         let context = zmq::Context::new();
         let receiver = context.socket(zmq::SUB).unwrap();
-        assert!(receiver.bind(&self.address).is_ok());
+        assert!(receiver.connect(&self.address).is_ok());
         self.receiver = Some(receiver.into());
         Ok(())
     }

--- a/src/blocks/zmq_sub_source.rs
+++ b/src/blocks/zmq_sub_source.rs
@@ -1,0 +1,94 @@
+use anyhow::Result;
+
+use crate::runtime::AsyncKernel;
+use crate::runtime::Block;
+use crate::runtime::BlockMeta;
+use crate::runtime::BlockMetaBuilder;
+use crate::runtime::MessageIo;
+use crate::runtime::MessageIoBuilder;
+use crate::runtime::StreamIo;
+use crate::runtime::StreamIoBuilder;
+use crate::runtime::WorkIo;
+
+pub struct ZMQSubSource {
+    item_size: usize,
+    address: String,
+    receiver: Option<zmq::Socket>,
+}
+
+impl ZMQSubSource {
+    pub fn new(item_size: usize, address: &str) -> Block {
+        Block::new_async(
+            BlockMetaBuilder::new("ZMQSubSource").build(),
+            StreamIoBuilder::new()
+                .add_stream_output("out", item_size)
+                .build(),
+            MessageIoBuilder::new().build(),
+            ZMQSubSource { item_size, address: address.to_string(), receiver: None },
+        )
+    }
+}
+
+#[async_trait]
+impl AsyncKernel for ZMQSubSource {
+    async fn work(
+        &mut self,
+        _io: &mut WorkIo,
+        sio: &mut StreamIo,
+        _mio: &mut MessageIo<Self>,
+        _meta: &mut BlockMeta,
+    ) -> Result<()> {
+
+        if let Ok(data) = self.receiver.as_mut().unwrap().recv_bytes(0) {
+            let o = sio.output(0).slice::<u8>();
+            debug_assert_eq!(o.len() % self.item_size, 0);
+            let n = o.len() / self.item_size;
+            //std::slice::bytes::copy_memory(&data, &mut o);
+            for (place, element) in o.iter_mut().zip(data.iter()) {
+                *place = *element;
+            }
+    
+            sio.output(0).produce(n);
+    
+        }
+
+        Ok(())
+    }
+
+    async fn init(
+        &mut self,
+        _sio: &mut StreamIo,
+        _mio: &mut MessageIo<Self>,
+        _meta: &mut BlockMeta,
+    ) -> Result<()> {
+        let context = zmq::Context::new();
+        let receiver = context.socket(zmq::SUB).unwrap();
+        assert!(receiver.bind(&self.address).is_ok());
+        self.receiver = Some(receiver.into());
+        Ok(())
+    }
+}
+
+
+pub struct ZMQSubSourceBuilder {
+    item_size: usize,
+    address: String,
+}
+
+impl ZMQSubSourceBuilder {
+    pub fn new(item_size: usize) -> ZMQSubSourceBuilder {
+        ZMQSubSourceBuilder {
+            item_size,
+            address: "tcp://*:5555".into(),
+        }
+    }
+
+    pub fn address(mut self, address: &str) -> ZMQSubSourceBuilder {
+        self.address = address.to_string();
+        self
+    }
+
+    pub fn build(&mut self) -> Block {
+        ZMQSubSource::new(self.item_size, &*self.address)
+    }
+}

--- a/src/blocks/zmq_sub_source.rs
+++ b/src/blocks/zmq_sub_source.rs
@@ -19,7 +19,7 @@ pub struct ZMQSubSource {
 impl ZMQSubSource {
     pub fn new(item_size: usize, address: &str) -> Block {
         Block::new_async(
-            BlockMetaBuilder::new("ZMQSubSource").build(),
+            BlockMetaBuilder::new("ZMQSubSource").blocking().build(),
             StreamIoBuilder::new()
                 .add_stream_output("out", item_size)
                 .build(),


### PR DESCRIPTION
Add ZMQSubSource and SMQPubSink for streaming over ZeroMQ protocol which is also by default in GNU Radio.
I think I have made it as a feature activated by default.
It also come with two binaries (one receiver, one emitter) that can talk to each other and/or with GNU Radio.

Apparently the topics is not settable in GNU Radio thus I have not provided way to set it. Maybe I should?

Close #3 