### PR TITLE
Bump the version for `soapysdr` to 0.3.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -106,7 +106,7 @@ vulkano-shaders = { version = "0.25.0", optional = true }
 tokio = { version = "1", features = ["rt"] }
 
 [target.'cfg(all(not(target_arch = "wasm32"), not(target_os = "android")))'.dependencies]
-soapysdr = { version = "0.3.0", optional = true }
+soapysdr = { version = "0.3.1", optional = true }
 
 [target.'cfg(unix)'.dependencies]
 xilinx-dma = { version = "0.0.3", optional = true }


### PR DESCRIPTION
## Motivation

On MacOS I was having issues getting a clean (or any) full compile because of an issue pulling in libclang.  See Issue #16 for more information on this issue.  Based on a suggestion from the author of the `soapysdr` crate, I have bumped the version number to 0.3.1 to correcte the issue.  I have now been able to get clean compile out of the FutureSDR crate.

## Solution

Change the required version in the `Cargo.toml` file for the `soapysdr` create from 0.3.0 to 0.3.1