### PR TITLE
ci: add clippy lints for `wasm32-unknown-unknown` target

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,7 @@ jobs:
           toolchain: nightly
           override: true
           components: rustfmt, clippy
+          target: wasm32-unknown-unknown
 
       - name: Install ZeroMQ
         run: sudo apt-get install -y libzmq3-dev
@@ -182,6 +183,12 @@ jobs:
           command: clippy
           args: --all-targets --workspace --features=vulkan,zeromq,audio,flow_scheduler,tpb_scheduler,soapy,lttng,zynq,wgpu -- -D warnings
 
+      - name: Run cargo clippy for wasm32-unknown-unknown (main)
+        uses: actions-rs/cargo@v1
+        with:
+          command: clippy
+          args: --lib --workspace --features=vulkan,zeromq,audio,flow_scheduler,tpb_scheduler,soapy,lttng,zynq,wgpu --target wasm32-unknown-unknown -- -D warnings
+
       - name: Run cargo clippy (perf/buffer_rand)
         uses: actions-rs/cargo@v1
         with:
@@ -236,6 +243,12 @@ jobs:
           command: clippy
           args: --all-targets --manifest-path=perf/wgpu/Cargo.toml -- -D warnings
 
+      - name: Run cargo clippy for wasm32-unknown-unknown (perf/wgpu)
+        uses: actions-rs/cargo@v1
+        with:
+          command: clippy
+          args: --lib --manifest-path=perf/wgpu/Cargo.toml --target wasm32-unknown-unknown -- -D warnings
+
       - name: Run cargo clippy (perf/zynq)
         uses: actions-rs/cargo@v1
         with:
@@ -265,6 +278,12 @@ jobs:
         with:
           command: clippy
           args: --all-targets --manifest-path=examples/cw/Cargo.toml -- -D warnings
+
+      - name: Run cargo clippy for wasm32-unknown-unknown (examples/cw)
+        uses: actions-rs/cargo@v1
+        with:
+          command: clippy
+          args: --lib --manifest-path=examples/cw/Cargo.toml --target wasm32-unknown-unknown -- -D warnings
 
       - name: Run cargo clippy (examples/firdes)
         uses: actions-rs/cargo@v1
@@ -296,17 +315,41 @@ jobs:
           command: clippy
           args: --all-targets --manifest-path=examples/spectrum/Cargo.toml -- -D warnings
 
+      - name: Run cargo clippy for wasm32-unknown-unknown (examples/spectrum)
+        uses: actions-rs/cargo@v1
+        env:
+          RUSTFLAGS: '-C target-cpu=generic --cfg=web_sys_unstable_apis'
+        with:
+          command: clippy
+          args: --lib --manifest-path=examples/spectrum/Cargo.toml --target wasm32-unknown-unknown -- -D warnings
+
       - name: Run cargo clippy (examples/wasm)
         uses: actions-rs/cargo@v1
         with:
           command: clippy
           args: --all-targets --manifest-path=examples/wasm/Cargo.toml -- -D warnings
 
+      - name: Run cargo clippy for wasm32-unknown-unknown (examples/wasm)
+        uses: actions-rs/cargo@v1
+        env:
+          RUSTFLAGS: '-C target-cpu=generic'
+        with:
+          command: clippy
+          args: --lib --manifest-path=examples/wasm/Cargo.toml --target wasm32-unknown-unknown -- -D warnings
+
       - name: Run cargo clippy (examples/wgpu)
         uses: actions-rs/cargo@v1
         with:
           command: clippy
           args: --all-targets --manifest-path=examples/wgpu/Cargo.toml -- -D warnings
+
+      - name: Run cargo clippy for wasm32-unknown-unknown (examples/wgpu)
+        uses: actions-rs/cargo@v1
+        env:
+          RUSTFLAGS: '-C target-cpu=generic --cfg=web_sys_unstable_apis'
+        with:
+          command: clippy
+          args: --lib --manifest-path=examples/wgpu/Cargo.toml --target wasm32-unknown-unknown -- -D warnings
 
       - name: Run cargo clippy (examples/zeromq)
         uses: actions-rs/cargo@v1
@@ -319,6 +362,20 @@ jobs:
         with:
           command: clippy
           args: --all-targets --manifest-path=examples/zigbee/Cargo.toml -- -D warnings
+
+      - name: Run cargo clippy for wasm32-unknown-unknown (examples/zigbee)
+        uses: actions-rs/cargo@v1
+        with:
+          command: clippy
+          args: --lib --manifest-path=examples/zigbee/Cargo.toml --target wasm32-unknown-unknown -- -D warnings
+
+      - name: Run cargo clippy for wasm32-unknown-unknown (frontend)
+        uses: actions-rs/cargo@v1
+        env:
+          RUSTFLAGS: '-C target-cpu=generic'
+        with:
+          command: clippy
+          args: --lib --manifest-path=frontend/Cargo.toml --target wasm32-unknown-unknown -- -D warnings
 
   test-linux:
     name: Unit Tests Linux


### PR DESCRIPTION
Hi,

this PR adds clippy lints for the WASM parts of the project to the CI workflow (partly addressing https://github.com/FutureSDR/FutureSDR/issues/56). 

I'm not sure what features should be enabled for the `Run cargo clippy for wasm32-unknown-unknown (main)` job.