### PR TITLE
Add polyphase rational resampler

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -102,6 +102,8 @@ futuresdr-pmt = { path = "pmt", version = "0.0.3" }
 log = { version = "0.4", features = ["std", "max_level_debug", "release_max_level_info"] }
 lttng-ust = { version = "0.1.0", optional = true}
 num-complex = "0.4.0"
+num-traits = "0.2"
+num-integer = "0.1"
 num_cpus = "1.13.0"
 once_cell = "1.5.2"
 rand = "0.8.0"

--- a/examples/firdes/src/main.rs
+++ b/examples/firdes/src/main.rs
@@ -10,7 +10,7 @@ use futuresdr::anyhow::Result;
 fn main() -> Result<()> {
     let mut fg = Flowgraph::new();
 
-    const SAMPLING_FREQ: u32 = 44_100;
+    const SAMPLING_FREQ: u32 = 66_150;
     const TONE_FREQ: (f32, f32, f32) = (2000.0, 6000.0, 10000.0);
     let enable_filter = true;
 
@@ -25,10 +25,16 @@ fn main() -> Result<()> {
         (2.0 * std::f32::consts::PI * t as f32 * freq / SAMPLING_FREQ as f32).sin()
     });
 
+    // Resample to 44.100 kHz (downsample by a factor of 2/3)
+    let interp = 2;
+    let decim = 3;
+    const DOWNSAMPLED_FREQ: u32 = 44_100;
+    let resamp_block = FirBuilder::new_resampling::<f32>(interp, decim);
+
     // Design bandpass filter for the middle tone
-    let lower_cutoff = (TONE_FREQ.1 - 200.0) as f64 / SAMPLING_FREQ as f64;
-    let higher_cutoff = (TONE_FREQ.1 + 200.0) as f64 / SAMPLING_FREQ as f64;
-    let transition_bw = 500.0 / SAMPLING_FREQ as f64;
+    let lower_cutoff = (TONE_FREQ.1 - 200.0) as f64 / DOWNSAMPLED_FREQ as f64;
+    let higher_cutoff = (TONE_FREQ.1 + 200.0) as f64 / DOWNSAMPLED_FREQ as f64;
+    let transition_bw = 500.0 / DOWNSAMPLED_FREQ as f64;
     let max_ripple = 0.01;
 
     let filter_taps =
@@ -40,13 +46,15 @@ fn main() -> Result<()> {
         _ => FirBuilder::new::<f32, f32, _>([1.0_f32]),
     };
 
-    let snk = AudioSink::new(SAMPLING_FREQ, 1);
+    let snk = AudioSink::new(DOWNSAMPLED_FREQ, 1);
 
     let src = fg.add_block(src);
+    let resamp_block = fg.add_block(resamp_block);
     let filter_block = fg.add_block(filter_block);
     let snk = fg.add_block(snk);
 
-    fg.connect_stream(src, "out", filter_block, "in")?;
+    fg.connect_stream(src, "out", resamp_block, "in")?;
+    fg.connect_stream(resamp_block, "out", filter_block, "in")?;
     fg.connect_stream(filter_block, "out", snk, "in")?;
 
     Runtime::new().run(fg)?;

--- a/examples/fm-receiver/Cargo.toml
+++ b/examples/fm-receiver/Cargo.toml
@@ -5,3 +5,4 @@ edition = "2021"
 
 [dependencies]
 futuresdr = { path = "../..", features=["soapy", "audio"] }
+futuredsp = { path = "../../futuredsp", version = "0.0.3" }

--- a/futuredsp/src/fir.rs
+++ b/futuredsp/src/fir.rs
@@ -151,6 +151,153 @@ impl<TapsType: TapsAccessor<TapType = f32>> UnaryKernel<Complex<f32>>
     }
 }
 
+/// A rational resampling polyphase FIR filter. For every input value, this filter
+/// produces `interp/decim` output samples. The length of `taps` must be divisible by `interp`.
+/// For the best performance, `interp` and `decim` should be relatively prime.
+///
+/// If `decim=1`, then the filter is a pure interpolator. If `interp=1`, then the filter
+/// is a pure decimator.
+///
+/// The specified FIR filter `H(z)` is split into `interp` polyphase components
+/// `E_0(z), E_1(z), ..., E_(interp-1)(z)`, such that
+/// `H(z) = E_0(z^interp) + z^(-1)E_1(z^interp) + ... + z^(-(interp-1))E_(interp-1)(z^interp)`
+/// The taps for each polyphase component are given by `e_l(n) = h(l*n+l)` for `0 <= l <= interp-1`.
+///
+/// Implementations of this core exist for the following combinations:
+/// - `f32` samples, `f32` taps.
+/// - `Complex<f32>` samples, `f32` taps.
+///
+/// Example usage:
+/// ```
+/// use futuredsp::UnaryKernel;
+/// use futuredsp::fir::PolyphaseResamplingFirKernel;
+///
+/// let decim = 2;
+/// let interp = 3;
+/// let taps = [1.0, 2.0, 3.0, 4.0, 5.0, 6.0];
+/// let fir = PolyphaseResamplingFirKernel::<f32, _>::new(interp, decim, taps);
+///
+/// let input = [1.0, 2.0, 3.0];
+/// let mut output = [0.0; 3];
+/// fir.work(&input, &mut output);
+/// ```
+pub struct PolyphaseResamplingFirKernel<SampleType, TapsType: TapsAccessor> {
+    interp: usize,
+    decim: usize,
+    taps: TapsType,
+    _sampletype: core::marker::PhantomData<SampleType>,
+}
+
+impl<SampleType, TapsType: TapsAccessor> PolyphaseResamplingFirKernel<SampleType, TapsType> {
+    /// Create a new resampling FIR filter using the given filter bank taps.
+    pub fn new(interp: usize, decim: usize, taps: TapsType) -> Self {
+        // Ensure number of taps is divisible by interp
+        assert!(taps.num_taps() % interp == 0);
+        Self {
+            interp,
+            decim,
+            taps,
+            _sampletype: core::marker::PhantomData,
+        }
+    }
+}
+
+/// Internal helper function to abstract away everything but the core computation.
+/// Note that this function gets heavily inlined, so there is no (runtime) performance
+/// overhead.
+fn resampling_fir_kernel_core<
+    SampleType,
+    TapsType: TapsAccessor,
+    InitFn: Fn() -> SampleType,
+    MacFn: Fn(SampleType, SampleType, TapsType::TapType) -> SampleType,
+>(
+    interp: usize,
+    decim: usize,
+    taps: &TapsType,
+    i: &[SampleType],
+    o: &mut [SampleType],
+    init: InitFn,
+    mac: MacFn,
+) -> (usize, usize, ComputationStatus)
+where
+    SampleType: Copy,
+    TapsType::TapType: Copy,
+{
+    // Assume same number of taps in all filters
+    let num_taps = taps.num_taps() / interp;
+    let num_producable_samples =
+        ((i.len() + 1).saturating_sub(num_taps) * interp).saturating_sub(1) / decim;
+    // Ensure it is divisible by interpolation factor to avoid keeping track of state
+    let num_producable_samples = (num_producable_samples / interp) * interp;
+    let (num_producable_samples, status) = match num_producable_samples.cmp(&o.len()) {
+        Ordering::Greater => (
+            (o.len() / interp) * interp,
+            ComputationStatus::InsufficientOutput,
+        ),
+        Ordering::Equal => (num_producable_samples, ComputationStatus::BothSufficient),
+        Ordering::Less => (num_producable_samples, ComputationStatus::InsufficientInput),
+    };
+    // Compute number of input samples to consume
+    //let n = num_producable_samples.saturating_sub(1) * decim / interp + 1;
+    let n = (num_producable_samples / interp) * decim;
+
+    unsafe {
+        for k in 0..num_producable_samples {
+            let bank_idx = (k * decim) % interp;
+            let input_idx = k * decim / interp;
+            let mut sum = init();
+            for t in 0..num_taps {
+                let tap_idx = interp * (num_taps - t - 1) + bank_idx;
+                sum = mac(sum, *i.get_unchecked(input_idx + t), taps.get(tap_idx));
+            }
+            *o.get_unchecked_mut(k) = sum;
+        }
+    }
+    // Assert state is 0 so that we do not need to keep track of the state
+    debug_assert!(((num_producable_samples * decim) % interp) == 0);
+
+    (n, num_producable_samples, status)
+}
+
+impl<TapsType: TapsAccessor<TapType = f32>> UnaryKernel<f32>
+    for PolyphaseResamplingFirKernel<f32, TapsType>
+{
+    fn work(&self, i: &[f32], o: &mut [f32]) -> (usize, usize, ComputationStatus) {
+        resampling_fir_kernel_core(
+            self.interp,
+            self.decim,
+            &self.taps,
+            i,
+            o,
+            || 0.0,
+            |accum, sample, tap| accum + sample * tap,
+        )
+    }
+}
+
+impl<TapsType: TapsAccessor<TapType = f32>> UnaryKernel<Complex<f32>>
+    for PolyphaseResamplingFirKernel<Complex<f32>, TapsType>
+{
+    fn work(
+        &self,
+        i: &[Complex<f32>],
+        o: &mut [Complex<f32>],
+    ) -> (usize, usize, ComputationStatus) {
+        resampling_fir_kernel_core(
+            self.interp,
+            self.decim,
+            &self.taps,
+            i,
+            o,
+            || Complex { re: 0.0, im: 0.0 },
+            |accum, sample, tap| Complex {
+                re: accum.re + sample.re * tap,
+                im: accum.im + sample.im * tap,
+            },
+        )
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -213,5 +360,94 @@ mod tests {
             kernel.work(&input, &mut output),
             (3, 3, ComputationStatus::BothSufficient)
         );
+    }
+
+    #[test]
+    fn direct_resampling_fir_kernel() {
+        let interp = 3;
+        let decim = 2;
+        let taps = [1.0, 2.0, 3.0, 4.0, 5.0, 6.0];
+        let kernel = PolyphaseResamplingFirKernel::new(interp, decim, taps);
+        let input = [1.0, 2.0, 3.0, 4.0, 5.0];
+        let mut output = [0.0; 8];
+        assert_eq!(
+            kernel.work(&input, &mut output),
+            (2, 3, ComputationStatus::InsufficientInput)
+        );
+        assert_eq!(output[0], 6.0);
+        assert_eq!(output[1], 12.0);
+        assert_eq!(output[2], 16.0);
+
+        let mut output = [];
+        assert_eq!(
+            kernel.work(&input, &mut output),
+            (0, 0, ComputationStatus::InsufficientOutput)
+        );
+
+        let mut output = [0.0; 3];
+        assert_eq!(
+            kernel.work(&input, &mut output),
+            (2, 3, ComputationStatus::BothSufficient)
+        );
+        assert_eq!(output[0], 6.0);
+        assert_eq!(output[1], 12.0);
+        assert_eq!(output[2], 16.0);
+
+        // With 3 input samples and 3 out, we've exactly filled the output
+        let input = [1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0];
+        let mut output = [0.0; 3];
+        assert_eq!(
+            kernel.work(&input, &mut output),
+            (2, 3, ComputationStatus::InsufficientOutput)
+        );
+        assert_eq!(output[0], 6.0);
+        assert_eq!(output[1], 12.0);
+        assert_eq!(output[2], 16.0);
+        let input = &input[2..input.len()];
+        assert_eq!(
+            kernel.work(&input, &mut output),
+            (2, 3, ComputationStatus::InsufficientOutput)
+        );
+        assert_eq!(output[0], 16.0);
+        assert_eq!(output[1], 30.0);
+        assert_eq!(output[2], 30.0);
+        let input = &input[2..input.len()];
+        assert_eq!(
+            kernel.work(&input, &mut output),
+            (2, 3, ComputationStatus::BothSufficient)
+        );
+        assert_eq!(output[0], 26.0);
+        assert_eq!(output[1], 48.0);
+        assert_eq!(output[2], 44.0);
+
+        let interp = 2;
+        let decim = 1;
+        let taps = [1.0, 2.0];
+        let kernel = PolyphaseResamplingFirKernel::new(interp, decim, taps);
+        let input = [1.0, 2.0, 3.0, 4.0];
+        let mut output = [0.0; 10];
+        assert_eq!(
+            kernel.work(&input, &mut output),
+            (3, 6, ComputationStatus::InsufficientInput)
+        );
+        assert_eq!(output[0], 1.0);
+        assert_eq!(output[1], 2.0);
+        assert_eq!(output[2], 2.0);
+        assert_eq!(output[3], 4.0);
+        assert_eq!(output[4], 3.0);
+        assert_eq!(output[5], 6.0);
+
+        let interp = 1;
+        let decim = 3;
+        let taps = [1.0, 2.0];
+        let kernel = PolyphaseResamplingFirKernel::new(interp, decim, taps);
+        let input = [1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0];
+        let mut output = [0.0; 8];
+        assert_eq!(
+            kernel.work(&input, &mut output),
+            (6, 2, ComputationStatus::InsufficientInput)
+        );
+        assert_eq!(output[0], 4.0);
+        assert_eq!(output[1], 13.0);
     }
 }

--- a/futuredsp/src/fir.rs
+++ b/futuredsp/src/fir.rs
@@ -405,7 +405,7 @@ mod tests {
         assert_eq!(output[2], 16.0);
         let input = &input[2..input.len()];
         assert_eq!(
-            kernel.work(&input, &mut output),
+            kernel.work(input, &mut output),
             (2, 3, ComputationStatus::InsufficientOutput)
         );
         assert_eq!(output[0], 16.0);
@@ -413,7 +413,7 @@ mod tests {
         assert_eq!(output[2], 30.0);
         let input = &input[2..input.len()];
         assert_eq!(
-            kernel.work(&input, &mut output),
+            kernel.work(input, &mut output),
             (2, 3, ComputationStatus::BothSufficient)
         );
         assert_eq!(output[0], 26.0);

--- a/futuredsp/src/firdes.rs
+++ b/futuredsp/src/firdes.rs
@@ -378,12 +378,11 @@ pub mod kaiser {
     fn compute_kaiser_beta(max_ripple: f64) -> f64 {
         // Determine Kaiser window parameters
         let ripple_db = -20.0 * max_ripple.log10();
-        let beta = match ripple_db {
+        match ripple_db {
             x if x > 50.0 => 0.1102 * (x - 8.7),
             x if x >= 21.0 => 0.5842 * (x - 21.0).powf(0.4) + 0.07886 * (x - 21.0),
             _ => 0.0,
-        };
-        beta
+        }
     }
 
     fn design_kaiser_window(transition_bw: f64, max_ripple: f64) -> (usize, f64) {

--- a/src/blocks/mod.rs
+++ b/src/blocks/mod.rs
@@ -9,7 +9,7 @@
 //! ## DSP blocks
 //! | Block | Usage | WebAssembly? |
 //! |---|---|---|
-//! | [fir](FirBuilder) | Generic FIR filter | ✅ |
+//! | [fir](FirBuilder) | Generic FIR filter, resampler | ✅ |
 //! | [fft](FftBuilder) | Computes FFT | ✅ |
 //!
 //! ## Limiting blocks


### PR DESCRIPTION
This pull request adds a polyphase implementation of a FIR rational resampler.

Specifically, it adds a `PolyphaseResamplingFirKernel` to `futuredsp::fir`, which implements a simple, stateless polyphase interpolator/decimator.

The following function in `futuredsp::firdes::kaiser` is provided to design Nyquist interpolation/decimation filters (similar to `designMultirateFIR` in Matlab):
```rust
pub fn multirate<T: FromPrimitive>(
        interp: usize,
        decim: usize,
        half_polyphase_len: usize,
        max_ripple: f64,
    ) -> Vec<T>
```

In addition, two functions are provided in `futuresdr::blocks::FirBuilder` to construct resampling blocks:
```rust
pub fn new_resampling<SampleType>(interp: usize, decim: usize) -> Block
```
which creates a interpolation/decimation filter using some standard parameters, and
```rust
    pub fn new_resampling_with_taps<SampleType, TapType, Taps>(
        interp: usize,
        decim: usize,
        taps: Taps,
    ) -> Block
```

Example usage can be found in `examples/firdes`.
I also have a working modification of `examples/fm-receiver` that uses the resampler decimate the high sampling rate before demodulation. Should we include that as well?