### PR TITLE
Firdes refactoring

### DIFF
--- a/examples/firdes/src/main.rs
+++ b/examples/firdes/src/main.rs
@@ -26,9 +26,9 @@ fn main() -> Result<()> {
     });
 
     // Design bandpass filter for the middle tone
-    let lower_cutoff = (TONE_FREQ.1 - 200.0) / SAMPLING_FREQ as f32;
-    let higher_cutoff = (TONE_FREQ.1 + 200.0) / SAMPLING_FREQ as f32;
-    let transition_bw = 500.0 / SAMPLING_FREQ as f32;
+    let lower_cutoff = (TONE_FREQ.1 - 200.0) as f64 / SAMPLING_FREQ as f64;
+    let higher_cutoff = (TONE_FREQ.1 + 200.0) as f64 / SAMPLING_FREQ as f64;
+    let transition_bw = 500.0 / SAMPLING_FREQ as f64;
     let max_ripple = 0.01;
 
     let filter_taps =
@@ -36,7 +36,9 @@ fn main() -> Result<()> {
     println!("Filter has {} taps", filter_taps.len());
 
     let filter_block = match enable_filter {
-        true => FirBuilder::new::<f32, f32, _>(filter_taps),
+        true => FirBuilder::new::<f32, f32, _>(
+            filter_taps.iter().map(|&x| x as f32).collect::<Vec<_>>(),
+        ),
         _ => FirBuilder::new::<f32, f32, _>([1.0_f32]),
     };
 

--- a/examples/firdes/src/main.rs
+++ b/examples/firdes/src/main.rs
@@ -32,13 +32,11 @@ fn main() -> Result<()> {
     let max_ripple = 0.01;
 
     let filter_taps =
-        firdes::kaiser::bandpass(lower_cutoff, higher_cutoff, transition_bw, max_ripple);
+        firdes::kaiser::bandpass::<f32>(lower_cutoff, higher_cutoff, transition_bw, max_ripple);
     println!("Filter has {} taps", filter_taps.len());
 
     let filter_block = match enable_filter {
-        true => FirBuilder::new::<f32, f32, _>(
-            filter_taps.iter().map(|&x| x as f32).collect::<Vec<_>>(),
-        ),
+        true => FirBuilder::new::<f32, f32, _>(filter_taps),
         _ => FirBuilder::new::<f32, f32, _>([1.0_f32]),
     };
 

--- a/futuredsp/Cargo.toml
+++ b/futuredsp/Cargo.toml
@@ -13,6 +13,7 @@ categories = ["asynchronous", "concurrency", "hardware-support", "science", "was
 
 [dependencies]
 num-complex = "0.4.0"
+num-traits = "0.2"
 log = "0.4"
 
 [build-dependencies]

--- a/futuredsp/src/firdes.rs
+++ b/futuredsp/src/firdes.rs
@@ -33,7 +33,7 @@ pub fn lowpass<T: FromPrimitive>(cutoff: f64, window: &[f64]) -> Vec<T> {
         .map(|(n, tap)| {
             let x = n as f64 - alpha;
             let filter_tap = match x == 0.0 {
-                true => 1.0,
+                true => omega_c / core::f64::consts::PI,
                 false => (omega_c * x).sin() / (core::f64::consts::PI * x),
             };
             tap * filter_tap

--- a/futuredsp/src/lib.rs
+++ b/futuredsp/src/lib.rs
@@ -4,6 +4,9 @@
 #[macro_use]
 pub extern crate log;
 
+#[macro_use]
+extern crate alloc;
+
 pub mod fir;
 pub mod firdes;
 pub mod iir;

--- a/futuredsp/src/math/special_funs.rs
+++ b/futuredsp/src/math/special_funs.rs
@@ -31,7 +31,7 @@ pub fn besseli0(x: f64) -> f64 {
     } else {
         if x < -3.75 {
             // The approximation is not made for this range
-            //warn!("Bessel approximation may be inaccurate for x < -3.75");
+            warn!("Bessel approximation may be inaccurate for x < -3.75");
         }
         (x.abs().sqrt() * (-x).exp()).recip()
             * (0.39894228 + 0.01328592 * t.powi(-1) + 0.00225319 * t.powi(-2)


### PR DESCRIPTION
This includes a few proposed changes to `firdes` and related modules:

- Window functions no longer use the `FilterWindow` trait, but directly returns the window as `Vec<f64>`. The use of `FilterWindow` trait seemed unnecessary, added a tight dependency between modules, and complicated the use of e.g., simd.

- Several of the window functions now includes a `periodic` argument that specifies whether the window should be constructed to be periodic. This is useful for spectral analysis (e.g., used in radar).

-  `firdes` now supports generic numeric types using the `num_traits::FromPrimitive` trait. This includes of course `f32` and `f64`, but can also be used for e.g., fixed-point numbers. Basically, everything is computed with `f64`, and then converted to the desired type before returning the filter taps.

- `firdes` now also includes a RRC filter.

In principle, the `num_traits::FromPrimitive` could also be used for the window functions, but I do not see the immediate benefit at the moment. It can be implemented later if needed.