### PR TITLE
Load the Vulkan `khr_get_physical_device_properties2` device extention

### DIFF
--- a/src/runtime/buffer/vulkan/mod.rs
+++ b/src/runtime/buffer/vulkan/mod.rs
@@ -39,8 +39,13 @@ pub struct Broker {
 
 impl Broker {
     pub fn new() -> Broker {
+        let instance_extensions = InstanceExtensions{
+            khr_get_physical_device_properties2: true,
+            ..InstanceExtensions::none()
+        };
+
         let instance =
-            Instance::new(None, Version::V1_1, &InstanceExtensions::none(), None).unwrap();
+            Instance::new(None, Version::V1_1, &instance_extensions, None).unwrap();
 
         let device_extensions = DeviceExtensions {
             khr_storage_buffer_storage_class: true,


### PR DESCRIPTION
## Motivation

I was attempting to execute the `Vulkan` example and was presented with an error:

```
❯ ./vulkan
thread 'main' panicked at 'called `Result::unwrap()` on an `Err` value: ExtensionRestrictionNotMet(ExtensionRestrictionError { extension: "khr_portability_subset", restriction: RequiresInstanceExtension("khr_get_physical_device_properties2") })', src/runtime/buffer/vulkan/mod.rs:79:10
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

## Solution

Apparently, the required extension `khr_get_physical_device_properties2` must be loaded at the device instantiation.  The code change adds this.