### PR TITLE
Change how FIR filters detect the end condition

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ categories = ["asynchronous", "concurrency", "hardware-support", "science", "was
 [workspace]
 members = [
     ".",
+    "futuredsp",
     "pmt",
     "frontend",
     "examples/android",
@@ -78,6 +79,7 @@ config = "0.11.0"
 dirs = "4.0"
 futures = "0.3.18"
 futures-lite = "1.10.0"
+futuredsp = { path = "futuredsp", version = "0.0.1" }
 futuresdr-pmt = { path = "pmt", version = "0.0.2" }
 log = { version = "0.4", features = ["std", "max_level_debug", "release_max_level_off"] }
 lttng-ust = { version = "0.1.0", optional = true}

--- a/futuredsp/Cargo.toml
+++ b/futuredsp/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "futuredsp"
+version = "0.0.1"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+num-complex = "0.4.0"
+
+[build-dependencies]
+rustc_version = "0.4.0"

--- a/futuredsp/Cargo.toml
+++ b/futuredsp/Cargo.toml
@@ -10,3 +10,11 @@ num-complex = "0.4.0"
 
 [build-dependencies]
 rustc_version = "0.4.0"
+
+[dev-dependencies]
+criterion = { version = "0.3.5", features = [ "html_reports" ] }
+rand = "0.8.4"
+
+[[bench]]
+name = "benchmarks"
+harness = false

--- a/futuredsp/benches/benchmarks.rs
+++ b/futuredsp/benches/benchmarks.rs
@@ -1,0 +1,99 @@
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use futuredsp::fir::{FirKernel, NonResamplingFirKernel};
+use num_complex::Complex;
+use rand::Rng;
+
+trait Generatable {
+    fn generate() -> Self;
+}
+
+impl Generatable for f32 {
+    fn generate() -> Self {
+        let mut rng = rand::thread_rng();
+        rng.gen::<f32>() * 2.0 - 1.0
+    }
+}
+
+impl Generatable for Complex<f32> {
+    fn generate() -> Self {
+        let mut rng = rand::thread_rng();
+        Complex {
+            re: rng.gen::<f32>() * 2.0 - 1.0,
+            im: rng.gen::<f32>() * 2.0 - 1.0,
+        }
+    }
+}
+
+fn bench_fir_dynamic_taps<SampleType: Generatable, TapType: Generatable>(
+    b: &mut criterion::Bencher,
+    ntaps: usize,
+    nsamps: usize,
+) where
+    SampleType: Clone,
+    Vec<TapType>: futuredsp::fir::TapsAccessor<TapType = TapType>,
+    NonResamplingFirKernel<SampleType, Vec<TapType>>: FirKernel<SampleType>,
+{
+    let taps: Vec<_> = (0..ntaps).map(|_| TapType::generate()).collect();
+    let input: Vec<_> = (0..nsamps + ntaps)
+        .map(|_| SampleType::generate())
+        .collect();
+    let mut output = vec![SampleType::generate(); nsamps];
+    let fir = NonResamplingFirKernel::<SampleType, _>::new(black_box(taps));
+    b.iter(|| {
+        fir.work(black_box(&input), black_box(&mut output));
+    });
+}
+
+fn bench_fir_static_taps<SampleType: Generatable, TapType: Generatable, const N: usize>(
+    b: &mut criterion::Bencher,
+    nsamps: usize,
+) where
+    SampleType: Clone,
+    TapType: std::fmt::Debug,
+    [TapType; N]: futuredsp::fir::TapsAccessor<TapType = TapType>,
+    NonResamplingFirKernel<SampleType, [TapType; N]>: FirKernel<SampleType>,
+{
+    let taps: Vec<_> = (0..N).map(|_| TapType::generate()).collect();
+    let taps: [TapType; N] = taps.try_into().unwrap();
+    let input: Vec<_> = (0..nsamps + N).map(|_| SampleType::generate()).collect();
+    let mut output = vec![SampleType::generate(); nsamps];
+    let fir = NonResamplingFirKernel::<SampleType, _>::new(black_box(taps));
+    b.iter(|| {
+        fir.work(black_box(&input), black_box(&mut output));
+    });
+}
+
+pub fn criterion_benchmark(c: &mut Criterion) {
+    let mut group = c.benchmark_group("fir");
+
+    let nsamps = 1000usize;
+    group.throughput(criterion::Throughput::Elements(nsamps as u64));
+
+    for ntaps in [3, 64] {
+        group.bench_function(
+            format!("fir-{}tap-dynamic real/real {}", ntaps, nsamps),
+            |b| {
+                bench_fir_dynamic_taps::<f32, f32>(b, ntaps, nsamps);
+            },
+        );
+        group.bench_function(
+            format!("fir-{}tap-dynamic complex/real {}", ntaps, nsamps),
+            |b| {
+                bench_fir_dynamic_taps::<Complex<f32>, f32>(b, ntaps, nsamps);
+            },
+        );
+    }
+
+    // Check some static taps as well
+    group.bench_function(format!("fir-3tap-static complex/real {}", nsamps), |b| {
+        bench_fir_static_taps::<Complex<f32>, f32, 3>(b, nsamps);
+    });
+    group.bench_function(format!("fir-64tap-static complex/real {}", nsamps), |b| {
+        bench_fir_static_taps::<Complex<f32>, f32, 64>(b, nsamps);
+    });
+
+    group.finish();
+}
+
+criterion_group!(benches, criterion_benchmark);
+criterion_main!(benches);

--- a/futuredsp/build.rs
+++ b/futuredsp/build.rs
@@ -1,0 +1,18 @@
+use rustc_version::{version_meta, Channel};
+
+fn main() {
+    match version_meta().unwrap().channel {
+        Channel::Stable => {
+            println!("cargo:rustc-cfg=RUSTC_IS_STABLE");
+        }
+        Channel::Beta => {
+            println!("cargo:rustc-cfg=RUSTC_IS_BETA");
+        }
+        Channel::Nightly => {
+            println!("cargo:rustc-cfg=RUSTC_IS_NIGHTLY");
+        }
+        Channel::Dev => {
+            println!("cargo:rustc-cfg=RUSTC_IS_DEV");
+        }
+    }
+}

--- a/futuredsp/src/fir.rs
+++ b/futuredsp/src/fir.rs
@@ -19,9 +19,6 @@ pub trait FirKernel<SampleType>: Send {
     ///
     /// Elements of `output` beyond what is produced are left in an unspecified state.
     fn work(&self, input: &[SampleType], output: &mut [SampleType]) -> (usize, usize, usize);
-
-    /// Returns the number of taps this FIR filter represents.
-    fn num_taps(&self) -> usize;
 }
 
 pub trait TapsAccessor: Send {
@@ -155,10 +152,6 @@ impl<TapsType: TapsAccessor<TapType = f32>> FirKernel<f32>
             |accum, sample, tap| unsafe { fadd_fast(accum, fmul_fast(sample, tap)) },
         )
     }
-
-    fn num_taps(&self) -> usize {
-        self.taps.num_taps()
-    }
 }
 
 #[cfg(RUSTC_IS_STABLE)]
@@ -173,10 +166,6 @@ impl<TapsType: TapsAccessor<TapType = f32>> FirKernel<f32>
             || 0.0,
             |accum, sample, tap| accum + sample * tap,
         )
-    }
-
-    fn num_taps(&self) -> usize {
-        self.taps.num_taps()
     }
 }
 
@@ -196,10 +185,6 @@ impl<TapsType: TapsAccessor<TapType = f32>> FirKernel<Complex<f32>>
             },
         )
     }
-
-    fn num_taps(&self) -> usize {
-        self.taps.num_taps()
-    }
 }
 
 #[cfg(RUSTC_IS_STABLE)]
@@ -217,10 +202,6 @@ impl<TapsType: TapsAccessor<TapType = f32>> FirKernel<Complex<f32>>
                 im: accum.im + sample.im * tap,
             },
         )
-    }
-
-    fn num_taps(&self) -> usize {
-        self.taps.num_taps()
     }
 }
 

--- a/futuredsp/src/fir.rs
+++ b/futuredsp/src/fir.rs
@@ -1,3 +1,4 @@
+use std::cmp::Ordering;
 #[cfg(not(RUSTC_IS_STABLE))]
 use std::intrinsics::{fadd_fast, fmul_fast};
 
@@ -151,13 +152,11 @@ where
     TapsType::TapType: Copy,
 {
     let num_producable_samples = (i.len() + 1).saturating_sub(taps.num_taps());
-    let (n, status) = if num_producable_samples > o.len() {
-        (o.len(), ComputationStatus::InsufficientOutput)
-    } else if num_producable_samples == o.len() {
-        (num_producable_samples, ComputationStatus::BothSufficient)
-    } else {
-        (num_producable_samples, ComputationStatus::InsufficientInput)
-    }; // std::cmp::min(num_producable_samples, o.len());
+    let (n, status) = match num_producable_samples.cmp(&o.len()) {
+        Ordering::Greater => (o.len(), ComputationStatus::InsufficientOutput),
+        Ordering::Equal => (num_producable_samples, ComputationStatus::BothSufficient),
+        Ordering::Less => (num_producable_samples, ComputationStatus::InsufficientInput),
+    };
 
     unsafe {
         for k in 0..n {

--- a/futuredsp/src/fir.rs
+++ b/futuredsp/src/fir.rs
@@ -256,19 +256,31 @@ mod tests {
         let kernel = NonResamplingFirKernel::new(taps);
         let input = [1.0, 2.0, 3.0];
         let mut output = [0.0; 3];
-        assert_eq!(kernel.work(&input, &mut output), (1, 1, 0));
+        assert_eq!(
+            kernel.work(&input, &mut output),
+            (1, 1, ComputationStatus::InsufficientInput)
+        );
         assert_eq!(output[0], 14.0);
 
         let mut output = [];
-        assert_eq!(kernel.work(&input, &mut output), (0, 0, 1));
+        assert_eq!(
+            kernel.work(&input, &mut output),
+            (0, 0, ComputationStatus::InsufficientOutput)
+        );
 
         let mut output = [0.0; 3];
-        assert_eq!(kernel.work(&input, &mut output), (1, 1, 0));
+        assert_eq!(
+            kernel.work(&input, &mut output),
+            (1, 1, ComputationStatus::InsufficientInput)
+        );
         assert_eq!(output[0], 14.0);
 
         let input = [1.0, 2.0, 3.0, 4.0, 5.0];
         let mut output = [0.0; 2];
-        assert_eq!(kernel.work(&input, &mut output), (2, 2, 1));
+        assert_eq!(
+            kernel.work(&input, &mut output),
+            (2, 2, ComputationStatus::InsufficientOutput)
+        );
         assert_eq!(output[0], 14.0);
         assert_eq!(output[1], 20.0);
     }
@@ -284,11 +296,17 @@ mod tests {
         // With 5 input samples and 3 out, we just need more output space
         let input = [1.0, 2.0, 3.0, 4.0, 5.0];
         let mut output = [0.0; 3];
-        assert_eq!(kernel.work(&input, &mut output), (3, 3, 1));
+        assert_eq!(
+            kernel.work(&input, &mut output),
+            (3, 3, ComputationStatus::InsufficientOutput)
+        );
 
         // With 4 input samples and 3 out, we've exactly filled the output
         let input = [1.0, 2.0, 3.0, 4.0];
         let mut output = [0.0; 3];
-        assert_eq!(kernel.work(&input, &mut output), (3, 3, 0));
+        assert_eq!(
+            kernel.work(&input, &mut output),
+            (3, 3, ComputationStatus::BothSufficient)
+        );
     }
 }

--- a/futuredsp/src/fir.rs
+++ b/futuredsp/src/fir.rs
@@ -28,7 +28,8 @@ pub trait TapsAccessor: Send {
 
     /// Gets the `index`th tap.
     ///
-    /// Safety: The invariant `index < num_taps()` must be upheld.
+    /// # Safety
+    /// The invariant `index < num_taps()` must be upheld.
     unsafe fn get(&self, index: usize) -> Self::TapType;
 }
 

--- a/futuredsp/src/fir.rs
+++ b/futuredsp/src/fir.rs
@@ -1,0 +1,248 @@
+#[cfg(not(RUSTC_IS_STABLE))]
+use std::intrinsics::{fadd_fast, fmul_fast};
+
+use num_complex::Complex;
+
+/// Implements a trait to run computations with FIR filters.
+pub trait FirKernel<SampleType>: Send {
+    /// Computes the FIR filter on the given input, outputting into the given output.
+    /// Note that filters will not generally have internal memory - therefore, even
+    /// if the output is sufficiently large, not all input samples may be consumed.
+    /// However, it is also permitted for kernel implementations to contain state
+    /// related to the input stream (for example, it may contain an internal buffer
+    /// of the last `num_taps` input samples).
+    ///
+    /// Returns a tuple containing, in order, the samples consumed from the input
+    /// and the samples produced in the output. Elements of `output` beyond what
+    /// is produced are left in an unspecified state.
+    fn work(&self, input: &[SampleType], output: &mut [SampleType]) -> (usize, usize);
+
+    /// Returns the number of taps this FIR filter represents.
+    fn num_taps(&self) -> usize;
+}
+
+pub trait TapsAccessor: Send {
+    type TapType;
+
+    fn num_taps(&self) -> usize;
+
+    /// Gets the `index`th tap.
+    ///
+    /// Safety: The invariant `index < num_taps()` must be upheld.
+    unsafe fn get(&self, index: usize) -> Self::TapType;
+}
+
+impl<const N: usize> TapsAccessor for [f32; N] {
+    type TapType = f32;
+
+    fn num_taps(&self) -> usize {
+        N
+    }
+
+    unsafe fn get(&self, index: usize) -> f32 {
+        debug_assert!(index < self.num_taps());
+        *self.get_unchecked(index)
+    }
+}
+
+impl<const N: usize> TapsAccessor for &[f32; N] {
+    type TapType = f32;
+
+    fn num_taps(&self) -> usize {
+        N
+    }
+
+    unsafe fn get(&self, index: usize) -> f32 {
+        debug_assert!(index < self.num_taps());
+        *self.get_unchecked(index)
+    }
+}
+
+impl TapsAccessor for Vec<f32> {
+    type TapType = f32;
+
+    fn num_taps(&self) -> usize {
+        self.len()
+    }
+
+    unsafe fn get(&self, index: usize) -> f32 {
+        debug_assert!(index < self.num_taps());
+        *self.get_unchecked(index)
+    }
+}
+
+/// A non-resampling FIR filter. Calling `work()` on this struct always
+/// produces exactly as many samples as it consumes.
+///
+/// Implementations of this core exist for the following combinations:
+/// - `f32` samples, `f32` taps.
+/// - `Complex<f32>` samples, `f32` taps.
+///
+/// Example usage:
+/// ```
+/// use futuredsp::fir::{FirKernel, NonResamplingFirKernel};
+///
+/// let fir = NonResamplingFirKernel::<f32, _>::new([1.0, 2.0, 3.0]);
+///
+/// let input = [1.0, 2.0, 3.0];
+/// let mut output = [0.0];
+/// fir.work(&input, &mut output);
+/// ```
+pub struct NonResamplingFirKernel<SampleType, TapsType: TapsAccessor> {
+    taps: TapsType,
+    _sampletype: std::marker::PhantomData<SampleType>,
+}
+
+impl<SampleType, TapsType: TapsAccessor> NonResamplingFirKernel<SampleType, TapsType> {
+    /// Create a new non-resampling FIR filter using the given taps.
+    pub fn new(taps: TapsType) -> Self {
+        Self {
+            taps,
+            _sampletype: std::marker::PhantomData,
+        }
+    }
+}
+
+#[cfg(not(RUSTC_IS_STABLE))]
+impl<TapsType: TapsAccessor<TapType = f32>> FirKernel<f32>
+    for NonResamplingFirKernel<f32, TapsType>
+{
+    fn work(&self, i: &[f32], o: &mut [f32]) -> (usize, usize) {
+        let n = std::cmp::min((i.len() + 1).saturating_sub(self.taps.num_taps()), o.len());
+
+        unsafe {
+            for k in 0..n {
+                let mut sum = 0.0;
+                for t in 0..self.taps.num_taps() {
+                    sum = fadd_fast(sum, fmul_fast(*i.get_unchecked(k + t), self.taps.get(t)));
+                }
+                *o.get_unchecked_mut(k) = sum;
+            }
+        }
+
+        (n, n)
+    }
+
+    fn num_taps(&self) -> usize {
+        self.taps.num_taps()
+    }
+}
+
+#[cfg(RUSTC_IS_STABLE)]
+impl<TapsType: TapsAccessor<TapType = f32>> FirKernel<f32>
+    for NonResamplingFirKernel<f32, TapsType>
+{
+    fn work(&self, i: &[f32], o: &mut [f32]) -> (usize, usize) {
+        let n = std::cmp::min((i.len() + 1).saturating_sub(self.taps.num_taps()), o.len());
+
+        unsafe {
+            for k in 0..n {
+                let mut sum = 0.0;
+                for t in 0..self.taps.num_taps() {
+                    sum += i.get_unchecked(k + t) * self.taps.get(t);
+                }
+                *o.get_unchecked_mut(k) = sum;
+            }
+        }
+
+        (n, n)
+    }
+
+    fn num_taps(&self) -> usize {
+        self.taps.num_taps()
+    }
+}
+
+#[cfg(not(RUSTC_IS_STABLE))]
+impl<TapsType: TapsAccessor<TapType = f32>> FirKernel<Complex<f32>>
+    for NonResamplingFirKernel<Complex<f32>, TapsType>
+{
+    fn work(&self, i: &[Complex<f32>], o: &mut [Complex<f32>]) -> (usize, usize) {
+        let n = std::cmp::min((i.len() + 1).saturating_sub(self.taps.num_taps()), o.len());
+
+        unsafe {
+            for k in 0..n {
+                let mut sum_re = 0.0;
+                let mut sum_im = 0.0;
+                for t in 0..self.taps.num_taps() {
+                    sum_re = fadd_fast(
+                        sum_re,
+                        fmul_fast(i.get_unchecked(k + t).re, self.taps.get(t)),
+                    );
+                    sum_im = fadd_fast(
+                        sum_im,
+                        fmul_fast(i.get_unchecked(k + t).im, self.taps.get(t)),
+                    );
+                }
+                *o.get_unchecked_mut(k) = Complex {
+                    re: sum_re,
+                    im: sum_im,
+                };
+            }
+        }
+
+        (n, n)
+    }
+
+    fn num_taps(&self) -> usize {
+        self.taps.num_taps()
+    }
+}
+
+#[cfg(RUSTC_IS_STABLE)]
+impl<TapsType: TapsAccessor<TapType = f32>> FirKernel<Complex<f32>>
+    for NonResamplingFirKernel<Complex<f32>, TapsType>
+{
+    fn work(&self, i: &[Complex<f32>], o: &mut [Complex<f32>]) -> (usize, usize) {
+        let n = std::cmp::min((i.len() + 1).saturating_sub(self.taps.num_taps()), o.len());
+
+        unsafe {
+            for k in 0..n {
+                let mut sum_re = 0.0;
+                let mut sum_im = 0.0;
+                for t in 0..self.taps.num_taps() {
+                    sum_re += i.get_unchecked(k + t).re * self.taps.get(t);
+                    sum_im += i.get_unchecked(k + t).im * self.taps.get(t);
+                }
+                *o.get_unchecked_mut(k) = Complex {
+                    re: sum_re,
+                    im: sum_im,
+                };
+            }
+        }
+
+        (n, n)
+    }
+
+    fn num_taps(&self) -> usize {
+        self.taps.num_taps()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn direct_fir_kernel() {
+        let taps = [1.0, 2.0, 3.0];
+        let kernel = NonResamplingFirKernel::new(taps);
+        let input = [1.0, 2.0, 3.0];
+        let mut output = [0.0; 3];
+        assert_eq!(kernel.work(&input, &mut output), (1, 1));
+        assert_eq!(output[0], 14.0);
+
+        let mut output = [];
+        assert_eq!(kernel.work(&input, &mut output), (0, 0));
+
+        let mut output = [0.0; 3];
+        assert_eq!(kernel.work(&input, &mut output), (1, 1));
+        assert_eq!(output[0], 14.0);
+
+        let input = [1.0, 2.0, 3.0, 4.0, 5.0];
+        let mut output = [0.0; 2];
+        assert_eq!(kernel.work(&input, &mut output), (2, 2));
+        assert_eq!(output[0], 14.0);
+        assert_eq!(output[1], 20.0);
+    }
+}

--- a/futuredsp/src/lib.rs
+++ b/futuredsp/src/lib.rs
@@ -1,0 +1,3 @@
+#![cfg_attr(not(RUSTC_IS_STABLE), feature(core_intrinsics))]
+
+pub mod fir;

--- a/src/blocks/fir.rs
+++ b/src/blocks/fir.rs
@@ -71,12 +71,12 @@ where
         let i = sio.input(0).slice::<SampleType>();
         let o = sio.output(0).slice::<SampleType>();
 
-        let (consumed, produced) = self.core.work(i, o);
+        let (consumed, produced, additional_production) = self.core.work(i, o);
 
         sio.input(0).consume(consumed);
         sio.output(0).produce(produced);
 
-        if sio.input(0).finished() && consumed + self.core.num_taps() == i.len() + 1 {
+        if sio.input(0).finished() && additional_production == 0 {
             io.finished = true;
         }
 

--- a/src/blocks/fir.rs
+++ b/src/blocks/fir.rs
@@ -71,12 +71,12 @@ where
         let i = sio.input(0).slice::<SampleType>();
         let o = sio.output(0).slice::<SampleType>();
 
-        let (consumed, produced, additional_production) = self.core.work(i, o);
+        let (consumed, produced, status) = self.core.work(i, o);
 
         sio.input(0).consume(consumed);
         sio.output(0).produce(produced);
 
-        if sio.input(0).finished() && additional_production == 0 {
+        if sio.input(0).finished() && status.produced_all_samples() {
             io.finished = true;
         }
 


### PR DESCRIPTION
This PR is a follow-on to #33 (and this contains the same commits as that PR, because I couldn't figure out how to make a PR to merge this into that). But, it's conceptually different so I probably not worth combining the PRs.

So I think we can move the finish condition into the FIR filters by calculating how many more samples we _could_ have produced. If the input is finished, and the core could not have produced more samples (even if it had room), then I think we can finish the block?

If so, this'll make resampling filters work a bit easier, eventually.