### PR TITLE
Consider no_std in futuredsp

### DIFF
--- a/futuredsp/benches/benchmarks.rs
+++ b/futuredsp/benches/benchmarks.rs
@@ -3,6 +3,9 @@ use futuredsp::fir::{FirKernel, NonResamplingFirKernel};
 use num_complex::Complex;
 use rand::Rng;
 
+extern crate alloc;
+use alloc::vec::Vec;
+
 trait Generatable {
     fn generate() -> Self;
 }

--- a/futuredsp/src/fir.rs
+++ b/futuredsp/src/fir.rs
@@ -1,8 +1,11 @@
-use std::cmp::Ordering;
+use core::cmp::Ordering;
 #[cfg(not(RUSTC_IS_STABLE))]
-use std::intrinsics::{fadd_fast, fmul_fast};
+use core::intrinsics::{fadd_fast, fmul_fast};
 
 use num_complex::Complex;
+
+extern crate alloc;
+use alloc::vec::Vec;
 
 /// Represents the status of a computation.
 #[derive(PartialEq, Eq, Clone, Copy, Debug)]
@@ -119,7 +122,7 @@ impl TapsAccessor for Vec<f32> {
 /// ```
 pub struct NonResamplingFirKernel<SampleType, TapsType: TapsAccessor> {
     taps: TapsType,
-    _sampletype: std::marker::PhantomData<SampleType>,
+    _sampletype: core::marker::PhantomData<SampleType>,
 }
 
 impl<SampleType, TapsType: TapsAccessor> NonResamplingFirKernel<SampleType, TapsType> {
@@ -127,7 +130,7 @@ impl<SampleType, TapsType: TapsAccessor> NonResamplingFirKernel<SampleType, Taps
     pub fn new(taps: TapsType) -> Self {
         Self {
             taps,
-            _sampletype: std::marker::PhantomData,
+            _sampletype: core::marker::PhantomData,
         }
     }
 }

--- a/futuredsp/src/lib.rs
+++ b/futuredsp/src/lib.rs
@@ -1,3 +1,4 @@
+#![no_std]
 #![cfg_attr(not(RUSTC_IS_STABLE), feature(core_intrinsics))]
 
 pub mod fir;


### PR DESCRIPTION
This PR is changing the fir in futuredsp to no_std.

The motivation is to keep this crate as platform independent as possible, especially also ready for bare metal programming. More infos about it here: https://docs.rust-embedded.org/book/intro/no-std.html