### PR TITLE
pmt: add f64 support for futuresdr

### DIFF
--- a/futuredsp/benches/benchmarks.rs
+++ b/futuredsp/benches/benchmarks.rs
@@ -29,6 +29,23 @@ impl Generatable for Complex<f32> {
     }
 }
 
+impl Generatable for f64 {
+    fn generate() -> Self {
+        let mut rng = rand::thread_rng();
+        rng.gen::<f64>() * 2.0 - 1.0
+    }
+}
+
+impl Generatable for Complex<f64> {
+    fn generate() -> Self {
+        let mut rng = rand::thread_rng();
+        Complex {
+            re: rng.gen::<f64>() * 2.0 - 1.0 + f64::MIN_POSITIVE,
+            im: rng.gen::<f64>() * 2.0 - 1.0 + f64::MIN_POSITIVE,
+        }
+    }
+}
+
 fn bench_fir_dynamic_taps<InputType, OutputType, TapType: Generatable>(
     b: &mut criterion::Bencher,
     ntaps: usize,
@@ -125,14 +142,23 @@ pub fn criterion_benchmark(c: &mut Criterion) {
 
     group.finish();
 
-    let mut group = c.benchmark_group("iir");
-    group.throughput(criterion::Throughput::Elements(nsamps as u64));
+    let mut group32 = c.benchmark_group("iir32");
+    group32.throughput(criterion::Throughput::Elements(nsamps as u64));
 
-    group.bench_function("iir", |b| {
-        bench_iir(b, 7, 1, nsamps);
+    group32.bench_function("iir32", |b| {
+        bench_iir::<_, _, f32>(b, 7, 1, nsamps);
     });
 
-    group.finish();
+    group32.finish();
+
+    let mut group64 = c.benchmark_group("iir64");
+    group64.throughput(criterion::Throughput::Elements(nsamps as u64));
+
+    group64.bench_function("iir64", |b| {
+        bench_iir::<_, _, f64>(b, 7, 1, nsamps);
+    });
+
+    group64.finish();
 }
 
 criterion_group!(benches, criterion_benchmark);

--- a/futuredsp/src/fir.rs
+++ b/futuredsp/src/fir.rs
@@ -4,6 +4,7 @@ use core::intrinsics::{fadd_fast, fmul_fast};
 
 use crate::{ComputationStatus, TapsAccessor, UnaryKernel};
 use num_complex::Complex;
+use num_traits::{Float, Zero};
 
 /// A non-resampling FIR filter. Calling `work()` on this struct always
 /// produces exactly as many samples as it consumes.
@@ -122,19 +123,50 @@ impl<TA: TapsAccessor<TapType = f32>> UnaryKernel<f32, f32>
 }
 
 #[cfg(not(RUSTC_IS_STABLE))]
-impl<TA: TapsAccessor<TapType = f32>> UnaryKernel<Complex<f32>, Complex<f32>>
-    for NonResamplingFirKernel<Complex<f32>, Complex<f32>, TA, f32>
+impl<TA: TapsAccessor<TapType = f64>> UnaryKernel<f64, f64>
+    for NonResamplingFirKernel<f64, f64, TA, f64>
+{
+    fn work(&self, i: &[f64], o: &mut [f64]) -> (usize, usize, ComputationStatus) {
+        fir_kernel_core(
+            &self.taps,
+            i,
+            o,
+            || 0.0,
+            |accum, sample, tap| unsafe { fadd_fast(accum, fmul_fast(sample, tap)) },
+        )
+    }
+}
+
+#[cfg(RUSTC_IS_STABLE)]
+impl<TA: TapsAccessor<TapType = f64>> UnaryKernel<f64, f64>
+    for NonResamplingFirKernel<f64, f64, TA, f64>
+{
+    fn work(&self, i: &[f64], o: &mut [f64]) -> (usize, usize, ComputationStatus) {
+        fir_kernel_core(
+            &self.taps,
+            i,
+            o,
+            || 0.0,
+            |accum, sample, tap| accum + sample * tap,
+        )
+    }
+}
+
+#[cfg(not(RUSTC_IS_STABLE))]
+impl<TA: TapsAccessor<TapType = T>> UnaryKernel<Complex<T>, Complex<T>>
+    for NonResamplingFirKernel<Complex<T>, Complex<T>, TA, T>
+    where T: Float + Send + Sync + Copy + Zero
 {
     fn work(
         &self,
-        i: &[Complex<f32>],
-        o: &mut [Complex<f32>],
+        i: &[Complex<T>],
+        o: &mut [Complex<T>],
     ) -> (usize, usize, ComputationStatus) {
         fir_kernel_core(
             &self.taps,
             i,
             o,
-            || Complex { re: 0.0, im: 0.0 },
+            || Complex{im: T::zero(), re: T::zero()},
             |accum, sample, tap| Complex {
                 re: unsafe { fadd_fast(accum.re, fmul_fast(sample.re, tap)) },
                 im: unsafe { fadd_fast(accum.im, fmul_fast(sample.im, tap)) },
@@ -144,19 +176,20 @@ impl<TA: TapsAccessor<TapType = f32>> UnaryKernel<Complex<f32>, Complex<f32>>
 }
 
 #[cfg(RUSTC_IS_STABLE)]
-impl<TA: TapsAccessor<TapType = f32>> UnaryKernel<Complex<f32>, Complex<f32>>
-    for NonResamplingFirKernel<Complex<f32>, Complex<f32>, TA, f32>
+impl<TA: TapsAccessor<TapType = T>, T> UnaryKernel<Complex<T>, Complex<T>>
+    for NonResamplingFirKernel<Complex<T>, Complex<T>, TA, T>
+    where T: Float + Send + Sync + Copy + Zero
 {
     fn work(
         &self,
-        i: &[Complex<f32>],
-        o: &mut [Complex<f32>],
+        i: &[Complex<T>],
+        o: &mut [Complex<T>],
     ) -> (usize, usize, ComputationStatus) {
         fir_kernel_core(
             &self.taps,
             i,
             o,
-            || Complex { re: 0.0, im: 0.0 },
+            || Complex{im: T::zero(), re: T::zero()},
             |accum, sample, tap| Complex {
                 re: accum.re + sample.re * tap,
                 im: accum.im + sample.im * tap,
@@ -165,19 +198,20 @@ impl<TA: TapsAccessor<TapType = f32>> UnaryKernel<Complex<f32>, Complex<f32>>
     }
 }
 
-impl<TA: TapsAccessor<TapType = Complex<f32>>> UnaryKernel<Complex<f32>, Complex<f32>>
-    for NonResamplingFirKernel<Complex<f32>, Complex<f32>, TA, Complex<f32>>
+impl<TA: TapsAccessor<TapType = Complex<T>>, T> UnaryKernel<Complex<T>, Complex<T>>
+    for NonResamplingFirKernel<Complex<T>, Complex<T>, TA, Complex<T>>
+    where T: Float + Send + Sync + Copy + Zero
 {
     fn work(
         &self,
-        i: &[Complex<f32>],
-        o: &mut [Complex<f32>],
+        i: &[Complex<T>],
+        o: &mut [Complex<T>],
     ) -> (usize, usize, ComputationStatus) {
         fir_kernel_core(
             &self.taps,
             i,
             o,
-            || Complex { re: 0.0, im: 0.0 },
+            || Complex{im: T::zero(), re: T::zero()},
             |accum, sample, tap| accum + sample * tap,
         )
     }
@@ -340,13 +374,54 @@ impl<TA: TapsAccessor<TapType = f32>> UnaryKernel<Complex<f32>, Complex<f32>>
     }
 }
 
+
+impl<TA: TapsAccessor<TapType = f64>> UnaryKernel<f64, f64>
+    for PolyphaseResamplingFirKernel<f64, f64, TA, f64>
+{
+    fn work(&self, i: &[f64], o: &mut [f64]) -> (usize, usize, ComputationStatus) {
+        resampling_fir_kernel_core(
+            self.interp,
+            self.decim,
+            &self.taps,
+            i,
+            o,
+            || 0.0,
+            |accum, sample, tap| accum + sample * tap,
+        )
+    }
+}
+
+impl<TA: TapsAccessor<TapType = f64>> UnaryKernel<Complex<f64>, Complex<f64>>
+    for PolyphaseResamplingFirKernel<Complex<f64>, Complex<f64>, TA, f64>
+{
+    fn work(
+        &self,
+        i: &[Complex<f64>],
+        o: &mut [Complex<f64>],
+    ) -> (usize, usize, ComputationStatus) {
+        resampling_fir_kernel_core(
+            self.interp,
+            self.decim,
+            &self.taps,
+            i,
+            o,
+            || Complex { re: 0.0, im: 0.0 },
+            |accum, sample, tap| Complex {
+                re: accum.re + sample.re * tap,
+                im: accum.im + sample.im * tap,
+            },
+        )
+    }
+}
+
+
 #[cfg(test)]
 mod tests {
     use super::*;
 
     #[test]
     fn direct_fir_kernel() {
-        let taps = [1.0, 2.0, 3.0];
+        let taps: [f32; 3] = [1.0, 2.0, 3.0];
         let kernel = NonResamplingFirKernel::new(taps);
         let input = [1.0, 2.0, 3.0];
         let mut output = [0.0; 3];
@@ -384,7 +459,29 @@ mod tests {
     /// filled the output buffer.
     #[test]
     fn terminating_condition() {
-        let taps = [1.0, 2.0];
+        let taps: [f32; 2] = [1.0, 2.0];
+        let kernel = NonResamplingFirKernel::new(taps);
+
+        // With 5 input samples and 3 out, we just need more output space
+        let input = [1.0, 2.0, 3.0, 4.0, 5.0];
+        let mut output = [0.0; 3];
+        assert_eq!(
+            kernel.work(&input, &mut output),
+            (3, 3, ComputationStatus::InsufficientOutput)
+        );
+
+        // With 4 input samples and 3 out, we've exactly filled the output
+        let input = [1.0, 2.0, 3.0, 4.0];
+        let mut output = [0.0; 3];
+        assert_eq!(
+            kernel.work(&input, &mut output),
+            (3, 3, ComputationStatus::BothSufficient)
+        );
+    }
+
+    #[test]
+    fn terminating_condition_f64(){
+        let taps: [f64; 2] = [1.0, 2.0];
         let kernel = NonResamplingFirKernel::new(taps);
 
         // With 5 input samples and 3 out, we just need more output space
@@ -408,7 +505,7 @@ mod tests {
     fn direct_resampling_fir_kernel() {
         let interp = 3;
         let decim = 2;
-        let taps = [1.0, 2.0, 3.0, 4.0, 5.0, 6.0];
+        let taps: [f32; 6] = [1.0, 2.0, 3.0, 4.0, 5.0, 6.0];
         let kernel = PolyphaseResamplingFirKernel::new(interp, decim, taps);
         let input = [1.0, 2.0, 3.0, 4.0, 5.0];
         let mut output = [0.0; 8];
@@ -464,7 +561,7 @@ mod tests {
 
         let interp = 2;
         let decim = 1;
-        let taps = [1.0, 2.0];
+        let taps: [f32; 2] = [1.0, 2.0];
         let kernel = PolyphaseResamplingFirKernel::new(interp, decim, taps);
         let input = [1.0, 2.0, 3.0, 4.0];
         let mut output = [0.0; 10];
@@ -481,7 +578,7 @@ mod tests {
 
         let interp = 1;
         let decim = 3;
-        let taps = [1.0, 2.0];
+        let taps: [f32; 2] = [1.0, 2.0];
         let kernel = PolyphaseResamplingFirKernel::new(interp, decim, taps);
         let input = [1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0];
         let mut output = [0.0; 8];

--- a/futuredsp/src/fir.rs
+++ b/futuredsp/src/fir.rs
@@ -155,18 +155,18 @@ impl<TA: TapsAccessor<TapType = f64>> UnaryKernel<f64, f64>
 #[cfg(not(RUSTC_IS_STABLE))]
 impl<TA: TapsAccessor<TapType = T>> UnaryKernel<Complex<T>, Complex<T>>
     for NonResamplingFirKernel<Complex<T>, Complex<T>, TA, T>
-    where T: Float + Send + Sync + Copy + Zero
+where
+    T: Float + Send + Sync + Copy + Zero,
 {
-    fn work(
-        &self,
-        i: &[Complex<T>],
-        o: &mut [Complex<T>],
-    ) -> (usize, usize, ComputationStatus) {
+    fn work(&self, i: &[Complex<T>], o: &mut [Complex<T>]) -> (usize, usize, ComputationStatus) {
         fir_kernel_core(
             &self.taps,
             i,
             o,
-            || Complex{im: T::zero(), re: T::zero()},
+            || Complex {
+                im: T::zero(),
+                re: T::zero(),
+            },
             |accum, sample, tap| Complex {
                 re: unsafe { fadd_fast(accum.re, fmul_fast(sample.re, tap)) },
                 im: unsafe { fadd_fast(accum.im, fmul_fast(sample.im, tap)) },
@@ -178,18 +178,18 @@ impl<TA: TapsAccessor<TapType = T>> UnaryKernel<Complex<T>, Complex<T>>
 #[cfg(RUSTC_IS_STABLE)]
 impl<TA: TapsAccessor<TapType = T>, T> UnaryKernel<Complex<T>, Complex<T>>
     for NonResamplingFirKernel<Complex<T>, Complex<T>, TA, T>
-    where T: Float + Send + Sync + Copy + Zero
+where
+    T: Float + Send + Sync + Copy + Zero,
 {
-    fn work(
-        &self,
-        i: &[Complex<T>],
-        o: &mut [Complex<T>],
-    ) -> (usize, usize, ComputationStatus) {
+    fn work(&self, i: &[Complex<T>], o: &mut [Complex<T>]) -> (usize, usize, ComputationStatus) {
         fir_kernel_core(
             &self.taps,
             i,
             o,
-            || Complex{im: T::zero(), re: T::zero()},
+            || Complex {
+                im: T::zero(),
+                re: T::zero(),
+            },
             |accum, sample, tap| Complex {
                 re: accum.re + sample.re * tap,
                 im: accum.im + sample.im * tap,
@@ -200,18 +200,18 @@ impl<TA: TapsAccessor<TapType = T>, T> UnaryKernel<Complex<T>, Complex<T>>
 
 impl<TA: TapsAccessor<TapType = Complex<T>>, T> UnaryKernel<Complex<T>, Complex<T>>
     for NonResamplingFirKernel<Complex<T>, Complex<T>, TA, Complex<T>>
-    where T: Float + Send + Sync + Copy + Zero
+where
+    T: Float + Send + Sync + Copy + Zero,
 {
-    fn work(
-        &self,
-        i: &[Complex<T>],
-        o: &mut [Complex<T>],
-    ) -> (usize, usize, ComputationStatus) {
+    fn work(&self, i: &[Complex<T>], o: &mut [Complex<T>]) -> (usize, usize, ComputationStatus) {
         fir_kernel_core(
             &self.taps,
             i,
             o,
-            || Complex{im: T::zero(), re: T::zero()},
+            || Complex {
+                im: T::zero(),
+                re: T::zero(),
+            },
             |accum, sample, tap| accum + sample * tap,
         )
     }
@@ -374,7 +374,6 @@ impl<TA: TapsAccessor<TapType = f32>> UnaryKernel<Complex<f32>, Complex<f32>>
     }
 }
 
-
 impl<TA: TapsAccessor<TapType = f64>> UnaryKernel<f64, f64>
     for PolyphaseResamplingFirKernel<f64, f64, TA, f64>
 {
@@ -413,7 +412,6 @@ impl<TA: TapsAccessor<TapType = f64>> UnaryKernel<Complex<f64>, Complex<f64>>
         )
     }
 }
-
 
 #[cfg(test)]
 mod tests {
@@ -480,7 +478,7 @@ mod tests {
     }
 
     #[test]
-    fn terminating_condition_f64(){
+    fn terminating_condition_f64() {
         let taps: [f64; 2] = [1.0, 2.0];
         let kernel = NonResamplingFirKernel::new(taps);
 

--- a/futuredsp/src/iir.rs
+++ b/futuredsp/src/iir.rs
@@ -1,4 +1,4 @@
-use core::ops::{Mul, AddAssign};
+use core::ops::{AddAssign, Mul};
 
 use crate::{ComputationStatus, StatefulUnaryKernel, TapsAccessor};
 
@@ -53,7 +53,7 @@ impl<TapsType: TapsAccessor<TapType = f32>> StatefulUnaryKernel<f32, f32>
     for IirKernel<f32, f32, TapsType>
 {
     fn work(&mut self, input: &[f32], output: &mut [f32]) -> (usize, usize, ComputationStatus) {
-        taps_accessor_work(&mut self.memory, &self.a_taps,&self.b_taps, input, output)
+        taps_accessor_work(&mut self.memory, &self.a_taps, &self.b_taps, input, output)
     }
 }
 
@@ -61,7 +61,7 @@ impl<TapsType: TapsAccessor<TapType = f64>> StatefulUnaryKernel<f64, f64>
     for IirKernel<f64, f64, TapsType>
 {
     fn work(&mut self, input: &[f64], output: &mut [f64]) -> (usize, usize, ComputationStatus) {
-        taps_accessor_work(&mut self.memory, &self.a_taps,&self.b_taps, input, output)
+        taps_accessor_work(&mut self.memory, &self.a_taps, &self.b_taps, input, output)
     }
 }
 
@@ -75,7 +75,7 @@ fn taps_accessor_work<TT, T>(
 ) -> (usize, usize, ComputationStatus)
 where
     TT: TapsAccessor<TapType = T>,
-    T: Copy + AddAssign + Zero + Mul<Output=T>,
+    T: Copy + AddAssign + Zero + Mul<Output = T>,
 {
     if i.is_empty() {
         return (

--- a/futuredsp/src/tapsaccessor.rs
+++ b/futuredsp/src/tapsaccessor.rs
@@ -1,6 +1,7 @@
 extern crate alloc;
 use alloc::vec::Vec;
-use num_complex::Complex32;
+use num_complex::Complex;
+use num_traits::Float;
 
 pub trait TapsAccessor: Send {
     type TapType;
@@ -14,27 +15,29 @@ pub trait TapsAccessor: Send {
     unsafe fn get(&self, index: usize) -> Self::TapType;
 }
 
-impl<const N: usize> TapsAccessor for [Complex32; N] {
-    type TapType = Complex32;
+impl<const N: usize, T> TapsAccessor for [Complex<T>; N]
+where T: Float + Send + Sync + Copy {
+    type TapType = Complex<T>;
 
     fn num_taps(&self) -> usize {
         N
     }
 
-    unsafe fn get(&self, index: usize) -> Complex32 {
+    unsafe fn get(&self, index: usize) -> Complex<T> {
         debug_assert!(index < self.num_taps());
         *self.get_unchecked(index)
     }
 }
 
-impl<const N: usize> TapsAccessor for &[Complex32; N] {
-    type TapType = Complex32;
+impl<const N: usize, T> TapsAccessor for &[Complex<T>; N] 
+where T: Float + Send + Sync + Copy {
+    type TapType = Complex<T>;
 
     fn num_taps(&self) -> usize {
         N
     }
 
-    unsafe fn get(&self, index: usize) -> Complex32 {
+    unsafe fn get(&self, index: usize) -> Complex<T> {
         debug_assert!(index < self.num_taps());
         *self.get_unchecked(index)
     }
@@ -66,14 +69,41 @@ impl<const N: usize> TapsAccessor for &[f32; N] {
     }
 }
 
-impl TapsAccessor for Vec<f32> {
-    type TapType = f32;
+impl<const N: usize> TapsAccessor for [f64; N] {
+    type TapType = f64;
+
+    fn num_taps(&self) -> usize {
+        N
+    }
+
+    unsafe fn get(&self, index: usize) -> f64 {
+        debug_assert!(index < self.num_taps());
+        *self.get_unchecked(index)
+    }
+}
+
+impl<const N: usize> TapsAccessor for &[f64; N] {
+    type TapType = f64;
+
+    fn num_taps(&self) -> usize {
+        N
+    }
+
+    unsafe fn get(&self, index: usize) -> f64 {
+        debug_assert!(index < self.num_taps());
+        *self.get_unchecked(index)
+    }
+}
+
+impl<T> TapsAccessor for Vec<T>
+where T: Float + Send + Sync + Copy {
+    type TapType = T;
 
     fn num_taps(&self) -> usize {
         self.len()
     }
 
-    unsafe fn get(&self, index: usize) -> f32 {
+    unsafe fn get(&self, index: usize) -> T {
         debug_assert!(index < self.num_taps());
         *self.get_unchecked(index)
     }

--- a/futuredsp/src/tapsaccessor.rs
+++ b/futuredsp/src/tapsaccessor.rs
@@ -16,7 +16,9 @@ pub trait TapsAccessor: Send {
 }
 
 impl<const N: usize, T> TapsAccessor for [Complex<T>; N]
-where T: Float + Send + Sync + Copy {
+where
+    T: Float + Send + Sync + Copy,
+{
     type TapType = Complex<T>;
 
     fn num_taps(&self) -> usize {
@@ -29,8 +31,10 @@ where T: Float + Send + Sync + Copy {
     }
 }
 
-impl<const N: usize, T> TapsAccessor for &[Complex<T>; N] 
-where T: Float + Send + Sync + Copy {
+impl<const N: usize, T> TapsAccessor for &[Complex<T>; N]
+where
+    T: Float + Send + Sync + Copy,
+{
     type TapType = Complex<T>;
 
     fn num_taps(&self) -> usize {
@@ -96,7 +100,9 @@ impl<const N: usize> TapsAccessor for &[f64; N] {
 }
 
 impl<T> TapsAccessor for Vec<T>
-where T: Float + Send + Sync + Copy {
+where
+    T: Float + Send + Sync + Copy,
+{
     type TapType = T;
 
     fn num_taps(&self) -> usize {

--- a/futuredsp/src/windows.rs
+++ b/futuredsp/src/windows.rs
@@ -1,7 +1,10 @@
 //! A collection of window functions.
 
 extern crate alloc;
-use core::{ops::{Div, Mul, Sub}, iter::Sum};
+use core::{
+    iter::Sum,
+    ops::{Div, Mul, Sub},
+};
 
 use crate::math::special_funs;
 use alloc::vec::Vec;
@@ -59,7 +62,7 @@ where
 /// ```
 pub fn gen_cos<T>(len: usize, coeffs: &[T], periodic: bool) -> Vec<T>
 where
-    T: Float + Mul<Output=T> + From<f32> + Sum + 'static,
+    T: Float + Mul<Output = T> + From<f32> + Sum + 'static,
     usize: AsPrimitive<T>,
 {
     let (len, truncate) = match periodic {
@@ -73,7 +76,8 @@ where
                 .map(|k| {
                     <T as From<f32>>::from(-1.0).powi(k as i32)
                         * coeffs[k]
-                        * (<T as From<f32>>::from(core::f32::consts::PI) * ((k * n).as_()) / alpha).cos()
+                        * (<T as From<f32>>::from(core::f32::consts::PI) * ((k * n).as_()) / alpha)
+                            .cos()
                 })
                 .sum()
         })

--- a/src/blocks/fir.rs
+++ b/src/blocks/fir.rs
@@ -122,11 +122,11 @@ where
 ///
 /// let mut fg = Flowgraph::new();
 ///
-/// let fir = fg.add_block(FirBuilder::new::<f32, f32, f32, _>([1.0, 2.0, 3.0]));
-/// let fir = fg.add_block(FirBuilder::new::<Complex<f32>, Complex<f32>, f32, _>(&[1.0, 2.0, 3.0]));
-/// let fir = fg.add_block(FirBuilder::new::<f32, f32, f32, _>(vec![1.0, 2.0, 3.0]));
+/// let fir = fg.add_block(FirBuilder::new::<f32, f32, f32, [f32; 3]>([1.0, 2.0, 3.0]));
+/// let fir = fg.add_block(FirBuilder::new::<Complex<f32>, Complex<f32>, f32, _>(&[1.0f32, 2.0, 3.0]));
+/// let fir = fg.add_block(FirBuilder::new::<f32, f32, f32, Vec<f32>>(vec![1.0, 2.0, 3.0]));
 ///
-/// let fir = fg.add_block(FirBuilder::new_resampling_with_taps::<f32, f32, f32, _>(3, 2, vec![1.0, 2.0, 3.0]));
+/// let fir = fg.add_block(FirBuilder::new_resampling_with_taps::<f32, f32, f32, _>(3, 2, vec![1.0f32, 2.0, 3.0]));
 /// ```
 pub struct FirBuilder {
     //

--- a/src/blocks/iir.rs
+++ b/src/blocks/iir.rs
@@ -128,7 +128,7 @@ where
 ///
 /// let mut fg = Flowgraph::new();
 ///
-/// let iir = fg.add_block(IirBuilder::new::<f32, f32, f32, _>([1.0, 2.0, 3.0], [4.0, 5.0, 6.0]));
+/// let iir = fg.add_block(IirBuilder::new::<f32, f32, f32, [f32; 3]>([1.0, 2.0, 3.0], [4.0, 5.0, 6.0]));
 /// ```
 pub struct IirBuilder {
     //


### PR DESCRIPTION
Where the Float trait from num-traits can may added. In some places copied the trait for f64. In other case the T could catch Complex<T>. Fixed docs, explicit type required. Test checked. 
_Sorry for my English._