### PR TITLE
Fix tag debug

### DIFF
--- a/src/blocks/tag_debug.rs
+++ b/src/blocks/tag_debug.rs
@@ -62,9 +62,9 @@ impl<T: Send + 'static> Kernel for TagDebug<T> {
         _mio: &mut MessageIo<Self>,
         _meta: &mut BlockMeta,
     ) -> Result<()> {
-        let i = sio.input(0).slice::<u8>();
+        let i = sio.input(0).slice::<T>();
 
-        let n = i.len() / std::mem::size_of::<T>();
+        let n = i.len();
         sio.input(0)
             .tags()
             .iter()
@@ -79,10 +79,8 @@ impl<T: Send + 'static> Kernel for TagDebug<T> {
                 )
             });
 
-        if n > 0 {
-            sio.input(0).consume(n);
-            self.n_received += n;
-        }
+        sio.input(0).consume(n);
+        self.n_received += n;
 
         if sio.input(0).finished() {
             io.finished = true;


### PR DESCRIPTION
The current `TagDebug` block violates the following assert when the input type is different from `u8`: https://github.com/FutureSDR/FutureSDR/blob/main/src/runtime/stream_io.rs#L79.

I believe the implementation is supposed to be like the one implemented in this pull request.

I also created a simple `TagDebug` example, but I did not include it in the pull request (https://github.com/AndersKaloer/FutureSDR/tree/tag-debug-example). The example fails with the current `TagDebug` implementation, but works with this fix.