### PR TITLE
Fix fir filter convolution

### DIFF
--- a/futuredsp/src/fir.rs
+++ b/futuredsp/src/fir.rs
@@ -68,7 +68,11 @@ where
         for k in 0..n {
             let mut sum = init();
             for t in 0..taps.num_taps() {
-                sum = mac(sum, *i.get_unchecked(k + t), taps.get(t));
+                sum = mac(
+                    sum,
+                    *i.get_unchecked(k + t),
+                    taps.get(taps.num_taps() - 1 - t),
+                );
             }
             *o.get_unchecked_mut(k) = sum;
         }
@@ -165,7 +169,7 @@ mod tests {
             kernel.work(&input, &mut output),
             (1, 1, ComputationStatus::InsufficientInput)
         );
-        assert_eq!(output[0], 14.0);
+        assert_eq!(output[0], 10.0);
 
         let mut output = [];
         assert_eq!(
@@ -178,7 +182,7 @@ mod tests {
             kernel.work(&input, &mut output),
             (1, 1, ComputationStatus::InsufficientInput)
         );
-        assert_eq!(output[0], 14.0);
+        assert_eq!(output[0], 10.0);
 
         let input = [1.0, 2.0, 3.0, 4.0, 5.0];
         let mut output = [0.0; 2];
@@ -186,8 +190,8 @@ mod tests {
             kernel.work(&input, &mut output),
             (2, 2, ComputationStatus::InsufficientOutput)
         );
-        assert_eq!(output[0], 14.0);
-        assert_eq!(output[1], 20.0);
+        assert_eq!(output[0], 10.0);
+        assert_eq!(output[1], 16.0);
     }
 
     /// Tests the "terminating condition" where the input is finished and the


### PR DESCRIPTION
The current FIR filter implementation does not reverse the filter taps before performing the convolution, leading to a correlation operation rather than convolution. This pull request fixes the problem.

For instance, passing a signal `[1.0, 2.0, 3.0, 4.0, 5.0, 6.0]` through a filter with impulse response `[1.0, 2.0]` should produce `[4.0, 7.0, 10.0, 13.0, 16.0]`, but the current implementation produces `[5.0, 8.0, 11.0, 14.0, 17.0]`.

It can be verified with the following example:
```rust
use futuresdr::anyhow::{Context, Result};
use futuresdr::blocks::FirBuilder;
use futuresdr::blocks::VectorSink;
use futuresdr::blocks::VectorSinkBuilder;
use futuresdr::blocks::VectorSourceBuilder;
use futuresdr::runtime::Flowgraph;
use futuresdr::runtime::Runtime;

fn main() -> Result<()> {
    let mut fg = Flowgraph::new();

    let input = vec![1.0_f32, 2.0, 3.0, 4.0, 5.0, 6.0];
    let src = fg.add_block(VectorSourceBuilder::new(input.clone()).build());
    let filter = fg.add_block(FirBuilder::new::<f32, f32, _>([1.0, 2.0]));
    let snk = fg.add_block(
        VectorSinkBuilder::<f32>::new()
            .init_capacity(input.len())
            .build(),
    );

    fg.connect_stream(src, "out", filter, "in")?;
    fg.connect_stream(filter, "out", snk, "in")?;

    fg = Runtime::new().run(fg)?;

    let snk = fg
        .kernel::<VectorSink<f32>>(snk)
        .context("block not found")?;
    let v = snk.items();
    println!("{:?}", v);

    Ok(())
}
```