### PR TITLE
Basic FIR design functionality

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ members = [
     "examples/android-hw",
     "examples/audio",
     "examples/cw",
+    "examples/firdes",
     "examples/fm-receiver",
     "examples/logging",
     "examples/rx-to-file",

--- a/examples/firdes/Cargo.toml
+++ b/examples/firdes/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "firdes"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+futuresdr = { path = "../..", features = ["audio"] }
+futuredsp = { path = "../../futuredsp", version = "0.0.2" }

--- a/examples/firdes/src/main.rs
+++ b/examples/firdes/src/main.rs
@@ -1,0 +1,58 @@
+use futuresdr::blocks::audio::AudioSink;
+use futuresdr::blocks::FirBuilder;
+use futuresdr::blocks::Source;
+use futuresdr::runtime::Flowgraph;
+use futuresdr::runtime::Runtime;
+
+use futuredsp::firdes;
+use futuresdr::anyhow::Result;
+
+fn main() -> Result<()> {
+    let mut fg = Flowgraph::new();
+
+    const SAMPLING_FREQ: u32 = 44_100;
+    const TONE_FREQ: (f32, f32, f32) = (2000.0, 6000.0, 10000.0);
+    let enable_filter = true;
+
+    static mut T: usize = 0;
+    let src = Source::<f32>::new(|| {
+        let x = unsafe {
+            T += 1;
+            T
+        };
+        let freq = match (x as f32 % SAMPLING_FREQ as f32) as u32 {
+            x if x < SAMPLING_FREQ / 3 => TONE_FREQ.0,
+            x if x < 2 * SAMPLING_FREQ / 3 => TONE_FREQ.1,
+            _ => TONE_FREQ.2,
+        };
+        (2.0 * std::f32::consts::PI * x as f32 * freq / SAMPLING_FREQ as f32).sin()
+    });
+
+    // Design bandpass filter for the middle tone
+    let lower_cutoff = (TONE_FREQ.1 - 200.0) / SAMPLING_FREQ as f32;
+    let higher_cutoff = (TONE_FREQ.1 + 200.0) / SAMPLING_FREQ as f32;
+    let transition_bw = 500.0 / SAMPLING_FREQ as f32;
+    let max_ripple = 0.01;
+
+    let filter_taps =
+        firdes::kaiser::bandpass(lower_cutoff, higher_cutoff, transition_bw, max_ripple);
+    println!("Filter has {} taps", filter_taps.len());
+
+    let filter_block = match enable_filter {
+        true => FirBuilder::new::<f32, f32, _>(filter_taps),
+        _ => FirBuilder::new::<f32, f32, _>([1.0_f32]),
+    };
+
+    let snk = AudioSink::new(SAMPLING_FREQ, 1);
+
+    let src = fg.add_block(src);
+    let filter_block = fg.add_block(filter_block);
+    let snk = fg.add_block(snk);
+
+    fg.connect_stream(src, "out", filter_block, "in")?;
+    fg.connect_stream(filter_block, "out", snk, "in")?;
+
+    Runtime::new().run(fg)?;
+
+    Ok(())
+}

--- a/examples/firdes/src/main.rs
+++ b/examples/firdes/src/main.rs
@@ -14,18 +14,15 @@ fn main() -> Result<()> {
     const TONE_FREQ: (f32, f32, f32) = (2000.0, 6000.0, 10000.0);
     let enable_filter = true;
 
-    static mut T: usize = 0;
-    let src = Source::<f32>::new(|| {
-        let x = unsafe {
-            T += 1;
-            T
-        };
-        let freq = match (x as f32 % SAMPLING_FREQ as f32) as u32 {
+    let mut t: usize = 0;
+    let src = Source::<f32>::new(move || {
+        t = t + 1;
+        let freq = match (t as f32 % SAMPLING_FREQ as f32) as u32 {
             x if x < SAMPLING_FREQ / 3 => TONE_FREQ.0,
             x if x < 2 * SAMPLING_FREQ / 3 => TONE_FREQ.1,
             _ => TONE_FREQ.2,
         };
-        (2.0 * std::f32::consts::PI * x as f32 * freq / SAMPLING_FREQ as f32).sin()
+        (2.0 * std::f32::consts::PI * t as f32 * freq / SAMPLING_FREQ as f32).sin()
     });
 
     // Design bandpass filter for the middle tone

--- a/futuredsp/src/firdes.rs
+++ b/futuredsp/src/firdes.rs
@@ -132,3 +132,363 @@ pub fn bandpass<T: FilterWindow<f32>>(
     }
     taps
 }
+
+/// FIR filter design methods based on the Kaiser window method. The resulting
+/// filters have generalized linear phase.
+///
+/// The Kaiser method is described in:
+/// - J. F. Kaiser "Nonrecursive Digital Filter Design using the I_0-sinh
+///   Window Function," Proc. 1974 IEEE International Symposium on Circuits
+///   & Systems, San Francisco CA, April. 1974.
+/// - A. V. Oppenheim and R. W. Schafer "Digital Signal Processing," 3rd Edition.
+pub mod kaiser {
+    extern crate alloc;
+    use crate::windows::KaiserWindow;
+    use alloc::vec::Vec;
+
+    /// Designs a lowpass FIR filter with cutoff frequency `cutoff` and
+    /// transition width `transition_bw` (in cycles/sample).
+    /// The number of taps in the filter depends on the specifications.
+    ///
+    /// Example usage:
+    /// ```
+    /// use futuredsp::firdes;
+    ///
+    /// let sampling_freq = 10_000;
+    /// // 2000 Hz cutoff frequency and 500 Hz transtion band
+    /// let cutoff = 2_000.0 / sampling_freq as f32;
+    /// let transition_bw = 500.0 / sampling_freq as f32;
+    /// let max_ripple = 0.001;
+    /// let taps = firdes::kaiser::lowpass(cutoff, transition_bw, max_ripple);
+    /// ```
+    pub fn lowpass(cutoff: f32, transition_bw: f32, max_ripple: f32) -> Vec<f32> {
+        assert!(cutoff > 0.0, "cutoff must be greater than 0");
+        assert!(transition_bw > 0.0, "transition_bw must be greater than 0");
+        assert!(
+            cutoff + transition_bw < 1.0 / 2.0,
+            "cutoff+transition_bw must be less than 1/2"
+        );
+        let (num_taps, beta) = design_kaiser_window(transition_bw, max_ripple);
+        let win = KaiserWindow::new(num_taps, beta);
+        let omega_c = (2.0 * cutoff + transition_bw) / 2.0;
+        super::lowpass(num_taps, omega_c, win)
+    }
+
+    /// Designs a highpass FIR filter with cutoff frequency `cutoff` and
+    /// transition width `transition_bw` (in cycles/sample).
+    /// The number of taps in the filter depends on the specifications.
+    ///
+    /// Example usage:
+    /// ```
+    /// use futuredsp::firdes;
+    ///
+    /// let sampling_freq = 10_000;
+    /// // 4000 Hz cutoff frequency and 500 Hz transtion band
+    /// let cutoff = 4_000.0 / sampling_freq as f32;
+    /// let transition_bw = 500.0 / sampling_freq as f32;
+    /// let max_ripple = 0.001;
+    /// let taps = firdes::kaiser::highpass(cutoff, transition_bw, max_ripple);
+    /// ```
+    pub fn highpass(cutoff: f32, transition_bw: f32, max_ripple: f32) -> Vec<f32> {
+        assert!(cutoff > 0.0, "cutoff must be greater than 0");
+        assert!(transition_bw > 0.0, "transition_bw must be greater than 0");
+        assert!(
+            cutoff + transition_bw < 1.0 / 2.0,
+            "cutoff+transition_bw must be less than 1/2"
+        );
+        // Determine cutoff frequency of the underlying ideal lowpass filter
+        let (num_taps, beta) = design_kaiser_window(transition_bw, max_ripple);
+        // Number of taps must be odd
+        let num_taps = num_taps + (num_taps % 2);
+        let win = KaiserWindow::new(num_taps, beta);
+        let omega_c = (2.0 * cutoff - transition_bw) / 2.0;
+        super::highpass(num_taps, omega_c, win)
+    }
+
+    /// Designs a bandpass FIR filter with lower cutoff frequency `lower_cutoff`,
+    /// higher cutoff frequency `higher_cutoff`, and transition widths
+    /// `transition_bw` (in cycles/sample).
+    /// The number of taps in the filter depends on the specifications.
+    ///
+    /// Example usage:
+    /// ```
+    /// use futuredsp::firdes;
+    ///
+    /// let sampling_freq = 10_000;
+    /// // 1000 Hz lower cutoff frequency, 2000 Hz higher cutoff frequency,
+    /// // and 500 Hz transtion bands
+    /// let lower_cutoff = 1_000.0 / sampling_freq as f32;
+    /// let higher_cutoff = 4_000.0 / sampling_freq as f32;
+    /// let transition_bw = 500.0 / sampling_freq as f32;
+    /// let max_ripple = 0.001;
+    /// let taps = firdes::kaiser::bandpass(lower_cutoff, higher_cutoff, transition_bw, max_ripple);
+    /// ```
+    pub fn bandpass(
+        lower_cutoff: f32,
+        higher_cutoff: f32,
+        transition_bw: f32,
+        max_ripple: f32,
+    ) -> Vec<f32> {
+        assert!(lower_cutoff > 0.0, "lower_cutoff must be greater than 0");
+        assert!(
+            higher_cutoff > lower_cutoff,
+            "higher_cutoff must be greater than lower_cutoff"
+        );
+        assert!(transition_bw > 0.0, "transition_bw must be greater than 0");
+        assert!(
+            higher_cutoff + transition_bw < 1.0 / 2.0,
+            "higher_cutoff+transition_bw must be less than 1/2"
+        );
+        let (num_taps, beta) = design_kaiser_window(transition_bw, max_ripple);
+        let win = KaiserWindow::new(num_taps, beta);
+        let lower_omega_c = (2.0 * lower_cutoff - transition_bw) / 2.0;
+        let higher_omega_c = (2.0 * higher_cutoff + transition_bw) / 2.0;
+        super::bandpass(num_taps, lower_omega_c, higher_omega_c, win)
+    }
+
+    fn design_kaiser_window(transition_bw: f32, max_ripple: f32) -> (usize, f32) {
+        // Determine Kaiser window parameters
+        let ripple_db = -20.0 * max_ripple.log10();
+        let beta = match ripple_db {
+            x if x > 50.0 => 0.1102 * (x - 8.7),
+            x if x >= 21.0 => 0.5842 * (x - 21.0).powf(0.4) + 0.07886 * (x - 21.0),
+            _ => 0.0,
+        };
+        let num_taps = (((ripple_db - 7.95) / (14.36 * transition_bw)).ceil() + 1.0) as usize;
+        (num_taps, beta)
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use super::*;
+
+        #[test]
+        fn lowpass_accuracy() {
+            let cutoff = 0.2;
+            let transition_bw = 0.05;
+            let max_ripple = 0.01;
+            // Test taps generated using matlab:
+            // ```
+            // c = kaiserord([0.2, 0.2+0.05], [1,0], [0.01, 0.01], 1, 'cell')
+            // taps = fir1(c{:});
+            // ```
+            let test_taps = [
+                0.000801064154378,
+                -0.002365829920883,
+                -0.002317066829825,
+                0.002912423701086,
+                0.004722494338058,
+                -0.002581790957417,
+                -0.007902817296928,
+                0.000761425035067,
+                0.011472606580612,
+                0.003169041375600,
+                -0.014740633607712,
+                -0.009778385805180,
+                0.016687423513410,
+                0.019601855418468,
+                -0.015887002008125,
+                -0.033375572621574,
+                0.010135834366629,
+                0.052954908730137,
+                0.005241422655623,
+                -0.085435542746372,
+                -0.047877021123625,
+                0.179797936334912,
+                0.413161963225821,
+                0.413161963225821,
+                0.179797936334912,
+                -0.047877021123625,
+                -0.085435542746372,
+                0.005241422655623,
+                0.052954908730137,
+                0.010135834366629,
+                -0.033375572621574,
+                -0.015887002008125,
+                0.019601855418468,
+                0.016687423513410,
+                -0.009778385805180,
+                -0.014740633607712,
+                0.003169041375600,
+                0.011472606580612,
+                0.000761425035067,
+                -0.007902817296928,
+                -0.002581790957417,
+                0.004722494338058,
+                0.002912423701086,
+                -0.002317066829825,
+                -0.002365829920883,
+                0.000801064154378,
+            ];
+            let filter_taps = lowpass(cutoff, transition_bw, max_ripple);
+            assert_eq!(filter_taps.len(), test_taps.len());
+            for i in 0..filter_taps.len() {
+                let tol = 1e-2;
+                assert!(
+                    (filter_taps[i] - test_taps[i]).abs() < tol,
+                    "abs({} - {}) < {} (tap {})",
+                    filter_taps[i],
+                    test_taps[i],
+                    tol,
+                    i
+                );
+            }
+        }
+
+        #[test]
+        fn highpass_accuracy() {
+            let cutoff = 0.4;
+            let transition_bw = 0.03;
+            let max_ripple = 0.02;
+            // Test taps generated using matlab:
+            // ```
+            // c = kaiserord([0.4-0.03, 0.4], [0,1], [0.02, 0.02], 1, 'cell')
+            // taps = fir1(c{:});
+            // ```
+            let test_taps = [
+                0.001101862089183,
+                0.000987622783890,
+                -0.003144929902063,
+                0.004076732108724,
+                -0.002873600914298,
+                -0.000331019542578,
+                0.004174826882078,
+                -0.006576810746863,
+                0.005795137106459,
+                -0.001525908120121,
+                -0.004593884000360,
+                0.009497895103678,
+                -0.010132234027704,
+                0.005193768023735,
+                0.003759912990388,
+                -0.012577161166323,
+                0.016278660841859,
+                -0.011643406975008,
+                -0.000637437587598,
+                0.015485234438367,
+                -0.025215481059303,
+                0.023076863879726,
+                -0.007061591302535,
+                -0.017877268877849,
+                0.040566083410670,
+                -0.047438192023434,
+                0.028130634522281,
+                0.019450998802247,
+                -0.086907962984950,
+                0.157220576563611,
+                -0.210275430209926,
+                0.230000000000000,
+                -0.210275430209926,
+                0.157220576563611,
+                -0.086907962984950,
+                0.019450998802247,
+                0.028130634522281,
+                -0.047438192023434,
+                0.040566083410670,
+                -0.017877268877849,
+                -0.007061591302535,
+                0.023076863879726,
+                -0.025215481059303,
+                0.015485234438367,
+                -0.000637437587598,
+                -0.011643406975008,
+                0.016278660841859,
+                -0.012577161166323,
+                0.003759912990388,
+                0.005193768023735,
+                -0.010132234027704,
+                0.009497895103678,
+                -0.004593884000360,
+                -0.001525908120121,
+                0.005795137106459,
+                -0.006576810746863,
+                0.004174826882078,
+                -0.000331019542578,
+                -0.002873600914298,
+                0.004076732108724,
+                -0.003144929902063,
+                0.000987622783890,
+                0.001101862089183,
+            ];
+            let filter_taps = highpass(cutoff, transition_bw, max_ripple);
+            assert_eq!(filter_taps.len(), test_taps.len());
+            for i in 0..filter_taps.len() {
+                let tol = 1e-2;
+                assert!(
+                    (filter_taps[i] - test_taps[i]).abs() < tol,
+                    "abs({} - {}) < {} (tap {})",
+                    filter_taps[i],
+                    test_taps[i],
+                    tol,
+                    i
+                );
+            }
+        }
+
+        #[test]
+        fn bandpass_accuracy() {
+            let lower_cutoff = 0.2;
+            let higher_cutoff = 0.4;
+            let transition_bw = 0.05;
+            let max_ripple = 0.02;
+            // Test taps generated using matlab:
+            // ```
+            // c = kaiserord([0.2-0.05, 0.2, 0.4, 0.4+0.05], [0,1,0], [0.02, 0.02, 0.02], 1, 'cell')
+            // taps = fir1(c{:});
+            // ```
+            let test_taps = [
+                -0.008169897601110,
+                -0.000000000000000,
+                0.005286867164625,
+                0.003986474461264,
+                0.011611277126659,
+                -0.022475033526840,
+                -0.000000000000000,
+                -0.013107025925601,
+                0.023114960005114,
+                0.027331727341472,
+                -0.021725636110749,
+                0.000000000000000,
+                -0.075524292813853,
+                0.057280413744404,
+                0.029912678124411,
+                0.063777614141040,
+                0.000000000000000,
+                -0.370383496261635,
+                0.286180488307981,
+                0.286180488307981,
+                -0.370383496261635,
+                0.000000000000000,
+                0.063777614141040,
+                0.029912678124411,
+                0.057280413744404,
+                -0.075524292813853,
+                0.000000000000000,
+                -0.021725636110749,
+                0.027331727341472,
+                0.023114960005114,
+                -0.013107025925601,
+                -0.000000000000000,
+                -0.022475033526840,
+                0.011611277126659,
+                0.003986474461264,
+                0.005286867164625,
+                -0.000000000000000,
+                -0.008169897601110,
+            ];
+            let filter_taps = bandpass(lower_cutoff, higher_cutoff, transition_bw, max_ripple);
+            assert_eq!(filter_taps.len(), test_taps.len());
+            for i in 0..filter_taps.len() {
+                let tol = 1e-2;
+                assert!(
+                    (filter_taps[i] - test_taps[i]).abs() < tol,
+                    "abs({} - {}) < {} (tap {})",
+                    filter_taps[i],
+                    test_taps[i],
+                    tol,
+                    i
+                );
+            }
+        }
+    }
+}

--- a/futuredsp/src/firdes.rs
+++ b/futuredsp/src/firdes.rs
@@ -1,0 +1,134 @@
+//! Methods for designing FIR filters.
+
+extern crate alloc;
+use crate::math::consts;
+use crate::windows::FilterWindow;
+use alloc::vec::Vec;
+
+/// Constructs a lowpass FIR filter with unit gain and cutoff frequency `cutoff` (in cycles/sample)
+/// using the specified window.
+///
+/// Example usage:
+/// ```
+/// use futuredsp::{firdes, windows};
+///
+/// let sampling_freq = 10_000;
+/// // 2000 Hz cutoff frequency, rectangular window
+/// let cutoff = 2_000.0 / sampling_freq as f32;
+/// let num_taps = 65;
+/// let rect_win = windows::RectWindow::new(num_taps);
+/// let taps = firdes::lowpass(num_taps, cutoff, rect_win);
+/// ```
+pub fn lowpass<T: FilterWindow<f32>>(num_taps: usize, cutoff: f32, window: T) -> Vec<f32> {
+    assert!(num_taps > 0, "num_taps must be greater than 0");
+    assert!(
+        cutoff > 0.0 && cutoff < 1.0 / 2.0,
+        "cutoff must be in (0, 1/2)"
+    );
+    let mut taps: Vec<f32> = Vec::with_capacity(num_taps);
+    let omega_c = 2.0 * consts::f32::PI * cutoff;
+    let alpha = (num_taps - 1) as f32 / 2.0;
+    for n in 0..num_taps {
+        let x = n as f32 - alpha;
+        let tap = match x == 0.0 {
+            true => 1.0,
+            false => (omega_c * x).sin() / (consts::f32::PI * x),
+        };
+        taps.push(tap * window.get(n));
+    }
+
+    taps
+}
+
+/// Constructs a highpass FIR filter with unit gain and cutoff frequency `cutoff` (in cycles/sample)
+/// using the specified window.
+/// Note that `num_taps` must be odd, otherwise one tap is added to the generated filter.
+///
+/// Example usage:
+/// ```
+/// use futuredsp::{firdes, windows};
+///
+/// let sampling_freq = 10_000;
+/// // 2000 Hz cutoff frequency, rectangular window
+/// let cutoff = 4_000.0 / sampling_freq as f32;
+/// let num_taps = 65;
+/// let rect_win = windows::RectWindow::new(num_taps);
+/// let taps = firdes::highpass(num_taps, cutoff, rect_win);
+/// ```
+pub fn highpass<T: FilterWindow<f32>>(num_taps: usize, cutoff: f32, window: T) -> Vec<f32> {
+    assert!(num_taps > 0, "num_taps must be greater than 0");
+    assert!(
+        cutoff > 0.0 && cutoff < 1.0 / 2.0,
+        "cutoff must be in (0, 1/2)"
+    );
+    // Number of taps must be odd
+    let num_taps = match num_taps % 2 {
+        0 => {
+            // println!("Warning: num_taps must be odd. Adding one.");
+            num_taps + 1
+        }
+        _ => num_taps,
+    };
+    let mut taps: Vec<f32> = Vec::with_capacity(num_taps);
+    let omega_c = 2.0 * consts::f32::PI * cutoff;
+    let alpha = (num_taps - 1) as f32 / 2.0;
+    for n in 0..num_taps {
+        let x = n as f32 - alpha;
+        let tap = match x == 0.0 {
+            true => 1.0 - omega_c / consts::f32::PI,
+            false => -(omega_c * x).sin() / (consts::f32::PI * x),
+        };
+        taps.push(tap * window.get(n));
+    }
+    taps
+}
+
+/// Constructs a bandpass FIR filter with unit gain and cutoff frequencies
+/// `lower_cutoff` and `higher_cutoff` (in cycles/sample) using the specified window.
+///
+/// Example usage:
+/// ```
+/// use futuredsp::{firdes, windows};
+///
+/// let sampling_freq = 10_000;
+/// // 2000 Hz cutoff frequency, rectangular window
+/// let lower_cutoff = 2_000.0 / sampling_freq as f32;
+/// let higher_cutoff = 4_000.0 / sampling_freq as f32;
+/// let num_taps = 65;
+/// let rect_win = windows::RectWindow::new(num_taps);
+/// let taps = firdes::bandpass(num_taps, lower_cutoff, higher_cutoff, rect_win);
+/// ```
+pub fn bandpass<T: FilterWindow<f32>>(
+    num_taps: usize,
+    lower_cutoff: f32,
+    higher_cutoff: f32,
+    window: T,
+) -> Vec<f32> {
+    assert!(num_taps > 0, "num_taps must be greater than 0");
+    assert!(
+        lower_cutoff > 0.0 && lower_cutoff < 1.0 / 2.0,
+        "lower_cutoff must be in (0, 1/2)"
+    );
+    assert!(
+        higher_cutoff > lower_cutoff && higher_cutoff < 1.0 / 2.0,
+        "higher_cutoff must be in (lower_cutoff, 1/2)"
+    );
+    let mut taps: Vec<f32> = Vec::with_capacity(num_taps);
+    let lower_omega_c = 2.0 * consts::f32::PI * lower_cutoff;
+    let higher_omega_c = 2.0 * consts::f32::PI * higher_cutoff;
+    let omega_passband_bw = higher_omega_c - lower_omega_c;
+    let omega_passband_center = (lower_omega_c + higher_omega_c) / 2.0;
+    let alpha = (num_taps - 1) as f32 / 2.0;
+    for n in 0..num_taps {
+        let x = n as f32 - alpha;
+        let tap = match x == 0.0 {
+            true => omega_passband_bw / consts::f32::PI,
+            false => {
+                2.0 * (omega_passband_center * x).cos() * (omega_passband_bw / 2.0 * x).sin()
+                    / (consts::f32::PI * x)
+            }
+        };
+        taps.push(tap * window.get(n));
+    }
+    taps
+}

--- a/futuredsp/src/lib.rs
+++ b/futuredsp/src/lib.rs
@@ -2,7 +2,10 @@
 #![cfg_attr(not(RUSTC_IS_STABLE), feature(core_intrinsics))]
 
 pub mod fir;
+pub mod firdes;
 pub mod iir;
+pub mod math;
+pub mod windows;
 
 mod tapsaccessor;
 pub use tapsaccessor::TapsAccessor;

--- a/futuredsp/src/math/consts.rs
+++ b/futuredsp/src/math/consts.rs
@@ -1,0 +1,11 @@
+//! Mathematical constants
+
+pub mod f32 {
+    /// π
+    pub const PI: f32 = 3.14159265358979323846264338327950288f32;
+}
+
+pub mod f64 {
+    /// π
+    pub const PI: f64 = 3.14159265358979323846264338327950288f64;
+}

--- a/futuredsp/src/math/mod.rs
+++ b/futuredsp/src/math/mod.rs
@@ -1,3 +1,4 @@
 //! Mathematical constants, functions, etc.
 
 pub mod consts;
+pub mod special_funs;

--- a/futuredsp/src/math/mod.rs
+++ b/futuredsp/src/math/mod.rs
@@ -1,0 +1,3 @@
+//! Mathematical constants, functions, etc.
+
+pub mod consts;

--- a/futuredsp/src/math/special_funs.rs
+++ b/futuredsp/src/math/special_funs.rs
@@ -1,0 +1,123 @@
+//! Implementaions of mathematical special functions.
+
+/// Computes the modified Bessel function of the first kind of order zero evaluated at `x`.
+///
+/// The computation is based on the approximation given in
+/// M. Abramowitz and I. Stegun, Handbook of Mathematical Functions with Formulas, Graphs,
+/// and Mathematical Tables, 1964 (eqs. 9.8.1 and 9.8.2, p. 378).
+///
+/// The absolute approximation error of the underlying approximation is less than
+/// 1.6e-7 for `3.75 <= x <= 3.75` and less than 1.9e-7 for `3.75 <= x < ∞`.
+/// However, the error is usually larger due to the numerical accuracy.
+/// In practice the approximation is also reasonable for `x < -3.75`, but no
+/// bounds are given.
+///
+/// Example usage:
+/// ```
+/// use futuredsp::math::special_funs;
+///
+/// let x = 0.34_f64;
+/// let out = special_funs::besseli0(x);
+/// ```
+pub fn besseli0(x: f64) -> f64 {
+    let t = x / 3.75;
+    if x.abs() <= 3.75 {
+        1.0 + 3.5156229 * t.powi(2)
+            + 3.0899424 * t.powi(4)
+            + 1.2067492 * t.powi(6)
+            + 0.2659732 * t.powi(8)
+            + 0.0360768 * t.powi(10)
+            + 0.0045813 * t.powi(12)
+    } else {
+        if x < -3.75 {
+            // The approximation is not made for this range
+            //warn!("Bessel approximation may be inaccurate for x < -3.75");
+        }
+        (x.abs().sqrt() * (-x).exp()).recip()
+            * (0.39894228 + 0.01328592 * t.powi(-1) + 0.00225319 * t.powi(-2)
+                - 0.00157565 * t.powi(-3)
+                + 0.00916281 * t.powi(-4)
+                - 0.02057706 * t.powi(-5)
+                + 0.02635537 * t.powi(-6)
+                - 0.01647633 * t.powi(-7)
+                + 0.00392377 * t.powi(-8))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn besseli0_accuracy() {
+        // -3.75 <= x <= 3.75
+        let abs_epsilon = 1.6e-7;
+        let rel_epsilon = 1.0e-7;
+        let input_x = [
+            -3.75_f64, -3.0, -2.0, -1.5, -1.0, -0.3, -0.2, -0.1, -0.01, -0.001, 0.0, 0.001, 0.01,
+            0.1, 0.2, 0.3, 1.0, 1.5, 2.0, 3.0, 3.75,
+        ];
+        let test_x = [
+            9.118945860844564_f64,
+            4.880792585865025,
+            2.279585302336067,
+            1.646723189772891,
+            1.266065877752008,
+            1.022626879351597,
+            1.010025027795146,
+            1.002501562934095,
+            1.000025000156250,
+            1.000000250000016,
+            1.000000000000000,
+            1.000000250000016,
+            1.000025000156250,
+            1.002501562934095,
+            1.010025027795146,
+            1.022626879351597,
+            1.266065877752008,
+            1.646723189772891,
+            2.279585302336067,
+            4.880792585865025,
+            9.118945860844564,
+        ]; // Computed using MATLAB besseli()
+        for i in 0..input_x.len() {
+            let tol = abs_epsilon + rel_epsilon * test_x[i].abs();
+            assert!(
+                (besseli0(input_x[i]) - test_x[i]).abs() < tol,
+                "abs({} - {}) < {} (x={})",
+                besseli0(input_x[i]),
+                test_x[i],
+                tol,
+                input_x[i],
+            );
+        }
+        // 3.75 < x < infinity
+        let abs_epsilon = 1.9e-7;
+        let rel_epsilon = 1.0e-7;
+        let input_x = [3.8_f64, 4.0, 4.5, 5.0, 5.5, 6.0, 7.0, 8.0, 9.0, 10.0, 20.0];
+        let test_x = [
+            9.516888026098954_f64,
+            11.301921952136331,
+            17.481171855609279,
+            27.239871823604449,
+            42.694645151847787,
+            67.234406976477985,
+            1.685939085102897e2,
+            4.275641157218048e2,
+            1.093588354511375e3,
+            2.815716628466255e3,
+            4.355828255955355e7,
+        ]; // Computed using MATLAB besseli()
+        for i in 0..input_x.len() {
+            let tol = abs_epsilon + rel_epsilon * test_x[i].abs();
+            assert!(
+                (besseli0(input_x[i]) - test_x[i]).abs() < tol,
+                "abs({} - {}) < {} (x={})",
+                besseli0(input_x[i]),
+                test_x[i],
+                tol,
+                input_x[i],
+            );
+        }
+    }
+}

--- a/futuredsp/src/windows.rs
+++ b/futuredsp/src/windows.rs
@@ -1,6 +1,6 @@
 //! A collection of filter window functions.
 
-use crate::math::special_funs;
+use crate::math::{consts, special_funs};
 
 /// A generic trait for filter window functions.
 pub trait FilterWindow<TapsType> {
@@ -33,6 +33,161 @@ impl FilterWindow<f32> for RectWindow {
             return 0.0;
         }
         1.0
+    }
+}
+
+/// A Bartlett window of a given length.
+///
+/// Example usage:
+/// ```
+/// use futuredsp::windows::{FilterWindow, BartlettWindow};
+///
+/// let window = BartlettWindow::new(38);
+/// let tap0 = window.get(0);
+/// ```
+pub struct BartlettWindow {
+    num_taps: usize,
+}
+
+impl BartlettWindow {
+    /// Create a new Bartlett window with `num_taps` taps.
+    pub fn new(num_taps: usize) -> Self {
+        Self { num_taps }
+    }
+}
+impl FilterWindow<f32> for BartlettWindow {
+    fn get(&self, index: usize) -> f32 {
+        if index >= self.num_taps {
+            return 0.0;
+        }
+        let alpha = (self.num_taps - 1) as f32 / 2.0;
+        match (index as f32) < alpha {
+            true => (index as f32) / alpha,
+            false => 2.0 - (index as f32) / alpha,
+        }
+    }
+}
+
+/// A Blackman window of a given length.
+///
+/// Example usage:
+/// ```
+/// use futuredsp::windows::{FilterWindow, BlackmanWindow};
+///
+/// let window = BlackmanWindow::new(38);
+/// let tap0 = window.get(0);
+/// ```
+pub struct BlackmanWindow {
+    num_taps: usize,
+}
+
+impl BlackmanWindow {
+    /// Create a new Blackman window with `num_taps` taps.
+    pub fn new(num_taps: usize) -> Self {
+        Self { num_taps }
+    }
+}
+impl FilterWindow<f32> for BlackmanWindow {
+    fn get(&self, index: usize) -> f32 {
+        if index >= self.num_taps {
+            return 0.0;
+        }
+        let alpha = (self.num_taps - 1) as f32 / 2.0;
+        0.42 - 0.5 * (consts::f32::PI * (index as f32) / alpha).cos()
+            + 0.08 * (2.0 * consts::f32::PI * (index as f32) / alpha).cos()
+    }
+}
+
+/// A Gaussian window of a given length with width factor `alpha`, which is
+/// inversely proportional to the standard deviation.
+/// Note that sometimes, the width of a Gaussian window is specified in terms of
+/// a parameter that is proportional to the standard deviation (inversely proportional to alpha).
+///
+/// Example usage:
+/// ```
+/// use futuredsp::windows::{FilterWindow, GaussianWindow};
+///
+/// let window = GaussianWindow::new(38, 2.5);
+/// let tap0 = window.get(0);
+/// ```
+pub struct GaussianWindow {
+    num_taps: usize,
+    alpha: f32,
+}
+
+impl GaussianWindow {
+    /// Create a new Blackman window with `num_taps` taps and width factor `alpha`.
+    pub fn new(num_taps: usize, alpha: f32) -> Self {
+        Self { num_taps, alpha }
+    }
+}
+impl FilterWindow<f32> for GaussianWindow {
+    fn get(&self, index: usize) -> f32 {
+        if index >= self.num_taps {
+            return 0.0;
+        }
+        let mid = ((self.num_taps - 1) as f32) / 2.0;
+        let std_dev = mid / self.alpha;
+        let n = index as f32 - mid;
+        (-n.powi(2) / (2.0 * std_dev.powi(2))).exp()
+    }
+}
+
+/// A Hamming window of a given length.
+///
+/// Example usage:
+/// ```
+/// use futuredsp::windows::{FilterWindow, HammingWindow};
+///
+/// let window = HammingWindow::new(38);
+/// let tap0 = window.get(0);
+/// ```
+pub struct HammingWindow {
+    num_taps: usize,
+}
+
+impl HammingWindow {
+    /// Create a new Hamming window with `num_taps` taps.
+    pub fn new(num_taps: usize) -> Self {
+        Self { num_taps }
+    }
+}
+impl FilterWindow<f32> for HammingWindow {
+    fn get(&self, index: usize) -> f32 {
+        if index >= self.num_taps {
+            return 0.0;
+        }
+        let alpha = (self.num_taps - 1) as f32 / 2.0;
+        0.54 - 0.46 * (consts::f32::PI * (index as f32) / alpha).cos()
+    }
+}
+
+/// A Hann window of a given length (sometimes also referred to as Hanning window).
+///
+/// Example usage:
+/// ```
+/// use futuredsp::windows::{FilterWindow, HannWindow};
+///
+/// let window = HannWindow::new(38);
+/// let tap0 = window.get(0);
+/// ```
+pub struct HannWindow {
+    num_taps: usize,
+}
+
+impl HannWindow {
+    /// Create a new Hann window with `num_taps` taps.
+    pub fn new(num_taps: usize) -> Self {
+        Self { num_taps }
+    }
+}
+impl FilterWindow<f32> for HannWindow {
+    fn get(&self, index: usize) -> f32 {
+        if index >= self.num_taps {
+            return 0.0;
+        }
+        let alpha = (self.num_taps - 1) as f32 / 2.0;
+        0.5 * (1.0 - (consts::f32::PI * (index as f32) / alpha).cos())
     }
 }
 
@@ -70,6 +225,292 @@ impl FilterWindow<f32> for KaiserWindow {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn bartlett_accuracy() {
+        let n_taps = 38;
+        let test_taps = [
+            0.000000000000000,
+            0.054054054054054,
+            0.108108108108108,
+            0.162162162162162,
+            0.216216216216216,
+            0.270270270270270,
+            0.324324324324324,
+            0.378378378378378,
+            0.432432432432432,
+            0.486486486486487,
+            0.540540540540541,
+            0.594594594594595,
+            0.648648648648649,
+            0.702702702702703,
+            0.756756756756757,
+            0.810810810810811,
+            0.864864864864865,
+            0.918918918918919,
+            0.972972972972973,
+            0.972972972972973,
+            0.918918918918919,
+            0.864864864864865,
+            0.810810810810811,
+            0.756756756756757,
+            0.702702702702703,
+            0.648648648648649,
+            0.594594594594595,
+            0.540540540540541,
+            0.486486486486487,
+            0.432432432432432,
+            0.378378378378378,
+            0.324324324324324,
+            0.270270270270270,
+            0.216216216216216,
+            0.162162162162162,
+            0.108108108108108,
+            0.054054054054054,
+            0.000000000000000,
+        ]; // Computed using MATLAB bartlett()
+        let window = BartlettWindow::new(n_taps);
+        for i in 0..n_taps {
+            let tol = 1e-5;
+            assert!(
+                (window.get(i) - test_taps[i]).abs() < tol,
+                "abs({} - {}) < {} (tap {})",
+                window.get(i),
+                test_taps[i],
+                tol,
+                i
+            );
+        }
+    }
+
+    #[test]
+    fn blackman_accuracy() {
+        let n_taps = 38;
+        let test_taps = [
+            0.000000000000000,
+            0.002622240463032,
+            0.010804137614933,
+            0.025437526103984,
+            0.047836464440438,
+            0.079501212725209,
+            0.121830058635970,
+            0.175815273593484,
+            0.241762085771086,
+            0.319067599318524,
+            0.406090274118759,
+            0.500130613698768,
+            0.597531218304494,
+            0.693890766450019,
+            0.784373343232954,
+            0.864083342844346,
+            0.928468223065274,
+            0.973707602519644,
+            0.997048017099080,
+            0.997048017099080,
+            0.973707602519644,
+            0.928468223065274,
+            0.864083342844346,
+            0.784373343232954,
+            0.693890766450019,
+            0.597531218304494,
+            0.500130613698768,
+            0.406090274118759,
+            0.319067599318524,
+            0.241762085771086,
+            0.175815273593484,
+            0.121830058635970,
+            0.079501212725209,
+            0.047836464440438,
+            0.025437526103984,
+            0.010804137614933,
+            0.002622240463032,
+            0.000000000000000,
+        ]; // Computed using MATLAB blackman()
+        let window = BlackmanWindow::new(n_taps);
+        for i in 0..n_taps {
+            let tol = 1e-5;
+            assert!(
+                (window.get(i) - test_taps[i]).abs() < tol,
+                "abs({} - {}) < {} (tap {})",
+                window.get(i),
+                test_taps[i],
+                tol,
+                i
+            );
+        }
+    }
+
+    #[test]
+    fn gaussian_accuracy() {
+        let n_taps = 38;
+        let alpha = 2.2;
+        let test_taps = [
+            0.088921617459386,
+            0.114698396715108,
+            0.145869896370133,
+            0.182907845975514,
+            0.226129555908018,
+            0.275638995194989,
+            0.331270161955420,
+            0.392538551605780,
+            0.458606963743581,
+            0.528271654134153,
+            0.599973826254896,
+            0.671839656444629,
+            0.741749563359992,
+            0.807434491048862,
+            0.866593901972413,
+            0.917027361308578,
+            0.956769434838275,
+            0.984216463455208,
+            0.998233847825964,
+            0.998233847825964,
+            0.984216463455208,
+            0.956769434838275,
+            0.917027361308578,
+            0.866593901972413,
+            0.807434491048862,
+            0.741749563359992,
+            0.671839656444629,
+            0.599973826254896,
+            0.528271654134153,
+            0.458606963743581,
+            0.392538551605780,
+            0.331270161955420,
+            0.275638995194989,
+            0.226129555908018,
+            0.182907845975514,
+            0.145869896370133,
+            0.114698396715108,
+            0.088921617459386,
+        ]; // Computed using MATLAB gausswin()
+        let window = GaussianWindow::new(n_taps, alpha);
+        for i in 0..n_taps {
+            let tol = 1e-5;
+            assert!(
+                (window.get(i) - test_taps[i]).abs() < tol,
+                "abs({} - {}) < {} (tap {})",
+                window.get(i),
+                test_taps[i],
+                tol,
+                i
+            );
+        }
+    }
+
+    #[test]
+    fn hamming_accuracy() {
+        let n_taps = 38;
+        let test_taps = [
+            0.080000000000000,
+            0.086616681240054,
+            0.106276375087901,
+            0.138413507945853,
+            0.182103553013518,
+            0.236089627240563,
+            0.298818649563673,
+            0.368486020221058,
+            0.443087535801966,
+            0.520477046529772,
+            0.598428197083564,
+            0.674698474787213,
+            0.747093722616130,
+            0.813531261099972,
+            0.872099803219081,
+            0.921114438652167,
+            0.959165105578543,
+            0.985157155589410,
+            0.998342844729562,
+            0.998342844729562,
+            0.985157155589410,
+            0.959165105578543,
+            0.921114438652167,
+            0.872099803219081,
+            0.813531261099972,
+            0.747093722616130,
+            0.674698474787213,
+            0.598428197083564,
+            0.520477046529772,
+            0.443087535801966,
+            0.368486020221058,
+            0.298818649563673,
+            0.236089627240563,
+            0.182103553013518,
+            0.138413507945853,
+            0.106276375087901,
+            0.086616681240054,
+            0.080000000000000,
+        ]; // Computed using MATLAB hamming()
+        let window = HammingWindow::new(n_taps);
+        for i in 0..n_taps {
+            let tol = 1e-5;
+            assert!(
+                (window.get(i) - test_taps[i]).abs() < tol,
+                "abs({} - {}) < {} (tap {})",
+                window.get(i),
+                test_taps[i],
+                tol,
+                i
+            );
+        }
+    }
+
+    #[test]
+    fn hann_accuracy() {
+        let n_taps = 38;
+        let test_taps = [
+            0.000000000000000,
+            0.007192044826146,
+            0.028561277269458,
+            0.063492943419406,
+            0.110982122840780,
+            0.169662638304959,
+            0.237846358221384,
+            0.313571761109846,
+            0.394660365002137,
+            0.478779398401926,
+            0.563508909873439,
+            0.646411385638275,
+            0.725101872408837,
+            0.797316588152143,
+            0.860978046977262,
+            0.914254824621921,
+            0.955614245194068,
+            0.983866473466749,
+            0.998198744271263,
+            0.998198744271263,
+            0.983866473466749,
+            0.955614245194068,
+            0.914254824621921,
+            0.860978046977262,
+            0.797316588152143,
+            0.725101872408837,
+            0.646411385638275,
+            0.563508909873439,
+            0.478779398401926,
+            0.394660365002137,
+            0.313571761109846,
+            0.237846358221384,
+            0.169662638304959,
+            0.110982122840780,
+            0.063492943419406,
+            0.028561277269458,
+            0.007192044826146,
+            0.000000000000000,
+        ]; // Computed using MATLAB hann()
+        let window = HannWindow::new(n_taps);
+        for i in 0..n_taps {
+            let tol = 1e-5;
+            assert!(
+                (window.get(i) - test_taps[i]).abs() < tol,
+                "abs({} - {}) < {} (tap {})",
+                window.get(i),
+                test_taps[i],
+                tol,
+                i
+            );
+        }
+    }
 
     #[test]
     fn kaiser_accuracy() {

--- a/futuredsp/src/windows.rs
+++ b/futuredsp/src/windows.rs
@@ -1,5 +1,7 @@
 //! A collection of filter window functions.
 
+use crate::math::special_funs;
+
 /// A generic trait for filter window functions.
 pub trait FilterWindow<TapsType> {
     /// Returns the window function at index `index`
@@ -31,5 +33,99 @@ impl FilterWindow<f32> for RectWindow {
             return 0.0;
         }
         1.0
+    }
+}
+
+/// A Kaiser window of a given length and shape parameter.
+///
+/// Example usage:
+/// ```
+/// use futuredsp::windows::{FilterWindow, KaiserWindow};
+///
+/// let window = KaiserWindow::new(38, 0.5);
+/// let tap0 = window.get(0);
+/// ```
+pub struct KaiserWindow {
+    num_taps: usize,
+    beta: f32,
+}
+
+impl KaiserWindow {
+    /// Create a new Kaiser window with `num_taps` taps and shape `beta`.
+    pub fn new(num_taps: usize, beta: f32) -> Self {
+        Self { num_taps, beta }
+    }
+}
+impl FilterWindow<f32> for KaiserWindow {
+    fn get(&self, index: usize) -> f32 {
+        if index >= self.num_taps {
+            return 0.0;
+        }
+        let alpha = (self.num_taps - 1) as f32 / 2.0;
+        let x = self.beta * (1.0 - ((index as f32 - alpha) / alpha).powi(2)).sqrt();
+        (special_funs::besseli0(x as f64) / special_funs::besseli0(self.beta as f64)) as f32
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn kaiser_accuracy() {
+        let beta = 5.653;
+        let n_taps = 38;
+        let test_taps = [
+            0.020392806629217,
+            0.041484435695145,
+            0.070067692203354,
+            0.106749242190360,
+            0.151823492501156,
+            0.205218380642171,
+            0.266458522450125,
+            0.334649288647039,
+            0.408484172820245,
+            0.486276388059038,
+            0.566014081873242,
+            0.645436995269608,
+            0.722130922112194,
+            0.793635055125124,
+            0.857556328958361,
+            0.911684263160396,
+            0.954099618076827,
+            0.983270424870408,
+            0.998129626296050,
+            0.998129626296050,
+            0.983270424870408,
+            0.954099618076827,
+            0.911684263160396,
+            0.857556328958361,
+            0.793635055125124,
+            0.722130922112194,
+            0.645436995269608,
+            0.566014081873242,
+            0.486276388059038,
+            0.408484172820245,
+            0.334649288647039,
+            0.266458522450125,
+            0.205218380642171,
+            0.151823492501156,
+            0.106749242190360,
+            0.070067692203354,
+            0.041484435695145,
+            0.020392806629217,
+        ]; // Computed using MATLAB kaiser()
+        let window = KaiserWindow::new(n_taps, beta);
+        for i in 0..n_taps {
+            let tol = 1e-5;
+            assert!(
+                (window.get(i) - test_taps[i]).abs() < tol,
+                "abs({} - {}) < {} (tap {})",
+                window.get(i),
+                test_taps[i],
+                tol,
+                i
+            );
+        }
     }
 }

--- a/futuredsp/src/windows.rs
+++ b/futuredsp/src/windows.rs
@@ -1,0 +1,35 @@
+//! A collection of filter window functions.
+
+/// A generic trait for filter window functions.
+pub trait FilterWindow<TapsType> {
+    /// Returns the window function at index `index`
+    fn get(&self, index: usize) -> TapsType;
+}
+
+/// A rectangular window of a given length.
+///
+/// Example usage:
+/// ```
+/// use futuredsp::windows::{FilterWindow, RectWindow};
+///
+/// let window = RectWindow::new(64);
+/// let tap0 = window.get(0);
+/// ```
+pub struct RectWindow {
+    num_taps: usize,
+}
+
+impl RectWindow {
+    /// Create a new rectangular window with `num_taps` taps.
+    pub fn new(num_taps: usize) -> Self {
+        Self { num_taps }
+    }
+}
+impl FilterWindow<f32> for RectWindow {
+    fn get(&self, index: usize) -> f32 {
+        if index >= self.num_taps {
+            return 0.0;
+        }
+        1.0
+    }
+}


### PR DESCRIPTION
This implements basic window-based methods for designing FIR lowpass, highpass and bandpass filters.

The functionality is contained in the following modules:
- `futuredsp::windows`: Contains a generic `FilterWindow` trait and a number of commonly used window functions.
- `futuredsp::firdes`: Contains general lowpass, highpass, and bandpass filter design methods based on the window method.
- `futuredsp::firdes::kaiser`: Contains methods for generating lowpass, highpass, and bandpass filters by specifying cutoff frequencies, transition bandwidths, and maximum ripple. The design is based on the Kaiser method.
- `futuredsp::math::consts`: Replacement for `std::f32::consts` and `std::f64::consts`. So far only used for pi.
- `futuredsp::math::special_funs`: Special functions. So far includes an approximation of the modified Bessel function of the first kind of order zero. The approximation appears to be the same as the one used in GNU Radio.

An example is provided in `examples/firdes`.

Feel free to propose changes to this structure.

The implementations of the various functions have been tested against Matlab methods for a few test cases. I have left a test case for most of the functions in the code.

I am missing the possibility to print warnings in a couple of places. I have left a couple of commented `println!()` where it would be useful. I guess the best way to resolve these issues is to fix #32 and include it in `futuredsp`.