### PR TITLE
runtime:   do not return error on terminate msg

### DIFF
--- a/src/blocks/bad_block.rs
+++ b/src/blocks/bad_block.rs
@@ -1,0 +1,91 @@
+use std::{cmp, marker::PhantomData, ptr};
+
+use crate::{
+    anyhow::{bail, Result},
+    runtime::{
+        Block, BlockMeta, BlockMetaBuilder, Kernel, MessageIo, MessageIoBuilder, StreamIo,
+        StreamIoBuilder, WorkIo,
+    },
+};
+
+pub enum FailType {
+    Panic,
+    Error,
+}
+
+/// Intentionally generate errors to test the runtime.
+#[derive(Default)]
+pub struct BadBlock<T> {
+    pub work_fail: Option<FailType>,
+    pub drop_fail: Option<FailType>,
+    _phantom: PhantomData<T>,
+}
+
+impl<T: Clone + std::fmt::Debug + Send + Sync + 'static> BadBlock<T> {
+    pub fn to_block(self) -> Block {
+        Block::new(
+            BlockMetaBuilder::new("BadBlock").build(),
+            StreamIoBuilder::new()
+                .add_input::<T>("in")
+                .add_output::<T>("out")
+                .build(),
+            MessageIoBuilder::<Self>::new().build(),
+            self,
+        )
+    }
+}
+
+#[doc(hidden)]
+#[async_trait]
+impl<T: Clone + std::fmt::Debug + Send + Sync + 'static> Kernel for BadBlock<T> {
+    async fn work(
+        &mut self,
+        io: &mut WorkIo,
+        sio: &mut StreamIo,
+        _mio: &mut MessageIo<Self>,
+        meta: &mut BlockMeta,
+    ) -> Result<()> {
+        match self.work_fail {
+            Some(FailType::Panic) => {
+                debug!("BadBlock::work() {:?} : panic", meta.instance_name());
+                panic!("BadBlock!");
+            }
+            Some(FailType::Error) => {
+                debug!("BadBlock! {:?} work(): Err", meta.instance_name());
+                bail!("BadBlock!");
+            }
+            _ => {}
+        }
+
+        // The rest is from the copy block
+        let i = sio.input(0).slice_unchecked::<u8>();
+        let o = sio.output(0).slice_unchecked::<u8>();
+        let item_size = std::mem::size_of::<T>();
+
+        let m = cmp::min(i.len(), o.len());
+        if m > 0 {
+            unsafe {
+                ptr::copy_nonoverlapping(i.as_ptr(), o.as_mut_ptr(), m);
+            }
+
+            sio.input(0).consume(m / item_size);
+            sio.output(0).produce(m / item_size);
+        }
+
+        if sio.input(0).finished() && m == i.len() {
+            io.finished = true;
+        }
+
+        Ok(())
+    }
+}
+
+impl<T> Drop for BadBlock<T> {
+    fn drop(&mut self) {
+        debug!("In BadBlock::drop()");
+        if let Some(FailType::Panic) = self.drop_fail {
+            debug!("BadBlock! drop(): panic");
+            panic!("BadBlock!");
+        }
+    }
+}

--- a/src/blocks/mod.rs
+++ b/src/blocks/mod.rs
@@ -262,3 +262,5 @@ pub use zynq_sync::ZynqSync;
 mod wasm_ws_sink;
 #[cfg(target_arch = "wasm32")]
 pub use wasm_ws_sink::WasmWsSink;
+
+pub mod bad_block;

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -70,6 +70,7 @@ pub fn init() {
 
 #[derive(Debug)]
 pub enum FlowgraphMessage {
+    /// Request the flowgraph to shutdown and exit without an error.
     Terminate,
     Initialized,
     BlockDone {
@@ -93,6 +94,13 @@ pub enum FlowgraphMessage {
     BlockDescription {
         block_id: usize,
         tx: oneshot::Sender<BlockDescription>,
+    },
+    /// A block has encountered an unrecoverable error
+    /// This will cause the flowgraph to [`Terminate`] and exit with an error.
+    BlockError {
+        block_id: usize,
+        block: Block,
+        error: crate::anyhow::Error,
     },
 }
 

--- a/src/runtime/runtime.rs
+++ b/src/runtime/runtime.rs
@@ -11,7 +11,7 @@ use futures::FutureExt;
 #[cfg(target_arch = "wasm32")]
 type Task<T> = crate::runtime::scheduler::wasm::TaskHandle<T>;
 
-use crate::anyhow::{bail, Context, Result};
+use crate::anyhow::{Context, Result};
 use crate::runtime::config;
 #[cfg(not(target_arch = "wasm32"))]
 use crate::runtime::ctrl_port;
@@ -281,6 +281,7 @@ async fn run_flowgraph<S: Scheduler>(
     // main loop
     loop {
         if active_blocks == 0 {
+            debug!("No active blocks, exiting.");
             break;
         }
 
@@ -353,6 +354,7 @@ async fn run_flowgraph<S: Scheduler>(
                 .unwrap();
             }
             FlowgraphMessage::Terminate => {
+                debug!("FlowgraphMessage::Terminate");
                 for (_, opt) in inboxes.iter_mut() {
                     if let Some(ref mut chan) = opt {
                         if chan.send(BlockMessage::Terminate).await.is_err() {
@@ -360,7 +362,6 @@ async fn run_flowgraph<S: Scheduler>(
                         }
                     }
                 }
-                bail!("Flowgraph was terminated");
             }
             _ => warn!("main loop received unhandled message"),
         }

--- a/src/runtime/scheduler/smol.rs
+++ b/src/runtime/scheduler/smol.rs
@@ -70,7 +70,9 @@ impl SmolScheduler {
                         debug!("starting executor thread on core id {}", &c.id);
                         core_affinity::set_for_current(c);
                     }
-                    async_io::block_on(e.run(receiver)).unwrap();
+                    if let Err(e) = async_io::block_on(e.run(receiver)) {
+                        debug!("receiver error, exiting: {:?}", e);
+                    }
                 })
                 .expect("failed to spawn executor thread");
 

--- a/src/runtime/scheduler/smol.rs
+++ b/src/runtime/scheduler/smol.rs
@@ -39,8 +39,11 @@ impl fmt::Debug for SmolSchedulerInner {
 impl Drop for SmolSchedulerInner {
     fn drop(&mut self) {
         for i in self.workers.drain(..) {
-            i.1.send(()).unwrap();
-            i.0.join().unwrap();
+            if let Ok(()) = i.1.send(()) {
+                if let Err(e) = i.0.join() {
+                    debug!("join error: {:?}", e);
+                }
+            }
         }
     }
 }

--- a/tests/bad_block.rs
+++ b/tests/bad_block.rs
@@ -1,0 +1,199 @@
+use futuresdr::{
+    anyhow::{bail, Error, Result},
+    async_io::block_on,
+    blocks::{bad_block::*, Head, NullSink, NullSource, Throttle},
+    runtime::{Flowgraph, Runtime},
+};
+use futuresdr_macros::connect;
+use log::debug;
+
+enum RunMode {
+    Run,
+    Terminate,
+    TermRtDrop,
+}
+
+fn run_badblock(bb: BadBlock<f32>, mode: RunMode) -> Result<Option<Error>> {
+    let mut fg = Flowgraph::new();
+
+    let null_source = NullSource::<f32>::new();
+    let throttle = Throttle::<f32>::new(100.0);
+    let head = Head::<f32>::new(10);
+    let null_sink = NullSink::<f32>::new();
+
+    let bb = bb.to_block();
+
+    connect!(fg, null_source > throttle > head > bb > null_sink);
+
+    let rt_ret = match mode {
+        RunMode::Run => Runtime::new().run(fg),
+        RunMode::Terminate => {
+            let rt = Runtime::new();
+            let (fg_task, mut fg_handle) = block_on(rt.start(fg));
+            block_on(async move {
+                // Sleep to allow work to be called at least once
+                futuresdr::async_io::Timer::after(std::time::Duration::from_millis(1)).await;
+                fg_handle.terminate().await.unwrap();
+                fg_task.await
+            })
+        }
+        RunMode::TermRtDrop => {
+            // This drops runtime before flowgraph and causes a deadlock regardless of any badblock errors.
+            // E.g. `let (task, mut fg_handle) = block_on(Runtime::new().start(fg));`
+            let fg_task;
+            let mut fg_handle;
+            {
+                let rt = Runtime::new();
+                (fg_task, fg_handle) = block_on(rt.start(fg));
+            }
+            block_on(async move {
+                // Sleep to allow work to be called at least once
+                futuresdr::async_io::Timer::after(std::time::Duration::from_millis(1)).await;
+                fg_handle.terminate().await.unwrap();
+                fg_task.await
+            })
+        }
+    };
+    //This will drop fg
+    match rt_ret {
+        Ok(_) => Ok(None),
+        Err(e) => Ok(Some(e)),
+    }
+}
+
+// //////////////////////////////////
+// RunMode::Run
+
+#[test]
+fn run_no_err() -> Result<()> {
+    let bb = BadBlock::<f32>::default();
+    match run_badblock(bb, RunMode::Run)? {
+        None => Ok(()),
+        Some(e) => bail!("Expected None, got: {}", e),
+    }
+}
+
+#[test]
+fn run_work_err() -> Result<()> {
+    let mut bb = BadBlock::<f32>::default();
+    bb.work_fail = Some(FailType::Error);
+    match run_badblock(bb, RunMode::Run)? {
+        None => bail!("Expected Error, got: None"),
+        Some(e) => {
+            debug!("Error: {}", e);
+            if e.to_string() != "Flowgraph was terminated" {
+                bail!("Unexpected Error: {}", e)
+            }
+            Ok(())
+        }
+    }
+}
+
+#[test]
+#[ignore]
+#[should_panic(expected = "BadBlock!")]
+fn run_work_panic() {
+    //FIXME: (#89) this currently hangs the runtime
+    let mut bb = BadBlock::<f32>::default();
+    bb.work_fail = Some(FailType::Panic);
+    let _ = run_badblock(bb, RunMode::Run);
+}
+
+#[test]
+#[should_panic(expected = "BadBlock!")]
+fn run_drop_panic() {
+    let mut bb = BadBlock::<f32>::default();
+    bb.drop_fail = Some(FailType::Panic);
+    let _ = run_badblock(bb, RunMode::Run);
+}
+
+// //////////////////////////////////
+// RunMode::Terminate
+
+#[test]
+#[ignore]
+fn terminate_no_err() -> Result<()> {
+    //FIXME: (#80) this should return OK but currently returns Error("Flowgraph was terminated")
+    let bb = BadBlock::<f32>::default();
+    match run_badblock(bb, RunMode::Terminate)? {
+        None => Ok(()),
+        Some(e) => bail!("Expected None, got: {}", e),
+    }
+}
+
+/// BadBlock returns work error, terminate msg is sent later.
+#[test]
+#[ignore]
+fn terminate_work_err() -> Result<()> {
+    // panics `Err` value: send failed because receiver is gone
+    // FIXME: should probably return some sort of flowgraph not running error
+    let mut bb = BadBlock::<f32>::default();
+    bb.work_fail = Some(FailType::Error);
+    match run_badblock(bb, RunMode::Terminate)? {
+        None => bail!("Expected Error, got: None"),
+        Some(e) => {
+            debug!("Error: {}", e);
+            if e.to_string() != "Flowgraph was terminated" {
+                bail!("Unexpected Error: {}", e)
+            }
+            Ok(())
+        }
+    }
+}
+
+#[test]
+#[ignore]
+// #[should_panic(expected = "BadBlock!")]
+fn terminate_work_panic() -> Result<()> {
+    // This sometimes returns a flowgraph terminated error instead of panicking.
+    // Other times it panics in various channel/scheduler locations (send or drop)
+    // Assume race condition.
+    // TODO: can we do *something* reliably here?
+    let mut bb = BadBlock::<f32>::default();
+    bb.work_fail = Some(FailType::Panic);
+    match run_badblock(bb, RunMode::Terminate)? {
+        None => bail!("Expected Error, got: None"),
+        Some(e) => {
+            debug!("Error: {}", e);
+            if e.to_string() != "Flowgraph was terminated" {
+                bail!("Unexpected Error: {}", e)
+            }
+            Ok(())
+        }
+    }
+}
+
+#[test]
+#[ignore]
+#[should_panic(expected = "BadBlock!")]
+fn terminate_drop_panic() {
+    //TODO: try to make consistent
+    //      Intermittently panics with "task has failed", sometimes Error("Flowgraph was terminated")
+    //      Assume race condition.
+    let mut bb = BadBlock::<f32>::default();
+    bb.drop_fail = Some(FailType::Panic);
+    match run_badblock(bb, RunMode::Terminate) {
+        Ok(None) => panic!("Expected Error, got: None"),
+        Ok(Some(e)) => {
+            debug!("Error: {}", e);
+            if e.to_string() != "Flowgraph was terminated" {
+                panic!("Unexpected Error: {}", e)
+            }
+        }
+        Err(e) => panic!("Unexpected Error: {}", e),
+    }
+}
+
+// //////////////////////////////////
+// RunMode::TermRtDrop
+
+#[test]
+#[ignore]
+fn rtdrop_no_err() -> Result<()> {
+    //FIXME: (#89) this currently hangs (or panics with deadlock detected)
+    let bb = BadBlock::<f32>::default();
+    match run_badblock(bb, RunMode::TermRtDrop)? {
+        None => Ok(()),
+        Some(e) => bail!("Expected None, got: {}", e),
+    }
+}

--- a/tests/bad_block.rs
+++ b/tests/bad_block.rs
@@ -74,7 +74,6 @@ fn run_no_err() -> Result<()> {
 }
 
 #[test]
-// #[ignore]
 fn run_work_err() -> Result<()> {
     //FIXME: (#89) this currently hangs the runtime
     let mut bb = BadBlock::<f32>::default();
@@ -124,7 +123,6 @@ fn terminate_no_err() -> Result<()> {
 /// BadBlock returns work error, terminate msg is sent later (after already shut down).
 #[test]
 fn terminate_work_err() -> Result<()> {
-    //FIXME: (#89) this sometimes hangs the runtime
     let mut bb = BadBlock::<f32>::default();
     bb.work_fail = Some(FailType::Error);
     match run_badblock(bb, RunMode::Terminate)? {


### PR DESCRIPTION
Also added an Err check in the executor loop of SmolScheduler::new() when testing. Probably should remain in some form.

Left commented-out deadlock code in:
tests/runtime::fg_terminate()

refs: #80