### PR TITLE
Add transfer example

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ members = [
     "examples/fm-receiver",
     "examples/logging",
     "examples/spectrum",
+    "examples/transfer",
     "examples/wasm",
     "examples/wgpu",
     "examples/zeromq",

--- a/examples/transfer/Cargo.toml
+++ b/examples/transfer/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "transfer"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+futuresdr = { path = "../..", features = ["soapy"] }
+num-complex = "0.4.0"
+clap = { version = "3.0.13", features = ["derive"] }

--- a/examples/transfer/src/main.rs
+++ b/examples/transfer/src/main.rs
@@ -1,0 +1,158 @@
+use clap::Parser;
+use futuresdr::anyhow::Result;
+use futuresdr::blocks::Apply;
+use futuresdr::blocks::Head;
+use futuresdr::blocks::SoapySource;
+use futuresdr::blocks::{FileSink, FileSource};
+use futuresdr::runtime::Flowgraph;
+use futuresdr::runtime::Runtime;
+use num_complex::Complex;
+use std::time::Instant;
+
+#[derive(Parser, Debug)]
+#[clap(author, version, about, long_about = None)]
+struct Args {
+    /// Gain to apply to the soapy source
+    #[clap(short, long, default_value_t = 0.0)]
+    gain: f64,
+
+    /// Center frequency
+    #[clap(short, long, default_value_t = 100_000_000.0)]
+    frequency: f64,
+
+    /// Sample rate
+    #[clap(short, long, default_value_t = 1000000.0)]
+    rate: f64,
+
+    /// Soapy source to use as a source
+    #[clap(long)]
+    soapy: Option<String>,
+
+    /// File source to load
+    #[clap(long)]
+    input: Option<String>,
+
+    /// Input file format, automatically determined from filename if not specified
+    #[clap(long)]
+    format_in: Option<String>,
+
+    /// File to dump to
+    #[clap(long)]
+    out: String,
+
+    /// Format to dump to. Will be automatically determined from the filename
+    /// if not specified.
+    #[clap(long)]
+    format_out: Option<String>,
+
+    /// Number of samples to record. Continuous recording if not specified.
+    #[clap(long)]
+    samples: Option<u64>,
+}
+
+fn main() -> Result<()> {
+    let args = Args::parse();
+
+    let mut fg = Flowgraph::new();
+
+    let src = match (args.soapy, args.input) {
+        (Some(_), Some(_)) => {
+            panic!("Cannot specify both soapy source and input file");
+        }
+        (Some(soapy), None) => fg.add_block(SoapySource::new(
+            args.frequency,
+            args.rate,
+            args.gain,
+            soapy,
+        )),
+        (None, Some(input)) => {
+            let format = args
+                .format_in
+                .or_else(|| {
+                    let parts: Vec<_> = input.split('.').collect();
+                    Some(parts[parts.len() - 1].to_string())
+                })
+                .expect("Input format could not be determined!");
+            match format.as_str() {
+                "cs8" => {
+                    let src = fg.add_block(FileSource::<Complex<i8>>::new(input));
+                    let typecvt =
+                        fg.add_block(Apply::<Complex<i8>, Complex<f32>>::new(|i| Complex {
+                            re: i.re as f32 / 127.,
+                            im: i.im as f32 / 127.,
+                        }));
+                    fg.connect_stream(src, "out", typecvt, "in")?;
+                    typecvt
+                }
+                _ => {
+                    panic!("Unrecognized input format {}", format);
+                }
+            }
+        }
+        (None, None) => {
+            panic!("Must specify one of soapy source or input file");
+        }
+    };
+
+    let src = if let Some(samples) = args.samples {
+        let sample_counter = fg.add_block(Head::<Complex<f32>>::new(samples));
+        fg.connect_stream(src, "out", sample_counter, "in")?;
+        sample_counter
+    } else {
+        src
+    };
+
+    let mut last_clip_warning = Instant::now();
+    let mut last_power_print = Instant::now();
+    let mut avgmag = 0.0;
+    let mut maxmag = 0.0;
+    let powermeter = fg.add_block(Apply::<Complex<f32>, Complex<f32>>::new(move |i| {
+        let norm = i.norm();
+        if norm > 0.95 && last_clip_warning.elapsed().as_secs_f32() > 0.1 {
+            last_clip_warning = Instant::now();
+            eprintln!("Possible clipping!");
+        }
+        avgmag = avgmag * 0.9999 + norm * 0.0001;
+        if norm > maxmag {
+            maxmag = norm;
+        }
+        if last_power_print.elapsed().as_secs_f32() > 2.0 {
+            println!("Average/max signal magnitudes: {:.4}/{:.4}", avgmag, maxmag);
+            maxmag = 0.0;
+            last_power_print = Instant::now();
+        }
+        *i
+    }));
+
+    fg.connect_stream(src, "out", powermeter, "in")?;
+
+    let format = args
+        .format_out
+        .or_else(|| {
+            let parts: Vec<_> = args.out.split('.').collect();
+            Some(parts[parts.len() - 1].to_string())
+        })
+        .expect("Output format could not be determined!");
+    match format.as_str() {
+        "cs8" => {
+            let typecvt = fg.add_block(Apply::<Complex<f32>, Complex<i8>>::new(|i| Complex {
+                re: (i.re * 127.) as i8,
+                im: (i.im * 127.) as i8,
+            }));
+            let sink = fg.add_block(FileSink::<Complex<i8>>::new(&args.out));
+            fg.connect_stream(powermeter, "out", typecvt, "in")?;
+            fg.connect_stream(typecvt, "out", sink, "in")?;
+        }
+        "cf32" => {
+            let sink = fg.add_block(FileSink::<Complex<f32>>::new(&args.out));
+            fg.connect_stream(powermeter, "out", sink, "in")?;
+        }
+        format => {
+            panic!("Unknown format {}! (known formats: cs8, cf32", format);
+        }
+    }
+
+    Runtime::new().run(fg)?;
+
+    Ok(())
+}


### PR DESCRIPTION
The `SampleCounter` allows stopping the flowgraph after exactly N samples have passed. This is particularly useful for the `record` example which is also added, which simply grabs samples from a soapy source and stuffs them in a file. It also prints out average magnitudes and warns when the magnitude is close to 1.0. I'm not really sure if that's the best way to do that (since my understanding is the better way is to watch the noise floor vs. the signal), but in a generic IQ stream it's hard to do better. But I'm also fine pulling it out.