### PR TITLE
Remove destructuring assignment in slab allocator

### DIFF
--- a/src/runtime/buffer/slab.rs
+++ b/src/runtime/buffer/slab.rs
@@ -342,7 +342,7 @@ impl BufferReaderHost for Reader {
             return;
         }
 
-        _ = self
+        let _ = self
             .writer_inbox
             .send(AsyncMessage::StreamOutputDone {
                 output_id: self.writer_output_id,


### PR DESCRIPTION
```
fixup! refactor slab buffer

   `_ = ...` is a "destructuring assignment", which as of 1.58.1 is behind a
   feature flag. However, in nightly it is stabilized, and so this code works
   on nightly, but not on stable.

   This commit changes the `_ = ...` to `let _ = ...`, which I think has the
   same behaviour.
```