### PR TITLE
Add IIR filter

### DIFF
--- a/futuredsp/src/fir.rs
+++ b/futuredsp/src/fir.rs
@@ -2,10 +2,8 @@ use core::cmp::Ordering;
 #[cfg(not(RUSTC_IS_STABLE))]
 use core::intrinsics::{fadd_fast, fmul_fast};
 
+use crate::TapsAccessor;
 use num_complex::Complex;
-
-extern crate alloc;
-use alloc::vec::Vec;
 
 /// Represents the status of a computation.
 #[derive(PartialEq, Eq, Clone, Copy, Debug)]
@@ -50,57 +48,6 @@ pub trait FirKernel<SampleType>: Send {
         input: &[SampleType],
         output: &mut [SampleType],
     ) -> (usize, usize, ComputationStatus);
-}
-
-pub trait TapsAccessor: Send {
-    type TapType;
-
-    fn num_taps(&self) -> usize;
-
-    /// Gets the `index`th tap.
-    ///
-    /// # Safety
-    /// The invariant `index < num_taps()` must be upheld.
-    unsafe fn get(&self, index: usize) -> Self::TapType;
-}
-
-impl<const N: usize> TapsAccessor for [f32; N] {
-    type TapType = f32;
-
-    fn num_taps(&self) -> usize {
-        N
-    }
-
-    unsafe fn get(&self, index: usize) -> f32 {
-        debug_assert!(index < self.num_taps());
-        *self.get_unchecked(index)
-    }
-}
-
-impl<const N: usize> TapsAccessor for &[f32; N] {
-    type TapType = f32;
-
-    fn num_taps(&self) -> usize {
-        N
-    }
-
-    unsafe fn get(&self, index: usize) -> f32 {
-        debug_assert!(index < self.num_taps());
-        *self.get_unchecked(index)
-    }
-}
-
-impl TapsAccessor for Vec<f32> {
-    type TapType = f32;
-
-    fn num_taps(&self) -> usize {
-        self.len()
-    }
-
-    unsafe fn get(&self, index: usize) -> f32 {
-        debug_assert!(index < self.num_taps());
-        *self.get_unchecked(index)
-    }
 }
 
 /// A non-resampling FIR filter. Calling `work()` on this struct always

--- a/futuredsp/src/iir.rs
+++ b/futuredsp/src/iir.rs
@@ -1,0 +1,200 @@
+use crate::{ComputationStatus, StatefulUnaryKernel, TapsAccessor};
+
+extern crate alloc;
+use alloc::vec::Vec;
+
+/// An IIR filter.
+///
+/// Calling `work()` on this struct always produces exactly as many samples as
+/// it consumes. Note that this kernel is stateful, and thus implements the
+/// [StatefulUnaryKernel] trait.
+///
+/// Implementations of this core currently exist only for `f32` samples with
+/// `f32` taps.
+///
+/// Example usage:
+/// ```
+/// use futuredsp::StatefulUnaryKernel;
+/// use futuredsp::iir::IirKernel;
+///
+/// let mut iir = IirKernel::<f32, _>::new([1.0, 2.0, 3.0], [4.0, 5.0, 6.0]);
+///
+/// let input = [1.0, 2.0, 3.0, 4.0, 5.0];
+/// let mut output = [0.0];
+/// iir.work(&input, &mut output);
+/// assert_eq!(output[0], 42.0);
+/// ```
+pub struct IirKernel<SampleType, TapsType: TapsAccessor> {
+    a_taps: TapsType,
+    b_taps: TapsType,
+    memory: Vec<SampleType>,
+    _sampletype: core::marker::PhantomData<SampleType>,
+}
+
+impl<SampleType, TapType, TapsType: TapsAccessor<TapType = TapType>>
+    IirKernel<SampleType, TapsType>
+{
+    pub fn new(a_taps: TapsType, b_taps: TapsType) -> Self {
+        Self {
+            a_taps,
+            b_taps,
+            memory: Vec::new(),
+            _sampletype: core::marker::PhantomData,
+        }
+    }
+}
+
+impl<TapsType: TapsAccessor<TapType = f32>> StatefulUnaryKernel<f32> for IirKernel<f32, TapsType> {
+    fn work(&mut self, i: &[f32], o: &mut [f32]) -> (usize, usize, ComputationStatus) {
+        if i.is_empty() {
+            return (
+                0,
+                0,
+                if o.is_empty() {
+                    ComputationStatus::BothSufficient
+                } else {
+                    ComputationStatus::InsufficientInput
+                },
+            );
+        }
+
+        // Load the memory with samples
+        let mut num_filled = 0;
+        while self.memory.len() < self.a_taps.num_taps() {
+            if i.len() <= self.memory.len() {
+                return (
+                    0,
+                    0,
+                    if o.is_empty() {
+                        ComputationStatus::BothSufficient
+                    } else {
+                        ComputationStatus::InsufficientInput
+                    },
+                );
+            }
+            self.memory.push(i[self.memory.len()]);
+            num_filled += 1;
+        }
+        if num_filled == i.len() {
+            return (
+                0,
+                0,
+                if o.is_empty() {
+                    ComputationStatus::BothSufficient
+                } else {
+                    ComputationStatus::InsufficientInput
+                },
+            );
+        }
+
+        assert_eq!(self.a_taps.num_taps(), self.memory.len());
+        assert!(self.b_taps.num_taps() > 0);
+
+        let mut n_consumed = 0;
+        let mut n_produced = 0;
+        while n_consumed + self.b_taps.num_taps() - 1 < i.len() && n_produced < o.len() {
+            let o: &mut f32 = &mut o[n_produced];
+
+            *o = 0.0;
+
+            // Calculate the intermediate value
+            for b_tap in 0..self.b_taps.num_taps() {
+                // Safety: We're iterating only up to the # of taps in B
+                *o += unsafe { self.b_taps.get(b_tap) }
+                    * i[n_consumed + self.b_taps.num_taps() - b_tap - 1];
+            }
+
+            // Apply the feedback a taps
+            for a_tap in 0..self.a_taps.num_taps() {
+                // Safety: The iterand is limited to a_taps' length
+                *o += unsafe { self.a_taps.get(a_tap) } * self.memory[a_tap];
+            }
+
+            // Update the memory
+            for idx in 1..self.memory.len() {
+                self.memory[idx] = self.memory[idx - 1];
+            }
+            if !self.memory.is_empty() {
+                self.memory[0] = *o;
+            }
+
+            n_produced += 1;
+            n_consumed += 1;
+        }
+
+        (
+            n_consumed,
+            n_produced,
+            if n_consumed == i.len() && n_produced == o.len() {
+                ComputationStatus::BothSufficient
+            } else if n_consumed < i.len() {
+                ComputationStatus::InsufficientOutput
+            } else {
+                assert!(n_produced < o.len());
+                ComputationStatus::InsufficientInput
+            },
+        )
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    use alloc::vec;
+
+    struct Feeder {
+        filter: IirKernel<f32, Vec<f32>>,
+        input: Vec<f32>,
+    }
+
+    impl Feeder {
+        fn feed(&mut self, input: f32) -> Option<f32> {
+            self.input.push(input);
+
+            let mut out = [0.0];
+            let (n_consumed, n_produced, _status) = self.filter.work(&self.input[..], &mut out);
+            assert_eq!(n_consumed, n_produced); // If we consume samples, we produce samples
+            if n_consumed > 0 {
+                self.input.drain(0..n_consumed);
+            }
+            if n_produced > 0 {
+                Some(out[0])
+            } else {
+                None
+            }
+        }
+    }
+
+    fn make_filter(a_taps: Vec<f32>, b_taps: Vec<f32>) -> Feeder {
+        Feeder {
+            filter: IirKernel {
+                a_taps,
+                b_taps,
+                memory: vec![],
+                _sampletype: core::marker::PhantomData,
+            },
+            input: vec![],
+        }
+    }
+
+    #[test]
+    fn test_iir_b_taps_algorithm() {
+        let mut iir = make_filter(vec![], vec![1.0, 2.0, 3.0]);
+
+        assert_eq!(iir.feed(10.0), None);
+        assert_eq!(iir.feed(20.0), None);
+        assert_eq!(iir.feed(30.0), Some(30.0 + 40.0 + 30.0));
+        assert_eq!(iir.feed(40.0), Some(40.0 + 60.0 + 60.0));
+    }
+
+    #[test]
+    fn test_iir_single_a_tap_algorithm() {
+        let mut iir = make_filter(vec![0.5], vec![1.0]);
+
+        assert_eq!(iir.feed(10.0), None);
+        assert_eq!(iir.feed(10.0), Some(15.0));
+        assert_eq!(iir.feed(10.0), Some(17.5));
+        assert_eq!(iir.feed(10.0), Some(18.75));
+    }
+}

--- a/futuredsp/src/kernel.rs
+++ b/futuredsp/src/kernel.rs
@@ -1,0 +1,121 @@
+/// Represents the status of a computation.
+#[derive(PartialEq, Eq, Clone, Copy, Debug)]
+pub enum ComputationStatus {
+    /// Indicates that the output buffer could hold more samples, if more
+    /// input samples were present.
+    InsufficientInput,
+
+    /// Indicates that more output samples can be computed from the given input,
+    /// but there is not enough available space in the output buffer.
+    InsufficientOutput,
+
+    /// Indicates that as many samples as possible could be computed from the
+    /// input buffer, and that the output buffer was exactly filled.
+    BothSufficient,
+}
+
+impl ComputationStatus {
+    /// Returns whether the output was sufficient to hold all producible samples.
+    pub fn produced_all_samples(self) -> bool {
+        self == Self::BothSufficient || self == Self::InsufficientInput
+    }
+}
+
+/// Implements a trait to run computations with FIR filters.
+pub trait UnaryKernel<SampleType>: Send {
+    /// Computes the FIR filter on the given input, outputting into the given output.
+    /// Note that filters will not generally have internal memory - therefore, even
+    /// if the output is sufficiently large, not all input samples may be consumed.
+    /// However, it is also permitted for kernel implementations to contain state
+    /// related to the input stream (for example, it may contain an internal buffer
+    /// of the last `num_taps` input samples).
+    ///
+    /// Returns a tuple containing, in order:
+    /// - The number of samples consumed from the input,
+    /// - The number of samples produced in the output, and
+    /// - A `ComputationStatus` which indicates whether the buffers were undersized.
+    ///
+    /// Elements of `output` beyond what is produced are left in an unspecified state.
+    fn work(
+        &self,
+        input: &[SampleType],
+        output: &mut [SampleType],
+    ) -> (usize, usize, ComputationStatus);
+}
+
+/// Implements a trait to run computations with FIR filters.
+pub trait StatefulUnaryKernel<SampleType>: Send {
+    /// Computes the FIR filter on the given input, outputting into the given output.
+    /// Note that filters will not generally have internal memory - therefore, even
+    /// if the output is sufficiently large, not all input samples may be consumed.
+    /// However, it is also permitted for kernel implementations to contain state
+    /// related to the input stream (for example, it may contain an internal buffer
+    /// of the last `num_taps` input samples).
+    ///
+    /// Returns a tuple containing, in order:
+    /// - The number of samples consumed from the input,
+    /// - The number of samples produced in the output, and
+    /// - A `ComputationStatus` which indicates whether the buffers were undersized.
+    ///
+    /// Elements of `output` beyond what is produced are left in an unspecified state.
+    fn work(
+        &mut self,
+        input: &[SampleType],
+        output: &mut [SampleType],
+    ) -> (usize, usize, ComputationStatus);
+}
+
+impl<SampleType, T: UnaryKernel<SampleType>> StatefulUnaryKernel<SampleType> for T {
+    fn work(
+        &mut self,
+        input: &[SampleType],
+        output: &mut [SampleType],
+    ) -> (usize, usize, ComputationStatus) {
+        UnaryKernel::<SampleType>::work(self, input, output)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    struct NopKernel;
+
+    impl UnaryKernel<f32> for NopKernel {
+        fn work(&self, _input: &[f32], output: &mut [f32]) -> (usize, usize, ComputationStatus) {
+            for i in 0..output.len() {
+                output[i] = i as f32;
+            }
+            (0, output.len(), ComputationStatus::BothSufficient)
+        }
+    }
+
+    fn exec_kernel<T: StatefulUnaryKernel<f32>>(mut kernel: T, output: &mut [f32]) {
+        kernel.work(&[], output);
+    }
+
+    #[test]
+    fn call_stateful_unary_on_unary_test() {
+        let kernel = NopKernel;
+        let mut output = [0.0; 4];
+        exec_kernel(kernel, &mut output);
+        assert_eq!(output, [0.0, 1.0, 2.0, 3.0]);
+    }
+
+    #[test]
+    fn can_naturally_resolve_mut_kernel() {
+        #[allow(unused_mut)]
+        let mut kernel = NopKernel;
+        let mut output = [0.0; 4];
+        kernel.work(&[], &mut output);
+        assert_eq!(output, [0.0, 1.0, 2.0, 3.0]);
+    }
+
+    #[test]
+    fn can_naturally_resolve_const_kernel() {
+        let kernel = NopKernel;
+        let mut output = [0.0; 4];
+        kernel.work(&[], &mut output);
+        assert_eq!(output, [0.0, 1.0, 2.0, 3.0]);
+    }
+}

--- a/futuredsp/src/kernel.rs
+++ b/futuredsp/src/kernel.rs
@@ -51,7 +51,7 @@ pub trait StatefulUnaryKernel<SampleType>: Send {
     /// * A given instantiated kernel must be called sequentially on a single
     ///   stream of data. Switching between data streams with a single kernel
     ///   will result in undefined behaviour.
-    /// 
+    ///
     /// Note that all `StatefulUnaryKernel`s implement `UnaryKernel` by
     /// definition.
     ///
@@ -86,8 +86,8 @@ mod test {
 
     impl UnaryKernel<f32> for NopKernel {
         fn work(&self, _input: &[f32], output: &mut [f32]) -> (usize, usize, ComputationStatus) {
-            for i in 0..output.len() {
-                output[i] = i as f32;
+            for (i, out) in output.iter_mut().enumerate() {
+                *out = i as f32;
             }
             (0, output.len(), ComputationStatus::BothSufficient)
         }

--- a/futuredsp/src/lib.rs
+++ b/futuredsp/src/lib.rs
@@ -5,3 +5,6 @@ pub mod fir;
 
 mod tapsaccessor;
 pub use tapsaccessor::TapsAccessor;
+
+mod kernel;
+pub use kernel::{ComputationStatus, StatefulUnaryKernel, UnaryKernel};

--- a/futuredsp/src/lib.rs
+++ b/futuredsp/src/lib.rs
@@ -2,3 +2,6 @@
 #![cfg_attr(not(RUSTC_IS_STABLE), feature(core_intrinsics))]
 
 pub mod fir;
+
+mod tapsaccessor;
+pub use tapsaccessor::TapsAccessor;

--- a/futuredsp/src/lib.rs
+++ b/futuredsp/src/lib.rs
@@ -2,6 +2,7 @@
 #![cfg_attr(not(RUSTC_IS_STABLE), feature(core_intrinsics))]
 
 pub mod fir;
+pub mod iir;
 
 mod tapsaccessor;
 pub use tapsaccessor::TapsAccessor;

--- a/futuredsp/src/tapsaccessor.rs
+++ b/futuredsp/src/tapsaccessor.rs
@@ -1,0 +1,53 @@
+extern crate alloc;
+use alloc::vec::Vec;
+
+pub trait TapsAccessor: Send {
+    type TapType;
+
+    fn num_taps(&self) -> usize;
+
+    /// Gets the `index`th tap.
+    ///
+    /// # Safety
+    /// The invariant `index < num_taps()` must be upheld.
+    unsafe fn get(&self, index: usize) -> Self::TapType;
+}
+
+impl<const N: usize> TapsAccessor for [f32; N] {
+    type TapType = f32;
+
+    fn num_taps(&self) -> usize {
+        N
+    }
+
+    unsafe fn get(&self, index: usize) -> f32 {
+        debug_assert!(index < self.num_taps());
+        *self.get_unchecked(index)
+    }
+}
+
+impl<const N: usize> TapsAccessor for &[f32; N] {
+    type TapType = f32;
+
+    fn num_taps(&self) -> usize {
+        N
+    }
+
+    unsafe fn get(&self, index: usize) -> f32 {
+        debug_assert!(index < self.num_taps());
+        *self.get_unchecked(index)
+    }
+}
+
+impl TapsAccessor for Vec<f32> {
+    type TapType = f32;
+
+    fn num_taps(&self) -> usize {
+        self.len()
+    }
+
+    unsafe fn get(&self, index: usize) -> f32 {
+        debug_assert!(index < self.num_taps());
+        *self.get_unchecked(index)
+    }
+}

--- a/src/blocks/fir.rs
+++ b/src/blocks/fir.rs
@@ -11,12 +11,13 @@ use crate::runtime::StreamIoBuilder;
 use crate::runtime::SyncKernel;
 use crate::runtime::WorkIo;
 use futuredsp::fir::*;
+use futuredsp::{TapsAccessor, UnaryKernel};
 
 pub struct Fir<SampleType, TapType, Core>
 where
     SampleType: 'static + Send,
     TapType: 'static,
-    Core: 'static + FirKernel<SampleType>,
+    Core: 'static + UnaryKernel<SampleType>,
 {
     core: Core,
     _sampletype: std::marker::PhantomData<SampleType>,
@@ -27,7 +28,7 @@ unsafe impl<SampleType, TapType, Core> Send for Fir<SampleType, TapType, Core>
 where
     SampleType: 'static + Send,
     TapType: 'static,
-    Core: 'static + FirKernel<SampleType>,
+    Core: 'static + UnaryKernel<SampleType>,
 {
 }
 
@@ -35,7 +36,7 @@ impl<SampleType, TapType, Core> Fir<SampleType, TapType, Core>
 where
     SampleType: 'static + Send,
     TapType: 'static,
-    Core: 'static + FirKernel<SampleType>,
+    Core: 'static + UnaryKernel<SampleType>,
 {
     pub fn new(core: Core) -> Block {
         Block::new_sync(
@@ -59,7 +60,7 @@ impl<SampleType, TapType, Core> SyncKernel for Fir<SampleType, TapType, Core>
 where
     SampleType: 'static + Send,
     TapType: 'static,
-    Core: 'static + FirKernel<SampleType>,
+    Core: 'static + UnaryKernel<SampleType>,
 {
     fn work(
         &mut self,
@@ -115,7 +116,7 @@ impl FirBuilder {
         SampleType: 'static + Send,
         TapType: 'static,
         Taps: 'static + TapsAccessor,
-        NonResamplingFirKernel<SampleType, Taps>: FirKernel<SampleType>,
+        NonResamplingFirKernel<SampleType, Taps>: UnaryKernel<SampleType>,
     {
         Fir::<SampleType, TapType, NonResamplingFirKernel<SampleType, Taps>>::new(
             NonResamplingFirKernel::new(taps),

--- a/src/blocks/iir.rs
+++ b/src/blocks/iir.rs
@@ -1,0 +1,141 @@
+use std::mem;
+
+use crate::anyhow::Result;
+use crate::runtime::Block;
+use crate::runtime::BlockMeta;
+use crate::runtime::BlockMetaBuilder;
+use crate::runtime::MessageIo;
+use crate::runtime::MessageIoBuilder;
+use crate::runtime::StreamIo;
+use crate::runtime::StreamIoBuilder;
+use crate::runtime::SyncKernel;
+use crate::runtime::WorkIo;
+use futuredsp::iir::IirKernel;
+use futuredsp::{StatefulUnaryKernel, TapsAccessor};
+
+pub struct Iir<SampleType, TapType, Core>
+where
+    SampleType: 'static + Send,
+    TapType: 'static,
+    Core: 'static + StatefulUnaryKernel<SampleType>,
+{
+    core: Core,
+    _sampletype: std::marker::PhantomData<SampleType>,
+    _taptype: std::marker::PhantomData<TapType>,
+}
+
+unsafe impl<SampleType, TapType, Core> Send for Iir<SampleType, TapType, Core>
+where
+    SampleType: 'static + Send,
+    TapType: 'static,
+    Core: 'static + StatefulUnaryKernel<SampleType>,
+{
+}
+
+impl<SampleType, TapType, Core> Iir<SampleType, TapType, Core>
+where
+    SampleType: 'static + Send,
+    TapType: 'static,
+    Core: 'static + StatefulUnaryKernel<SampleType>,
+{
+    pub fn new(core: Core) -> Block {
+        Block::new_sync(
+            BlockMetaBuilder::new("Iir").build(),
+            StreamIoBuilder::new()
+                .add_input("in", mem::size_of::<SampleType>())
+                .add_output("out", mem::size_of::<SampleType>())
+                .build(),
+            MessageIoBuilder::<Iir<SampleType, TapType, Core>>::new().build(),
+            Iir {
+                core,
+                _sampletype: std::marker::PhantomData,
+                _taptype: std::marker::PhantomData,
+            },
+        )
+    }
+}
+
+#[async_trait]
+impl<SampleType, TapType, Core> SyncKernel for Iir<SampleType, TapType, Core>
+where
+    SampleType: 'static + Send,
+    TapType: 'static,
+    Core: 'static + StatefulUnaryKernel<SampleType>,
+{
+    fn work(
+        &mut self,
+        io: &mut WorkIo,
+        sio: &mut StreamIo,
+        _mio: &mut MessageIo<Self>,
+        _meta: &mut BlockMeta,
+    ) -> Result<()> {
+        let i = sio.input(0).slice::<SampleType>();
+        let o = sio.output(0).slice::<SampleType>();
+
+        let (consumed, produced, status) = self.core.work(i, o);
+
+        sio.input(0).consume(consumed);
+        sio.output(0).produce(produced);
+
+        if sio.input(0).finished() && status.produced_all_samples() {
+            io.finished = true;
+        }
+
+        Ok(())
+    }
+}
+
+/// Creates a generic IIR filter.
+///
+/// This filter consumes two sets of taps, `a_taps` and `b_taps`. `a_taps` are
+/// the feedback taps, and `b_taps` are the feed-forward taps. If there are `n`
+/// feed-forward taps and `m` feed-back taps, the equation is:
+/// ```text
+/// y(k) = x[k] * b[0] + x[k-1] * b[1] + ... + x[k-n] * b[n]
+///        + x[k-1] * a[0] + x[k-2] * a[1] + ... + x[k-m-1] * a[m]
+/// ```
+///
+/// Uses the `futuredsp` to pick the optimal IIR implementation for the given
+/// constraints.
+///
+/// Note that there must be an implementation of [futuredsp::TapsAccessor] for
+/// the taps objects you pass in, see docs for details. Both the a_taps and the
+/// b_taps objects must be the same type.
+///
+/// Additionally, there must be an available core (implementation of
+/// [futuredsp::StatefulUnaryKernel]) available for the specified `SampleType`
+/// and `TapsType`. See the [futuredsp docs](futuredsp::iir) for available
+/// implementations.
+///
+/// # Inputs
+///
+/// `in`: Input
+///
+/// # Outputs
+///
+/// `out`: Output
+///
+/// # Usage
+/// ```
+/// use futuresdr::blocks::IirBuilder;
+/// use futuresdr::runtime::Flowgraph;
+///
+/// let mut fg = Flowgraph::new();
+///
+/// let iir = fg.add_block(IirBuilder::new::<f32, f32, _>([1.0, 2.0, 3.0], [4.0, 5.0, 6.0]));
+/// ```
+pub struct IirBuilder {
+    //
+}
+
+impl IirBuilder {
+    pub fn new<SampleType, TapType, Taps>(a_taps: Taps, b_taps: Taps) -> Block
+    where
+        SampleType: 'static + Send + Clone,
+        TapType: 'static,
+        Taps: 'static + TapsAccessor,
+        IirKernel<SampleType, Taps>: StatefulUnaryKernel<SampleType>,
+    {
+        Iir::<SampleType, TapType, IirKernel<SampleType, Taps>>::new(IirKernel::new(a_taps, b_taps))
+    }
+}

--- a/src/blocks/mod.rs
+++ b/src/blocks/mod.rs
@@ -42,6 +42,9 @@ pub use finite_source::FiniteSource;
 mod head;
 pub use head::Head;
 
+mod iir;
+pub use iir::{Iir, IirBuilder};
+
 #[cfg(feature = "lttng")]
 pub mod lttng;
 


### PR DESCRIPTION
This refactors some of the `futuredsp` code to make the kernel interfaces generic, and adds a IIR filter block.

It isn't currently optimized (at all), and it also only supports `f32` samples with `f32` taps. But, on my mid-tier laptop, it does apparently run at >70MS/s with 7 feedback taps and 1 feedforward tap, which is pretty reasonable, and certainly good enough for e.g. a FM radio de-emphasis filter or other audio work.
