### PR TITLE
unsafe: rm unneeded Send/Sync impls

### DIFF
--- a/src/blocks/audio/audio_sink.rs
+++ b/src/blocks/audio/audio_sink.rs
@@ -28,6 +28,7 @@ pub struct AudioSink {
     tx: Option<mpsc::Sender<Vec<f32>>>,
 }
 
+// cpal::Stream is !Send
 #[allow(clippy::non_send_fields_in_send_ty)]
 unsafe impl Send for AudioSink {}
 

--- a/src/blocks/audio/audio_source.rs
+++ b/src/blocks/audio/audio_source.rs
@@ -27,6 +27,7 @@ pub struct AudioSource {
     buff: Option<(Vec<f32>, usize)>,
 }
 
+// cpal::Stream is !Send
 #[allow(clippy::non_send_fields_in_send_ty)]
 unsafe impl Send for AudioSource {}
 

--- a/src/blocks/fir.rs
+++ b/src/blocks/fir.rs
@@ -18,8 +18,8 @@ pub struct Fir<InputType, OutputType, TapType, Core>
 where
     InputType: 'static + Send,
     OutputType: 'static + Send,
-    TapType: 'static,
-    Core: 'static + UnaryKernel<InputType, OutputType>,
+    TapType: 'static + Send,
+    Core: 'static + UnaryKernel<InputType, OutputType> + Send,
 {
     core: Core,
     _input_type: std::marker::PhantomData<InputType>,
@@ -27,21 +27,12 @@ where
     _tap_type: std::marker::PhantomData<TapType>,
 }
 
-unsafe impl<InputType, OutputType, TapType, Core> Send for Fir<InputType, OutputType, TapType, Core>
-where
-    InputType: 'static + Send,
-    OutputType: 'static + Send,
-    TapType: 'static,
-    Core: 'static + UnaryKernel<InputType, OutputType>,
-{
-}
-
 impl<InputType, OutputType, TapType, Core> Fir<InputType, OutputType, TapType, Core>
 where
     InputType: 'static + Send,
     OutputType: 'static + Send,
-    TapType: 'static,
-    Core: 'static + UnaryKernel<InputType, OutputType>,
+    TapType: 'static + Send,
+    Core: 'static + UnaryKernel<InputType, OutputType> + Send,
 {
     pub fn new(core: Core) -> Block {
         Block::new(
@@ -67,8 +58,8 @@ impl<InputType, OutputType, TapType, Core> Kernel for Fir<InputType, OutputType,
 where
     InputType: 'static + Send,
     OutputType: 'static + Send,
-    TapType: 'static,
-    Core: 'static + UnaryKernel<InputType, OutputType>,
+    TapType: 'static + Send,
+    Core: 'static + UnaryKernel<InputType, OutputType> + Send,
 {
     async fn work(
         &mut self,
@@ -138,10 +129,10 @@ impl FirBuilder {
     where
         InputType: 'static + Send,
         OutputType: 'static + Send,
-        TapType: 'static,
-        Taps: 'static + TapsAccessor<TapType = TapType>,
+        TapType: 'static + Send,
+        Taps: 'static + TapsAccessor<TapType = TapType> + Send,
         NonResamplingFirKernel<InputType, OutputType, Taps, TapType>:
-            UnaryKernel<InputType, OutputType>,
+            UnaryKernel<InputType, OutputType> + Send,
     {
         Fir::<
             InputType,
@@ -181,10 +172,10 @@ impl FirBuilder {
     where
         InputType: 'static + Send,
         OutputType: 'static + Send,
-        TapType: 'static,
-        Taps: 'static + TapsAccessor<TapType = TapType>,
+        TapType: 'static + Send,
+        Taps: 'static + TapsAccessor<TapType = TapType> + Send,
         PolyphaseResamplingFirKernel<InputType, OutputType, Taps, TapType>:
-            UnaryKernel<InputType, OutputType>,
+            UnaryKernel<InputType, OutputType> + Send,
     {
         Fir::<
             InputType,

--- a/src/blocks/iir.rs
+++ b/src/blocks/iir.rs
@@ -16,8 +16,8 @@ pub struct Iir<InputType, OutputType, TapType, Core>
 where
     InputType: 'static + Send,
     OutputType: 'static + Send,
-    TapType: 'static,
-    Core: 'static + StatefulUnaryKernel<InputType, OutputType>,
+    TapType: 'static + Send,
+    Core: 'static + StatefulUnaryKernel<InputType, OutputType> + Send,
 {
     core: Core,
     _input_type: std::marker::PhantomData<InputType>,
@@ -25,21 +25,12 @@ where
     _tap_type: std::marker::PhantomData<TapType>,
 }
 
-unsafe impl<InputType, OutputType, TapType, Core> Send for Iir<InputType, OutputType, TapType, Core>
-where
-    InputType: 'static + Send,
-    OutputType: 'static + Send,
-    TapType: 'static,
-    Core: 'static + StatefulUnaryKernel<InputType, OutputType>,
-{
-}
-
 impl<InputType, OutputType, TapType, Core> Iir<InputType, OutputType, TapType, Core>
 where
     InputType: 'static + Send,
     OutputType: 'static + Send,
-    TapType: 'static,
-    Core: 'static + StatefulUnaryKernel<InputType, OutputType>,
+    TapType: 'static + Send,
+    Core: 'static + StatefulUnaryKernel<InputType, OutputType> + Send,
 {
     pub fn new(core: Core) -> Block {
         Block::new(
@@ -65,8 +56,8 @@ impl<InputType, OutputType, TapType, Core> Kernel for Iir<InputType, OutputType,
 where
     InputType: 'static + Send,
     OutputType: 'static + Send,
-    TapType: 'static,
-    Core: 'static + StatefulUnaryKernel<InputType, OutputType>,
+    TapType: 'static + Send,
+    Core: 'static + StatefulUnaryKernel<InputType, OutputType> + Send,
 {
     async fn work(
         &mut self,
@@ -139,9 +130,9 @@ impl IirBuilder {
     where
         InputType: 'static + Send + Clone,
         OutputType: 'static + Send + Clone,
-        TapType: 'static,
-        Taps: 'static + TapsAccessor,
-        IirKernel<InputType, OutputType, Taps>: StatefulUnaryKernel<InputType, OutputType>,
+        TapType: 'static + Send,
+        Taps: 'static + TapsAccessor + Send,
+        IirKernel<InputType, OutputType, Taps>: StatefulUnaryKernel<InputType, OutputType> + Send,
     {
         Iir::<InputType, OutputType, TapType, IirKernel<InputType, OutputType, Taps>>::new(
             IirKernel::new(a_taps, b_taps),

--- a/src/blocks/soapy/mod.rs
+++ b/src/blocks/soapy/mod.rs
@@ -200,8 +200,6 @@ impl<T> SoapyDevice<T> {
     }
 }
 
-// unsafe impl<T> Sync for SoapyDevice<T> {}
-
 pub struct SoapyDevBuilder<T> {
     init_cfg: config::SoapyInitConfig,
     _phantom: PhantomData<T>,

--- a/src/runtime/buffer/circular.rs
+++ b/src/runtime/buffer/circular.rs
@@ -199,10 +199,6 @@ impl BufferWriterHost for Writer {
     }
 }
 
-#[allow(clippy::non_send_fields_in_send_ty)]
-unsafe impl Send for Writer {}
-unsafe impl Sync for Writer {}
-
 pub struct Reader {
     reader: generic::Reader<u8, MyNotifier, MyMetadata>,
     item_size: usize,
@@ -264,6 +260,3 @@ impl fmt::Debug for Reader {
             .finish()
     }
 }
-
-unsafe impl Send for Reader {}
-unsafe impl Sync for Reader {}

--- a/src/runtime/buffer/slab.rs
+++ b/src/runtime/buffer/slab.rs
@@ -289,8 +289,6 @@ impl BufferWriterHost for Writer {
     }
 }
 
-unsafe impl Send for Writer {}
-
 #[derive(Debug)]
 pub struct Reader {
     current: Option<CurrentBuffer>,
@@ -420,5 +418,3 @@ impl BufferReaderHost for Reader {
         self.finished && self.state.lock().unwrap().reader_input.is_empty()
     }
 }
-
-unsafe impl Send for Reader {}

--- a/src/runtime/buffer/vulkan/d2h.rs
+++ b/src/runtime/buffer/vulkan/d2h.rs
@@ -142,8 +142,6 @@ impl BufferWriterCustom for WriterD2H {
     }
 }
 
-unsafe impl Send for WriterD2H {}
-
 #[derive(Debug)]
 pub struct ReaderD2H {
     buffer: Option<CurrentBuffer>,
@@ -236,5 +234,3 @@ impl BufferReaderHost for ReaderD2H {
         self.finished && self.inbound.lock().unwrap().is_empty()
     }
 }
-
-unsafe impl Send for ReaderD2H {}

--- a/src/runtime/buffer/vulkan/h2d.rs
+++ b/src/runtime/buffer/vulkan/h2d.rs
@@ -202,8 +202,6 @@ impl BufferWriterHost for WriterH2D {
     }
 }
 
-unsafe impl Send for WriterH2D {}
-
 // ====================== READER ============================
 #[derive(Debug)]
 pub struct ReaderH2D {
@@ -255,5 +253,3 @@ impl BufferReaderCustom for ReaderH2D {
         self.finished
     }
 }
-
-unsafe impl Send for ReaderH2D {}

--- a/src/runtime/buffer/wgpu/d2h.rs
+++ b/src/runtime/buffer/wgpu/d2h.rs
@@ -143,8 +143,6 @@ impl BufferWriterCustom for WriterD2H {
     }
 }
 
-unsafe impl Send for WriterD2H {}
-
 #[derive(Debug)]
 pub struct ReaderD2H {
     buffer: Option<CurrentBuffer>,
@@ -163,6 +161,9 @@ struct CurrentBuffer {
     offset: usize,
     slice: BufferView<'static>,
 }
+
+// Needed for raw pointer `buffer`
+unsafe impl Send for CurrentBuffer {}
 
 #[async_trait]
 impl BufferReaderHost for ReaderD2H {
@@ -253,5 +254,3 @@ impl BufferReaderHost for ReaderD2H {
         self.finished && self.inbound.lock().unwrap().is_empty()
     }
 }
-
-unsafe impl Send for ReaderD2H {}

--- a/src/runtime/buffer/wgpu/h2d.rs
+++ b/src/runtime/buffer/wgpu/h2d.rs
@@ -201,8 +201,6 @@ impl BufferWriterHost for WriterH2D {
     }
 }
 
-unsafe impl Send for WriterH2D {}
-
 // ====================== READER ============================
 #[derive(Debug)]
 pub struct ReaderH2D {
@@ -254,5 +252,3 @@ impl BufferReaderCustom for ReaderH2D {
         self.finished
     }
 }
-
-unsafe impl Send for ReaderH2D {}

--- a/src/runtime/buffer/zynq/d2h.rs
+++ b/src/runtime/buffer/zynq/d2h.rs
@@ -142,8 +142,6 @@ impl BufferWriterCustom for WriterD2H {
     }
 }
 
-unsafe impl Send for WriterD2H {}
-
 #[derive(Debug)]
 pub struct ReaderD2H {
     buffer: Option<CurrentBuffer>,
@@ -237,5 +235,3 @@ impl BufferReaderHost for ReaderD2H {
         self.finished && self.inbound.lock().unwrap().is_empty()
     }
 }
-
-unsafe impl Send for ReaderD2H {}

--- a/src/runtime/buffer/zynq/h2d.rs
+++ b/src/runtime/buffer/zynq/h2d.rs
@@ -214,8 +214,6 @@ impl BufferWriterHost for WriterH2D {
     }
 }
 
-unsafe impl Send for WriterH2D {}
-
 // ====================== READER ============================
 #[derive(Debug)]
 pub struct ReaderH2D {
@@ -272,5 +270,3 @@ impl BufferReaderCustom for ReaderH2D {
         self.finished
     }
 }
-
-unsafe impl Send for ReaderH2D {}

--- a/src/runtime/scheduler/flow.rs
+++ b/src/runtime/scheduler/flow.rs
@@ -199,9 +199,6 @@ pub struct FlowExecutor {
     state: once_cell::sync::OnceCell<Arc<State>>,
 }
 
-unsafe impl Send for FlowExecutor {}
-unsafe impl Sync for FlowExecutor {}
-
 impl UnwindSafe for FlowExecutor {}
 impl RefUnwindSafe for FlowExecutor {}
 

--- a/src/runtime/stream_io.rs
+++ b/src/runtime/stream_io.rs
@@ -21,6 +21,9 @@ struct CurrentInput {
     tags: Vec<ItemTag>,
 }
 
+// Needed for raw pointer `ptr`
+unsafe impl Send for CurrentInput {}
+
 #[derive(Debug)]
 pub struct StreamInput {
     name: String,
@@ -30,8 +33,6 @@ pub struct StreamInput {
     current: Option<CurrentInput>,
     tags: Vec<ItemTag>,
 }
-
-unsafe impl Send for StreamInput {}
 
 impl StreamInput {
     pub fn new<T: Any>(name: &str) -> StreamInput {


### PR DESCRIPTION
Figured it is better to let the compiler infer the traits when possible rather than forcing/faking it.