### PR TITLE
Feature/soapysdr args

### DIFF
--- a/examples/soapy.rs
+++ b/examples/soapy.rs
@@ -41,7 +41,11 @@ mod inner {
     pub(super) fn main() -> Result<()> {
         let mut fg = Flowgraph::new();
 
-        let src = SoapySourceBuilder::new().build();
+        let src = SoapySourceBuilder::new()
+            .freq(100e6)
+            .sample_rate(3.2e6)
+            .gain(34.0)
+            .build();
         let fft = FftBuilder::new().build();
         let mag = ComplexToMag::new();
         let snk = WebsocketSinkBuilder::<f32>::new(9001)

--- a/src/blocks/soapy_src.rs
+++ b/src/blocks/soapy_src.rs
@@ -88,6 +88,7 @@ impl AsyncKernel for SoapySource {
         _meta: &mut BlockMeta,
     ) -> Result<()> {
         let channel: usize = 0;
+        soapysdr::configure_logging();
         self.dev = Some(soapysdr::Device::new("")?);
         let dev = self.dev.as_ref().context("no dev")?;
         dev.set_frequency(Rx, channel, 100e6, ()).unwrap();


### PR DESCRIPTION
## Motivation

SoapySDR inputs are hardcoded and should be user defined.

## Solution

### Add custom freq/sample_rate/gain SoapySdr Block
Add freq/sample_rate/gain to the SoapySdrBuilder. This allows the freq/gain/sample_rate to be set in the init() function once the soapySDR library has the context of the device.

This was tested on a HackRF One device.

### Enable soapysdr logging

This  changes the following output:
```
[INFO] Opening HackRF One #0 57b068dc214b4c63...
```

into the following:
```
FutureSDR: INFO - Opening HackRF One #0 57b068dc214b4c63...
```