### PR TITLE
fix(runtime): compilation error re libc

### DIFF
--- a/src/runtime/buffer/double_mapped_temp_file.rs
+++ b/src/runtime/buffer/double_mapped_temp_file.rs
@@ -46,7 +46,7 @@ impl DoubleMappedTempFile {
             fd = libc::mkstemp(path as *mut libc::c_char);
             ensure!(fd >= 0, "tempfile could not be created");
 
-            let ret = libc::unlink(path.cast::<i8>());
+            let ret = libc::unlink(path.cast::<libc::c_char>());
             if ret < 0 {
                 libc::close(fd);
                 bail!("unlinking failed");


### PR DESCRIPTION
Close #20

## Motivation

Cannot compile under Raspberry Pi.

## Solution

Use libc typedef so as to be cross platform.

`cargo test` does not reveal any troubles.