### PR TITLE
Add some docs!

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -156,3 +156,6 @@ debug = true
 lto = "fat"
 opt-level = 3
 panic = "abort"
+
+[package.metadata.docs.rs]
+rustdoc-args = ["--cfg", "docsrs"]

--- a/src/blocks/apply.rs
+++ b/src/blocks/apply.rs
@@ -11,6 +11,43 @@ use crate::runtime::StreamIoBuilder;
 use crate::runtime::SyncKernel;
 use crate::runtime::WorkIo;
 
+/// Applies a function to each sample in the stream.
+///
+/// # Inputs
+///
+/// `in`: Input
+///
+/// # Outputs
+///
+/// `out`: Output after function applied
+///
+/// # Usage
+/// ```
+/// use futuresdr::blocks::Apply;
+/// use futuresdr::runtime::Flowgraph;
+/// use num_complex::Complex;
+///
+/// let mut fg = Flowgraph::new();
+///
+/// // Double each sample
+/// let doubler = fg.add_block(Apply::<f32, f32>::new(|i| i * 2.0));
+///
+/// // Note that the closure can also hold state
+/// let mut last_value = 0.0;
+/// let moving_average = fg.add_block(Apply::<f32, f32>::new(move |i| {
+///     let new_value = (last_value + i) / 2.0;
+///     last_value = *i;
+///     new_value
+/// }));
+///
+/// // Additionally, the closure can change the type of the sample
+/// let to_complex = fg.add_block(Apply::<f32, Complex<f32>>::new(|i| {
+///     Complex {
+///         re: 0.0,
+///         im: *i,
+///     }
+/// }));
+/// ```
 pub struct Apply<A, B>
 where
     A: 'static,

--- a/src/blocks/combine.rs
+++ b/src/blocks/combine.rs
@@ -11,6 +11,29 @@ use crate::runtime::StreamIoBuilder;
 use crate::runtime::SyncKernel;
 use crate::runtime::WorkIo;
 
+/// Applies the specified function sample-by-sample to two streams to form one.
+///
+/// # Inputs
+///
+/// `in0`: Input A
+///
+/// `in1`: Input B
+///
+/// # Outputs
+///
+/// `out`: Combined output
+///
+/// # Usage
+/// ```
+/// use futuresdr::blocks::Combine;
+/// use futuresdr::runtime::Flowgraph;
+///
+/// let mut fg = Flowgraph::new();
+///
+/// let adder = fg.add_block(Combine::<f32, f32, f32>::new(|a, b| {
+///     a + b
+/// }));
+/// ```
 pub struct Combine<A, B, C>
 where
     A: 'static,

--- a/src/blocks/fft.rs
+++ b/src/blocks/fft.rs
@@ -73,6 +73,27 @@ impl AsyncKernel for Fft {
     }
 }
 
+/// Computes a FFT
+/// 
+/// This block computes the FFT on 2048 samples at a time, outputting 2048 samples per FFT.
+///
+/// # Inputs
+///
+/// `in`: Input samples
+///
+/// # Outputs
+///
+/// `out`: FFT results
+///
+/// # Usage
+/// ```
+/// use futuresdr::blocks::FftBuilder;
+/// use futuresdr::runtime::Flowgraph;
+///
+/// let mut fg = Flowgraph::new();
+///
+/// let fft = fg.add_block(FftBuilder::new().build());
+/// ```
 pub struct FftBuilder {}
 
 impl FftBuilder {

--- a/src/blocks/file_sink.rs
+++ b/src/blocks/file_sink.rs
@@ -13,6 +13,31 @@ use crate::runtime::StreamIo;
 use crate::runtime::StreamIoBuilder;
 use crate::runtime::WorkIo;
 
+/// Writes samples to a file.
+///
+/// Samples are encoded using the in-memory format of the machine the runtime is
+/// running on, like for [FileSource]. For most machines, this means little
+/// endian. Complex numbers are written with the real component coming before
+/// the complex component.
+///
+/// # Inputs
+///
+/// `in`: Input
+///
+/// # Outputs
+///
+/// No outputs.
+///
+/// # Usage
+/// ```no_run
+/// use futuresdr::blocks::FileSink;
+/// use futuresdr::runtime::Flowgraph;
+/// use num_complex::Complex;
+///
+/// let mut fg = Flowgraph::new();
+///
+/// let sink = fg.add_block(FileSink::<Complex<f32>>::new("my_sink_filename.cf32"));
+/// ```
 pub struct FileSink<T: Send + 'static> {
     file_name: String,
     file: Option<File>,

--- a/src/blocks/file_source.rs
+++ b/src/blocks/file_source.rs
@@ -36,7 +36,7 @@ use crate::runtime::WorkIo;
 /// // Loads 8-byte samples from the file
 /// let source = fg.add_block(FileSource::<Complex<f32>>::new("my_filename.cf32"));
 /// ```
-#[doc(cfg(not(target_arch = "wasm32")))]
+#[cfg_attr(docsrs, doc(cfg(not(target_arch = "wasm32"))))]
 pub struct FileSource<T: Send + 'static> {
     file_name: String,
     file: Option<async_fs::File>,

--- a/src/blocks/file_source.rs
+++ b/src/blocks/file_source.rs
@@ -36,6 +36,7 @@ use crate::runtime::WorkIo;
 /// // Loads 8-byte samples from the file
 /// let source = fg.add_block(FileSource::<Complex<f32>>::new("my_filename.cf32"));
 /// ```
+#[doc(cfg(not(target_arch = "wasm32")))]
 pub struct FileSource<T: Send + 'static> {
     file_name: String,
     file: Option<async_fs::File>,

--- a/src/blocks/file_source.rs
+++ b/src/blocks/file_source.rs
@@ -11,6 +11,31 @@ use crate::runtime::StreamIo;
 use crate::runtime::StreamIoBuilder;
 use crate::runtime::WorkIo;
 
+/// Loads samples from a file, then stops.
+///
+/// Samples are assumed to be encoded in the native format for the runtime. For
+/// example, on most machines, that means little endian. For complex samples,
+/// the real component must come before the complex component.
+///
+/// # Inputs
+///
+/// No inputs.
+///
+/// # Outputs
+///
+/// `out`: Output samples
+///
+/// # Usage
+/// ```no_run
+/// use futuresdr::blocks::FileSource;
+/// use futuresdr::runtime::Flowgraph;
+/// use num_complex::Complex;
+///
+/// let mut fg = Flowgraph::new();
+///
+/// // Loads 8-byte samples from the file
+/// let source = fg.add_block(FileSource::<Complex<f32>>::new("my_filename.cf32"));
+/// ```
 pub struct FileSource<T: Send + 'static> {
     file_name: String,
     file: Option<async_fs::File>,

--- a/src/blocks/filter.rs
+++ b/src/blocks/filter.rs
@@ -11,6 +11,32 @@ use crate::runtime::StreamIoBuilder;
 use crate::runtime::SyncKernel;
 use crate::runtime::WorkIo;
 
+/// Applies a function to filter a stream
+///
+/// # Inputs
+///
+/// `in`: Input
+///
+/// # Outputs
+///
+/// `out`: Filtered outputs
+///
+/// # Usage
+/// ```
+/// use futuresdr::blocks::Filter;
+/// use futuresdr::runtime::Flowgraph;
+///
+/// let mut fg = Flowgraph::new();
+///
+/// // Remove samples above 1.0
+/// let filter = fg.add_block(Filter::<f32, f32>::new(|i| {
+///     if i < 1.0 {
+///         Some(*i)
+///     } else {
+///         None
+///     }
+/// }));
+/// ```
 pub struct Filter<A, B>
 where
     A: 'static,

--- a/src/blocks/fir.rs
+++ b/src/blocks/fir.rs
@@ -84,32 +84,44 @@ where
     }
 }
 
+/// Creates a generic FIR filter.
+///
+/// Uses the `futuredsp` to pick the optimal FIR implementation for the given
+/// constraints.
+/// 
+/// Note that there must be an implementation of [futuredsp::TapsAccessor] for
+/// the taps object you pass in, see docs for details.
+/// 
+/// Additionally, there must be an available core (implementation of
+/// [futuredsp::UnaryKernel]) available for the specified `SampleType` and
+/// `TapsType`. See the [futuredsp docs](futuredsp::fir) for available
+/// implementations.
+///
+/// # Inputs
+///
+/// `in`: Input
+///
+/// # Outputs
+///
+/// `out`: Output
+///
+/// # Usage
+/// ```
+/// use futuresdr::blocks::FirBuilder;
+/// use futuresdr::runtime::Flowgraph;
+/// use num_complex::Complex;
+///
+/// let mut fg = Flowgraph::new();
+///
+/// let fir = fg.add_block(FirBuilder::new::<f32, f32, _>([1.0, 2.0, 3.0]));
+/// let fir = fg.add_block(FirBuilder::new::<Complex<f32>, f32, _>(&[1.0, 2.0, 3.0]));
+/// let fir = fg.add_block(FirBuilder::new::<f32, f32, _>(vec![1.0, 2.0, 3.0]));
+/// ```
 pub struct FirBuilder {
     //
 }
 
 impl FirBuilder {
-    /// Constructs a new FIR Filter using the given types and taps. This function will
-    /// pick the optimal FIR implementation for the given constraints.
-    ///
-    /// Note that there must be an implementation of `TapsAccessor` for the taps object
-    /// you pass in. Implementations are provided for arrays and `Vec<TapType>`.
-    ///
-    /// Additionally, there must be an available core (implementation of `FirKernel`) for
-    /// the specified `SampleType` and `TapType`. Cores are provided for the following
-    /// `SampleType`/`TapType` combinations:
-    /// - `SampleType=f32`, `TapType=f32`
-    /// - `SampleType=Complex<f32>`, `TapType=f32`
-    ///
-    /// Example usage:
-    /// ```
-    /// use futuresdr::blocks::FirBuilder;
-    /// use num_complex::Complex;
-    ///
-    /// let fir = FirBuilder::new::<f32, f32, _>([1.0, 2.0, 3.0]);
-    /// let fir = FirBuilder::new::<Complex<f32>, f32, _>(&[1.0, 2.0, 3.0]);
-    /// let fir = FirBuilder::new::<f32, f32, _>(vec![1.0, 2.0, 3.0]);
-    /// ```
     pub fn new<SampleType, TapType, Taps>(taps: Taps) -> Block
     where
         SampleType: 'static + Send,

--- a/src/blocks/head.rs
+++ b/src/blocks/head.rs
@@ -12,6 +12,26 @@ use crate::runtime::StreamIo;
 use crate::runtime::StreamIoBuilder;
 use crate::runtime::WorkIo;
 
+/// Stops the graph after the given number of samples
+///
+/// # Inputs
+///
+/// `in`: Input
+///
+/// # Outputs
+///
+/// `out`: Output
+///
+/// # Usage
+/// ```
+/// use futuresdr::blocks::Head;
+/// use futuresdr::runtime::Flowgraph;
+/// use num_complex::Complex;
+///
+/// let mut fg = Flowgraph::new();
+///
+/// let head = fg.add_block(Head::<Complex<f32>>::new(1_000_000));
+/// ```
 pub struct Head<T: Send + 'static> {
     n_items: u64,
     _type: std::marker::PhantomData<T>,

--- a/src/blocks/message_source.rs
+++ b/src/blocks/message_source.rs
@@ -81,6 +81,33 @@ impl AsyncKernel for MessageSource {
     }
 }
 
+/// Repeats a fixed message on an interval
+///
+/// # Inputs
+///
+/// No inputs.
+///
+/// # Outputs
+///
+/// **Message**: `out`: Message output
+///
+/// # Usage
+/// ```
+/// use futuresdr::blocks::MessageSourceBuilder;
+/// use futuresdr::runtime::Flowgraph;
+///
+/// let mut fg = Flowgraph::new();
+///
+/// // Repeat the message "foo" every 100ms twenty times
+/// let msg_source = fg.add_block(
+///     MessageSourceBuilder::new(
+///         Pmt::String("foo".to_string()),
+///         time::Duration::from_millis(100),
+///     )
+///     .n_messages(20)
+///     .build()
+/// );
+/// ```
 pub struct MessageSourceBuilder {
     message: Pmt,
     duration: Duration,

--- a/src/blocks/message_source.rs
+++ b/src/blocks/message_source.rs
@@ -108,7 +108,7 @@ impl AsyncKernel for MessageSource {
 ///     .build()
 /// );
 /// ```
-#[doc(cfg(not(target_arch = "wasm32")))]
+#[cfg_attr(docsrs, doc(cfg(not(target_arch = "wasm32"))))]
 pub struct MessageSourceBuilder {
     message: Pmt,
     duration: Duration,

--- a/src/blocks/message_source.rs
+++ b/src/blocks/message_source.rs
@@ -108,6 +108,7 @@ impl AsyncKernel for MessageSource {
 ///     .build()
 /// );
 /// ```
+#[doc(cfg(not(target_arch = "wasm32")))]
 pub struct MessageSourceBuilder {
     message: Pmt,
     duration: Duration,

--- a/src/blocks/message_source.rs
+++ b/src/blocks/message_source.rs
@@ -93,8 +93,9 @@ impl AsyncKernel for MessageSource {
 ///
 /// # Usage
 /// ```
+/// use std::time;
 /// use futuresdr::blocks::MessageSourceBuilder;
-/// use futuresdr::runtime::Flowgraph;
+/// use futuresdr::runtime::{Flowgraph, Pmt};
 ///
 /// let mut fg = Flowgraph::new();
 ///

--- a/src/blocks/mod.rs
+++ b/src/blocks/mod.rs
@@ -3,11 +3,13 @@
 //! |---|---|---|
 //! | [Apply] | Apply a function to each sample | ✅ |
 //! | [Combine] | Apply a function to combine two streams into one | ✅ |
+//! | [Filter] | Apply a function to filter samples | ✅ |
 //!
 //! ## DSP blocks
 //! | Block | Usage | WebAssembly? |
 //! |---|---|---|
 //! | [fir](FirBuilder) | Generic FIR filter | ✅ |
+//! | [fft](FftBuilder) | Computes FFT | ✅ |
 //!
 //! ## Limiting blocks
 //! | Block| Usage | WebAssembly? |
@@ -19,8 +21,11 @@
 //! | Block | Usage | WebAssembly? |
 //! |---|---|---|
 //! | [FileSource] | Reads samples from a file | ❌ |
+//! | [SoapySource](SoapySourceBuilder) | Read samples from a soapy device | ❌ |
+//! | [Source] | Repeatedly apply a function to generate samples | ✅ |
+//! | [NullSource] | Generates a stream of zeros | ✅ |
 //! | [FileSink] | Writes samples to a file | ❌ |
-//! | [SoapySource] | Read samples from a soapy device | ❌ |
+//! | [NullSink] | Drops samples | ✅ |
 //! 
 //! ## Message blocks
 //! | Block | Usage | WebAssembly? |

--- a/src/blocks/mod.rs
+++ b/src/blocks/mod.rs
@@ -4,7 +4,7 @@
 //! | [Apply] | Apply a function to each sample | ✅ |
 //! | [Combine] | Apply a function to combine two streams into one | ✅ |
 //!
-//! ## Filter blocks
+//! ## DSP blocks
 //! | Block | Usage | WebAssembly? |
 //! |---|---|---|
 //! | [fir](FirBuilder) | Generic FIR filter | ✅ |
@@ -15,10 +15,12 @@
 //! | [Throttle] | Limits graph sample rate | ❌ |
 //! | [Head] | Stops graph after specified number of samples | ✅ |
 //!
-//! ## I/O blocks
+//! ## Source/sink blocks
 //! | Block | Usage | WebAssembly? |
 //! |---|---|---|
 //! | [FileSource] | Reads samples from a file | ❌ |
+//! | [FileSink] | Writes samples to a file | ❌ |
+//! | [SoapySource] | Read samples from a soapy device | ❌ |
 //! 
 //! ## Message blocks
 //! | Block | Usage | WebAssembly? |

--- a/src/blocks/mod.rs
+++ b/src/blocks/mod.rs
@@ -23,7 +23,7 @@
 //! ## Message blocks
 //! | Block | Usage | WebAssembly? |
 //! |---|---|---|
-//! | [MessageSourceBuilder] | Repeats a fixed message on an interval | ❌ |
+//! | [MessageSource](MessageSourceBuilder) | Repeats a fixed message on an interval | ❌ |
 
 mod apply;
 pub use apply::Apply;

--- a/src/blocks/mod.rs
+++ b/src/blocks/mod.rs
@@ -1,3 +1,30 @@
+//! ## Generic blocks
+//! | Block | Usage | WebAssembly? |
+//! |---|---|---|
+//! | [Apply] | Apply a function to each sample | ✅ |
+//! | [Combine] | Apply a function to combine two streams into one | ✅ |
+//!
+//! ## Filter blocks
+//! | Block | Usage | WebAssembly? |
+//! |---|---|---|
+//! | [fir](FirBuilder) | Generic FIR filter | ✅ |
+//!
+//! ## Limiting blocks
+//! | Block| Usage | WebAssembly? |
+//! |---|---|---|
+//! | [Throttle] | Limits graph sample rate | ❌ |
+//! | [Head] | Stops graph after specified number of samples | ✅ |
+//!
+//! ## I/O blocks
+//! | Block | Usage | WebAssembly? |
+//! |---|---|---|
+//! | [FileSource] | Reads samples from a file | ❌ |
+//! 
+//! ## Message blocks
+//! | Block | Usage | WebAssembly? |
+//! |---|---|---|
+//! | [MessageSourceBuilder] | Repeats a fixed message on an interval | ❌ |
+
 mod apply;
 pub use apply::Apply;
 

--- a/src/blocks/null_sink.rs
+++ b/src/blocks/null_sink.rs
@@ -9,6 +9,26 @@ use crate::runtime::StreamIo;
 use crate::runtime::StreamIoBuilder;
 use crate::runtime::WorkIo;
 
+/// Silently drops samples
+///
+/// # Inputs
+///
+/// `in`: Stream to drop
+///
+/// # Outputs
+///
+/// No outputs
+///
+/// # Usage
+/// ```
+/// use futuresdr::blocks::NullSink;
+/// use futuresdr::runtime::Flowgraph;
+/// use num_complex::Complex;
+///
+/// let mut fg = Flowgraph::new();
+///
+/// let sink = fg.add_block(NullSink::<Complex<f32>>::new());
+/// ```
 pub struct NullSink<T: Send + 'static> {
     n_received: usize,
     _type: std::marker::PhantomData<T>,

--- a/src/blocks/null_source.rs
+++ b/src/blocks/null_source.rs
@@ -9,6 +9,26 @@ use crate::runtime::StreamIo;
 use crate::runtime::StreamIoBuilder;
 use crate::runtime::WorkIo;
 
+/// Generates a stream of zeroes
+///
+/// # Inputs
+///
+/// No inputs
+///
+/// # Outputs
+///
+/// `out`: Output
+///
+/// # Usage
+/// ```
+/// use futuresdr::blocks::NullSource;
+/// use futuresdr::runtime::Flowgraph;
+/// use num_complex::Complex;
+///
+/// let mut fg = Flowgraph::new();
+///
+/// let source = fg.add_block(NullSource::<Complex<f32>>::new());
+/// ```
 pub struct NullSource<T: Send + 'static> {
     _type: std::marker::PhantomData<T>,
 }

--- a/src/blocks/soapy_src.rs
+++ b/src/blocks/soapy_src.rs
@@ -16,26 +16,6 @@ use crate::runtime::StreamIo;
 use crate::runtime::StreamIoBuilder;
 use crate::runtime::WorkIo;
 
-/// Read samples from a SoapySDR source
-///
-/// # Inputs
-///
-/// **Message** `freq`: a Pmt::u32 to change the frequency to.
-///
-/// # Outputs
-///
-/// `out`: Samples received from device.
-///
-/// # Usage
-/// ```
-/// use futuresdr::blocks::SoapySource;
-/// use futuresdr::runtime::Flowgraph;
-/// use num_complex::Complex;
-///
-/// let mut fg = Flowgraph::new();
-///
-/// let source = fg.add_block(SoapySource::new(100e9, 1e6, 10.0, "device=hackrf"));
-/// ```
 pub struct SoapySource {
     dev: Option<soapysdr::Device>,
     stream: Option<soapysdr::RxStream<Complex<f32>>>,
@@ -145,6 +125,33 @@ impl AsyncKernel for SoapySource {
 
 unsafe impl Sync for SoapySource {}
 
+/// Read samples from a SoapySDR source
+///
+/// # Inputs
+///
+/// **Message** `freq`: a Pmt::u32 to change the frequency to.
+///
+/// # Outputs
+///
+/// `out`: Samples received from device.
+///
+/// # Usage
+/// ```no_run
+/// use futuresdr::blocks::SoapySourceBuilder;
+/// use futuresdr::runtime::Flowgraph;
+/// use num_complex::Complex;
+///
+/// let mut fg = Flowgraph::new();
+///
+/// let source = fg.add_block(
+///     SoapySourceBuilder::new()
+///         .freq(100e9)
+///         .sample_rate(1e6)
+///         .gain(10.0)
+///         .filter("device=hackrf")
+///         .build()
+/// );
+/// ```
 #[derive(Default)]
 pub struct SoapySourceBuilder {
     freq: f64,

--- a/src/blocks/soapy_src.rs
+++ b/src/blocks/soapy_src.rs
@@ -16,6 +16,26 @@ use crate::runtime::StreamIo;
 use crate::runtime::StreamIoBuilder;
 use crate::runtime::WorkIo;
 
+/// Read samples from a SoapySDR source
+///
+/// # Inputs
+///
+/// **Message** `freq`: a Pmt::u32 to change the frequency to.
+///
+/// # Outputs
+///
+/// `out`: Samples received from device.
+///
+/// # Usage
+/// ```
+/// use futuresdr::blocks::SoapySource;
+/// use futuresdr::runtime::Flowgraph;
+/// use num_complex::Complex;
+///
+/// let mut fg = Flowgraph::new();
+///
+/// let source = fg.add_block(SoapySource::new(100e9, 1e6, 10.0, "device=hackrf"));
+/// ```
 pub struct SoapySource {
     dev: Option<soapysdr::Device>,
     stream: Option<soapysdr::RxStream<Complex<f32>>>,

--- a/src/blocks/source.rs
+++ b/src/blocks/source.rs
@@ -11,6 +11,26 @@ use crate::runtime::StreamIoBuilder;
 use crate::runtime::SyncKernel;
 use crate::runtime::WorkIo;
 
+/// Repeatedly applies a function to generate samples.
+///
+/// # Inputs
+///
+/// No inputs.
+///
+/// # Outputs
+///
+/// `out`: Output samples
+///
+/// # Usage
+/// ```
+/// use futuresdr::blocks::Source;
+/// use futuresdr::runtime::Flowgraph;
+///
+/// let mut fg = Flowgraph::new();
+///
+/// // Generate zeroes
+/// let source = fg.add_block(Source::<f32>::new(|| { 0.0 }));
+/// ```
 pub struct Source<A>
 where
     A: 'static,

--- a/src/blocks/throttle.rs
+++ b/src/blocks/throttle.rs
@@ -35,6 +35,7 @@ use crate::runtime::WorkIo;
 ///
 /// let throttle = fg.add_block(Throttle::<Complex<f32>>::new(1_000_000.0));
 /// ```
+#[doc(cfg(not(target_arch = "wasm32")))]
 pub struct Throttle<T: Send + 'static> {
     rate: f64,
     t_init: Instant,

--- a/src/blocks/throttle.rs
+++ b/src/blocks/throttle.rs
@@ -35,7 +35,7 @@ use crate::runtime::WorkIo;
 ///
 /// let throttle = fg.add_block(Throttle::<Complex<f32>>::new(1_000_000.0));
 /// ```
-#[doc(cfg(not(target_arch = "wasm32")))]
+#[cfg_attr(docsrs, doc(cfg(not(target_arch = "wasm32"))))]
 pub struct Throttle<T: Send + 'static> {
     rate: f64,
     t_init: Instant,

--- a/src/blocks/throttle.rs
+++ b/src/blocks/throttle.rs
@@ -15,6 +15,26 @@ use crate::runtime::StreamIo;
 use crate::runtime::StreamIoBuilder;
 use crate::runtime::WorkIo;
 
+/// Limits the sample rate to the given value
+///
+/// # Inputs
+///
+/// `in`: Input
+///
+/// # Outputs
+///
+/// `out`: Output
+///
+/// # Usage
+/// ```
+/// use futuresdr::blocks::Throttle;
+/// use futuresdr::runtime::Flowgraph;
+/// use num_complex::Complex;
+///
+/// let mut fg = Flowgraph::new();
+///
+/// let throttle = fg.add_block(Throttle::<Complex<f32>>::new(1_000_000.0));
+/// ```
 pub struct Throttle<T: Send + 'static> {
     rate: f64,
     t_init: Instant,
@@ -23,6 +43,7 @@ pub struct Throttle<T: Send + 'static> {
 }
 
 impl<T: Send + 'static> Throttle<T> {
+    /// Creates a new Throttle block which will throttle to the specified rate.
     pub fn new(rate: f64) -> Block {
         Block::new_async(
             BlockMetaBuilder::new("Throttle").build(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,7 @@
 #![recursion_limit = "512"]
 #![allow(clippy::new_ret_no_self)]
 #![cfg_attr(not(RUSTC_IS_STABLE), feature(core_intrinsics))]
+#![cfg_attr(RUSTC_IS_NIGHTLY, feature(doc_cfg))]
 
 //! An experimental asynchronous SDR runtime for heterogeneous architectures that is:
 //! * **Extensible**: custom buffers (supporting accelerators like GPUs and FPGAs) and custom schedulers (optimized for your application).

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,7 @@
 #![recursion_limit = "512"]
 #![allow(clippy::new_ret_no_self)]
 #![cfg_attr(not(RUSTC_IS_STABLE), feature(core_intrinsics))]
-#![cfg_attr(RUSTC_IS_NIGHTLY, feature(doc_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 
 //! An experimental asynchronous SDR runtime for heterogeneous architectures that is:
 //! * **Extensible**: custom buffers (supporting accelerators like GPUs and FPGAs) and custom schedulers (optimized for your application).


### PR DESCRIPTION
Inspired by the [nom docs](https://github.com/Geal/nom/blob/main/doc/choosing_a_combinator.md), I started writing some block docs. I've only written a few so far, but I think it's a reasonable cross-section of blocks (and I plan to write more later but I have to go get food right now).

The high points:
* There's a summary table in `futuredsp::blocks` that looks quite nice, and gives a brief description of all the available blocks, as well as sorting them by type.
  * Note that the major difference between this and the block listing below is twofold: One, it groups the blocks, and two, it excludes things that aren't blocks, like `MessageSourceBuilder` vs. `MessageSource`. But at the same time, it does duplicate quite a bit of information.
* Each block's docs has a standardized:
  * Description,
  * list of inputs & outputs (including marking which are message inputs/output),
  * and usage code sample.
* Also, the `doc(cfg())` gives us the nice little purple tag that says what features are required. There is a `doc_auto_cfg` feature, but it doesn't seem to pick up the features well, so in my limited experimenting we do have to manually specify it. The method for enabling it on docs.rs is stolen from [StackOverflow](https://stackoverflow.com/questions/61417452/how-to-get-a-feature-requirement-tag-in-the-documentation-generated-by-cargo-do).

To generate the docs locally, you can run e.g.:
```
$ RUSTDOCFLAGS="--cfg docsrs" cargo +nightly doc
```

Summary:
![image](https://user-images.githubusercontent.com/879600/158028585-e16c90a7-6fe3-43a8-9347-6b5bd46f20a1.png)

Block documentation:
![image](https://user-images.githubusercontent.com/879600/158028772-0720ccd8-4725-469b-9b3f-4622ef841ed5.png)

(also, note that some of the links for the FIR documentation are currently broken, because they refer to some things I'm still working on in another branch)