### PR TITLE
Round FileSource output to item_size

### DIFF
--- a/src/blocks/file_source.rs
+++ b/src/blocks/file_source.rs
@@ -46,6 +46,9 @@ impl<T: Send + 'static> AsyncKernel for FileSource<T> {
         let out = sio.output(0).slice::<u8>();
         let item_size = std::mem::size_of::<T>();
 
+        let out_len = out.len();
+        let out = &mut out[..out_len - out_len % item_size];
+
         let mut i = 0;
 
         while i < out.len() {


### PR DESCRIPTION
This change enforces that, as long as there are sufficient bytes, a
multiple of item_size bytes will be read from the file.

Note that the block will always _produce_ a multiple of item_size bytes, but I don't think it was guaranteed that it would always read a multiple. (for example, if the `item_size` is 8, and the output buffer is 11 bytes long) Note that I haven't actually reproduced or encountered this bug, but I think it is actually a bug.