### PR TITLE
ADS-B decoder example

### DIFF
--- a/examples/adsb/Cargo.toml
+++ b/examples/adsb/Cargo.toml
@@ -18,4 +18,4 @@ serde = { version = "1.0", features = ["derive"] }
 serde_with = "2.1.0"
 serde_json = "1.0.89"
 env_logger = "0.10.0"
-adsb_deku = { git = "https://github.com/rsadsb/adsb_deku" }
+adsb_deku = "0.6.2"

--- a/examples/adsb/Cargo.toml
+++ b/examples/adsb/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "adsb_demod"
+version = "0.1.0"
+edition = "2021"
+
+[workspace]
+
+[[bin]]
+name = "listen-adsb"
+path = "src/bin/listen_adsb.rs"
+
+[dependencies]
+clap = { version = "4.0.27", features = ["derive"] }
+futuresdr = { path = "../..", features=["soapy", "audio"] }
+futuredsp = { path = "../../futuredsp" }
+futuresdr-pmt = { path = "../../pmt" }
+serde = { version = "1.0", features = ["derive"] }
+serde_with = "2.1.0"
+serde_json = "1.0.89"
+env_logger = "0.10.0"
+adsb_deku = { git = "https://github.com/rsadsb/adsb_deku" }

--- a/examples/adsb/Gulpfile.js
+++ b/examples/adsb/Gulpfile.js
@@ -1,0 +1,29 @@
+var gulp = require('gulp');
+var sass = require('gulp-sass')(require('sass'));
+var browserSync = require('browser-sync');
+var reload = browserSync.reload;
+
+gulp.task('assets:static', function() {
+    return gulp.src('assets/static/**/*')
+        .pipe(gulp.dest('dist/'))
+        .pipe(browserSync.stream());
+});
+
+gulp.task('assets:futuresdr', function() {
+    return gulp.src('../../frontend/dist/futuresdr*')
+        .pipe(gulp.dest('dist/'))
+        .pipe(browserSync.stream());
+});
+
+gulp.task('assets', gulp.parallel('assets:static', 'assets:futuresdr'));
+gulp.task('default', gulp.parallel('assets'));
+
+gulp.task('serve', function() {
+
+    gulp.watch('assets/static/**/*', gulp.task('assets:static'));
+
+    browserSync({
+        server: './dist',
+        open: false
+    });
+});

--- a/examples/adsb/README.md
+++ b/examples/adsb/README.md
@@ -1,0 +1,12 @@
+# ADS-B Decoder
+
+To start, compile and run ADS-B decoder in one terminal:
+```
+cargo run
+```
+Then start the web server from another terminal:
+```
+gulp
+cd dist && python ../serve.py
+```
+The map is served at http://localhost:8000.

--- a/examples/adsb/assets/static/index.html
+++ b/examples/adsb/assets/static/index.html
@@ -1,0 +1,33 @@
+<html>
+  <head>
+    <title>FutureSDR ADSB Decoder</title>
+    <link rel="stylesheet" href="https://unpkg.com/boxicons@latest/css/boxicons.min.css" crossorigin="" />
+     <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.3/dist/leaflet.css" integrity="sha256-kLaT2GOSpHechhsozzB+flnD+zUyjE2LlfWPgU04xyI=" crossorigin=""/>
+     <script src="https://unpkg.com/leaflet@1.9.3/dist/leaflet.js" integrity="sha256-WBkoXOwTeyKclOHuWtc+i2uENFpDZ9YPdf5Hf+D7ewM=" crossorigin=""></script>
+     <script src="leaflet.rotatedMarker.js"></script>
+     <script src="script.js"></script>
+     <style>
+       html, body {
+           height: 100%;
+           font-size: 12pt;
+       }
+       table {
+           font-size: 1em;
+       }
+       div, body {
+           margin: 0;
+       }
+       #map {
+           height: 100%;
+           width: 100%;
+       }
+       .leaflet-div-icon {
+           background-color: transparent;
+           border: 0;
+       }
+     </style>
+  </head>
+  <body>
+    <div id="map"></div>
+  </body>
+</html>

--- a/examples/adsb/assets/static/leaflet.rotatedMarker.js
+++ b/examples/adsb/assets/static/leaflet.rotatedMarker.js
@@ -1,0 +1,57 @@
+(function() {
+    // save these original methods before they are overwritten
+    var proto_initIcon = L.Marker.prototype._initIcon;
+    var proto_setPos = L.Marker.prototype._setPos;
+
+    var oldIE = (L.DomUtil.TRANSFORM === 'msTransform');
+
+    L.Marker.addInitHook(function () {
+        var iconOptions = this.options.icon && this.options.icon.options;
+        var iconAnchor = iconOptions && this.options.icon.options.iconAnchor;
+        if (iconAnchor) {
+            iconAnchor = (iconAnchor[0] + 'px ' + iconAnchor[1] + 'px');
+        }
+        this.options.rotationOrigin = this.options.rotationOrigin || iconAnchor || 'center bottom' ;
+        this.options.rotationAngle = this.options.rotationAngle || 0;
+
+        // Ensure marker keeps rotated during dragging
+        this.on('drag', function(e) { e.target._applyRotation(); });
+    });
+
+    L.Marker.include({
+        _initIcon: function() {
+            proto_initIcon.call(this);
+        },
+
+        _setPos: function (pos) {
+            proto_setPos.call(this, pos);
+            this._applyRotation();
+        },
+
+        _applyRotation: function () {
+            if(this.options.rotationAngle) {
+                this._icon.style[L.DomUtil.TRANSFORM+'Origin'] = this.options.rotationOrigin;
+
+                if(oldIE) {
+                    // for IE 9, use the 2D rotation
+                    this._icon.style[L.DomUtil.TRANSFORM] = 'rotate(' + this.options.rotationAngle + 'deg)';
+                } else {
+                    // for modern browsers, prefer the 3D accelerated version
+                    this._icon.style[L.DomUtil.TRANSFORM] += ' rotateZ(' + this.options.rotationAngle + 'deg)';
+                }
+            }
+        },
+
+        setRotationAngle: function(angle) {
+            this.options.rotationAngle = angle;
+            this.update();
+            return this;
+        },
+
+        setRotationOrigin: function(origin) {
+            this.options.rotationOrigin = origin;
+            this.update();
+            return this;
+        }
+    });
+})();

--- a/examples/adsb/assets/static/script.js
+++ b/examples/adsb/assets/static/script.js
@@ -1,0 +1,196 @@
+const UPDATE_INTERVAL_MS = 1000;
+
+let autozoom_in_progress = false;
+let autozoom = true;
+let map = null;
+let markers_group = null;
+
+window.onload = (event) => {
+    map = L.map('map').locate({setView: true, maxZoom: 10})
+        .on('locationfound', initialize_aircraft_poll)
+        .on('locationerror', initialize_aircraft_poll);
+    L.tileLayer('https://tile.openstreetmap.org/{z}/{x}/{y}.png', {
+        maxZoom: 19,
+        attribution: '&copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a>'
+    }).addTo(map);
+    markers_group = new L.LayerGroup().addTo(map);
+};
+
+var aeroplane_icon = L.divIcon({
+    html: '<i class="bx bxs-plane" style="font-size: 40"></i>',
+    iconSize: [40, 40],
+    iconAnchor: [20, 20],
+});
+
+
+let aircraft_poll_state = 0;
+function initialize_aircraft_poll() {
+    map.on('zoomstart', function() {
+        if (!autozoom_in_progress) {
+            autozoom = false;
+        }
+    }).on('dragstart', function() {
+        autozoom = false;
+    });
+    aircraft_poll_state = 1;
+    aircraft_poll();
+    setInterval(aircraft_poll, UPDATE_INTERVAL_MS);
+}
+
+let fg = null;
+let tracker_block = null;
+function aircraft_poll() {
+    switch(aircraft_poll_state) {
+    case 0: // uninitialized
+        break;
+    case 1: // Not connected
+        fetch_fg().then((result) => {
+            if(markers_group) {
+                markers_group.clearLayers();
+            }
+            fg = result['fg'];
+            tracker_block = result['tracker_block'];
+            aircraft_poll_state = 2;
+        }).catch((error) => {
+            console.error(error);
+        });
+        break;
+    case 2: // Connected
+        fetch_aircrafts(tracker_block).then((register) => {
+            update_aircrafts(register);
+        }).catch((error) => {
+            console.error(error);
+            aircraft_poll_state = 1;
+        });
+        break;
+    }
+}
+
+let aircraft_markers = {};
+function update_aircrafts(register) {
+    let cur_aircraft_positions = [];
+    for(let icao in register.register) {
+        let value = register.register[icao];
+        if(value.positions.length > 0) {
+            let pos_arr = [];
+            for(let i = 0; i < value.positions.length; i++) {
+                let pos = [value.positions[i].position.latitude,
+                           value.positions[i].position.longitude];
+                if(value.positions[i].position.altitude) {
+                    pos.push(value.positions[i].position.altitude);
+                }
+                pos_arr.push(pos);
+            }
+            let cur_pos = pos_arr[pos_arr.length-1];
+            cur_aircraft_positions.push(cur_pos);
+            let cur_velocity = null;
+            if(value.velocities.length > 0) {
+                cur_velocity = value.velocities[value.velocities.length-1].velocity;
+            }
+            let ground_speed = (cur_velocity && cur_velocity.ground_speed.toFixed(2)) || "N/A";
+            let heading = (cur_velocity && cur_velocity.heading) || "N/A";
+            let vertical_rate = (cur_velocity && cur_velocity.vertical_rate) || "N/A";
+            let vertical_rate_source = (cur_velocity && cur_velocity.vertical_rate_source) || "N/A";
+            let last_updated = new Date(value.last_seen.secs_since_epoch*1e3+value.last_seen.nanos_since_epoch/1e6);
+            let popup_content = `
+                <center><h3>${icao.toUpperCase()}</h3></center>
+                <table>
+                <tr><td>Callsign:</td><td>${value.callsign}</td></tr>
+                <tr><td>Last seen:</td><td>${last_updated.toLocaleString()}</td></tr>
+                <tr><td>Emitter category:</td><td>${value.emitter_category}</td></tr>
+                <tr><td>Altitude:</td><td>${cur_pos[2]} ft</td></tr>
+                <tr><td>Latitude:</td><td>${cur_pos[0].toFixed(4)}</td></tr>
+                <tr><td>Longitude:</td><td>${cur_pos[1].toFixed(4)}</td></tr>
+                <tr><td>Ground speed:</td><td>${ground_speed} kt</td></tr>
+                <tr><td>Vertical rate:</td><td>${vertical_rate} ft/min</td></tr>
+                <tr><td>Vertical rate source:</td><td>${vertical_rate_source}</td></tr>
+                </table>`;
+            let angle = (cur_velocity && cur_velocity.heading) || 0;
+            if(icao in aircraft_markers) {
+                // Update position
+                aircraft_markers[icao].marker
+                    .setLatLng(pos_arr[pos_arr.length-1])
+                    .setRotationAngle(angle)
+                    .setPopupContent(popup_content)
+                    .on("popupopen", (event) => {
+                        aircraft_markers[icao].pathline.setStyle({opacity: 1.0});
+                    })
+                    .on("popupclose", (event) => {
+                        aircraft_markers[icao].pathline.setStyle({opacity: 0.2});
+                    });
+                aircraft_markers[icao].pathline
+                    .setLatLngs(pos_arr);
+            } else {
+                let marker = L.marker(pos_arr[pos_arr.length-1], {
+                    icon: aeroplane_icon,
+                    rotationAngle: angle,
+                })
+                    .bindPopup(popup_content, { minWidth: 300 })
+                    .on("popupopen", (event) => {
+                        aircraft_markers[icao].pathline.setStyle({opacity: 1.0});
+                    })
+                    .on("popupclose", (event) => {
+                        aircraft_markers[icao].pathline.setStyle({opacity: 0.2});
+                    })
+                    .addTo(markers_group);
+                let pathline = L.polyline(pos_arr, {
+                    color: 'red',
+                    opacity: 0.2,
+                }).addTo(markers_group);
+                aircraft_markers[icao] = {
+                    marker: marker,
+                    pathline: pathline,
+                };
+                
+            }
+        }
+    }
+    // Remove the aircraft we had but are not in the new records
+    for(let marker in aircraft_markers) {
+        if(!(marker in register.register)) {
+            // Remove
+            markers_group.removeLayer(aircraft_markers[marker].marker);
+            markers_group.removeLayer(aircraft_markers[marker].pathline);
+            delete aircraft_markers[marker];
+        }
+    }
+
+    
+    if(cur_aircraft_positions.length > 0 && autozoom) {
+        autozoom_in_progress = true;
+        map.flyToBounds(cur_aircraft_positions, { maxZoom: 10 });
+        autozoom_in_progress = false;
+    }
+}
+
+function fetch_aircrafts(tracker_block) {
+    let ctrl_port = tracker_block.message_inputs.indexOf("ctrl_port");
+    let url = `http://localhost:1337/api/fg/0/block/${tracker_block.id}/call/${ctrl_port}/`;
+    let promise = fetch(url).then((response) => {
+        if (!response.ok) {
+            throw new Error(`HTTP error! Status: ${response.status}`);
+        }
+        return response.json();
+    }).then((response) => {
+        return JSON.parse(response.String);
+    });
+    return promise;
+}
+
+function fetch_fg() {
+    let promise = fetch('http://localhost:1337/api/fg/0/').then((response) => {
+        if (!response.ok) {
+            throw new Error(`HTTP error! Status: ${response.status}`);
+        }
+        return response.json();
+    }).then((response) => {
+        fg = response;
+        for(let i = 0; i < fg.blocks.length; i++) {
+            if(fg.blocks[i].type_name == "Tracker") {
+                tracker_block = fg.blocks[i];
+            }
+        }
+        return {'fg': fg, 'tracker_block': tracker_block};
+    });
+    return promise;
+}

--- a/examples/adsb/config.toml
+++ b/examples/adsb/config.toml
@@ -1,0 +1,3 @@
+log_level = "info"
+ctrlport_enable = true
+ctrlport_bind = "127.0.0.1:1337"

--- a/examples/adsb/package.json
+++ b/examples/adsb/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "futuresdr-adsb-decoder",
+  "version": "0.0.1",
+  "description": "FutureSDR ADS-B decoder",
+  "browserslist": [
+    "defaults"
+  ],
+  "dependencies": {
+    "browser-sync": "^2.27.11",
+    "gulp": "^4.0.2",
+    "gulp-sass": "^5.1.0",
+    "sass": "^1.57.1"
+  }
+}

--- a/examples/adsb/serve.py
+++ b/examples/adsb/serve.py
@@ -1,0 +1,13 @@
+#!/usr/bin/env python3
+from http.server import HTTPServer, SimpleHTTPRequestHandler, test
+import sys
+
+class CORSRequestHandler (SimpleHTTPRequestHandler):
+    def end_headers (self):
+        self.send_header('Access-Control-Allow-Origin', '*')
+        #self.send_header('Cross-Origin-Embedder-Policy', 'require-corp')
+        self.send_header('Cross-Origin-Opener-Policy', 'same-origin')
+        SimpleHTTPRequestHandler.end_headers(self)
+
+if __name__ == '__main__':
+    test(CORSRequestHandler, HTTPServer, port=int(sys.argv[1]) if len(sys.argv) > 1 else 8000)

--- a/examples/adsb/src/bin/listen_adsb.rs
+++ b/examples/adsb/src/bin/listen_adsb.rs
@@ -1,0 +1,142 @@
+use adsb_demod::Decoder;
+use adsb_demod::Demodulator;
+use adsb_demod::PreambleDetector;
+use adsb_demod::Tracker;
+use adsb_demod::DEMOD_SAMPLE_RATE;
+use clap::Parser;
+use futuresdr::anyhow::Result;
+use futuresdr::blocks::Apply;
+use futuresdr::blocks::FileSource;
+use futuresdr::blocks::FirBuilder;
+use futuresdr::blocks::SoapySourceBuilder;
+use futuresdr::blocks::Throttle;
+use futuresdr::log::{warn, LevelFilter};
+use futuresdr::num_complex::Complex32;
+use futuresdr::num_integer;
+use futuresdr::runtime::Flowgraph;
+use futuresdr::runtime::Runtime;
+use std::time::Duration;
+
+#[derive(Parser, Debug)]
+#[clap(version)]
+struct Args {
+    /// Antenna
+    #[clap(short, long)]
+    antenna: Option<String>,
+    /// Soapy Filter
+    #[clap(short, long)]
+    filter: Option<String>,
+    /// Gain
+    #[clap(short, long, default_value_t = 30.0)]
+    gain: f64,
+    /// Sample rate
+    #[clap(short, long, default_value_t = 2.2e6, value_parser = sample_rate_parser)]
+    sample_rate: f64,
+    /// Preamble detection threshold
+    #[clap(short, long, default_value_t = 10.0)]
+    preamble_threshold: f32,
+    /// Use a file instead of a device
+    #[clap(short, long)]
+    file: Option<String>,
+    /// Remove aircrafts when no packets have been received for the specified number of seconds
+    #[clap(short, long)]
+    lifetime: Option<u64>,
+}
+
+fn sample_rate_parser(sample_rate_str: &str) -> Result<f64, String> {
+    let sample_rate: f64 = sample_rate_str
+        .parse()
+        .map_err(|_| format!("`{sample_rate_str}` is not a valid sample rate"))?;
+    // Sample rate must be at least 2 MHz
+    if sample_rate < 2e6 {
+        Err("Sample rate must be at least 2 MHz".to_string())
+    } else {
+        Ok(sample_rate)
+    }
+}
+
+fn main() -> Result<()> {
+    let mut builder = env_logger::Builder::from_default_env();
+    builder.filter(None, LevelFilter::Info).init();
+
+    let args = Args::parse();
+    let mut fg = Flowgraph::new();
+
+    let src = match args.file {
+        Some(f) => {
+            let file_src_block = fg.add_block(FileSource::<Complex32>::new(f, false));
+            let throttle_block = fg.add_block(Throttle::<Complex32>::new(args.sample_rate));
+            fg.connect_stream(file_src_block, "out", throttle_block, "in")?;
+            throttle_block
+        }
+        None => {
+            // Load soapy source
+            let mut soapy_src = SoapySourceBuilder::new()
+                .freq(1090e6)
+                .sample_rate(args.sample_rate)
+                .gain(args.gain);
+            if let Some(a) = args.antenna {
+                soapy_src = soapy_src.antenna(a);
+            }
+            if let Some(f) = args.filter {
+                soapy_src = soapy_src.filter(f);
+            }
+            fg.add_block(soapy_src.build())
+        }
+    };
+
+    // Change sample rate to our demodulator sample rate.
+    // Using a sample rate higher than the signal bandwidth allows
+    // us to use a simple symbol synchronization mechanism and have
+    // more clear symbol transitions.
+    let gcd = num_integer::gcd(args.sample_rate as usize, DEMOD_SAMPLE_RATE);
+    let interp = DEMOD_SAMPLE_RATE / gcd;
+    let decim = args.sample_rate as usize / gcd;
+    if interp > 100 || decim > 100 {
+        warn!(
+            "Warning: Interpolation/decimation factor is large. \
+             Use a sampling frequency that is a divisor of {DEMOD_SAMPLE_RATE} for the best performance."
+        );
+    }
+    let interp_block = fg.add_block(FirBuilder::new_resampling::<Complex32, Complex32>(
+        interp, decim,
+    ));
+    fg.connect_stream(src, "out", interp_block, "in")?;
+
+    let complex_to_mag_2 = fg.add_block(Apply::new(|i: &Complex32| i.norm_sqr()));
+    fg.connect_stream(interp_block, "out", complex_to_mag_2, "in")?;
+
+    let nf_est_block = fg.add_block(FirBuilder::new::<f32, f32, _, _>(vec![1.0f32 / 32.0; 32]));
+    fg.connect_stream(complex_to_mag_2, "out", nf_est_block, "in")?;
+
+    let preamble_taps: Vec<f32> = PreambleDetector::preamble_correlator_taps();
+    let preamble_corr_block = fg.add_block(FirBuilder::new::<f32, f32, _, _>(preamble_taps));
+    fg.connect_stream(complex_to_mag_2, "out", preamble_corr_block, "in")?;
+
+    let preamble_detector = fg.add_block(PreambleDetector::new(args.preamble_threshold));
+    fg.connect_stream(complex_to_mag_2, "out", preamble_detector, "in_samples")?;
+    fg.connect_stream(nf_est_block, "out", preamble_detector, "in_nf")?;
+    fg.connect_stream(
+        preamble_corr_block,
+        "out",
+        preamble_detector,
+        "in_preamble_corr",
+    )?;
+
+    let adsb_demod = fg.add_block(Demodulator::new());
+    fg.connect_stream(preamble_detector, "out", adsb_demod, "in")?;
+
+    let adsb_decoder = fg.add_block(Decoder::new(false));
+    fg.connect_message(adsb_demod, "out", adsb_decoder, "in")?;
+
+    let tracker = match args.lifetime {
+        Some(s) => Tracker::with_pruning(Duration::from_secs(s)),
+        None => Tracker::new(),
+    };
+    let adsb_tracker = fg.add_block(tracker);
+    fg.connect_message(adsb_decoder, "out", adsb_tracker, "in")?;
+
+    Runtime::new().run(fg)?;
+
+    Ok(())
+}

--- a/examples/adsb/src/bin/listen_adsb.rs
+++ b/examples/adsb/src/bin/listen_adsb.rs
@@ -3,7 +3,7 @@ use adsb_demod::Demodulator;
 use adsb_demod::PreambleDetector;
 use adsb_demod::Tracker;
 use adsb_demod::DEMOD_SAMPLE_RATE;
-use clap::Parser;
+use clap::{command, Parser};
 use futuresdr::anyhow::Result;
 use futuresdr::blocks::Apply;
 use futuresdr::blocks::FileSource;
@@ -18,28 +18,28 @@ use futuresdr::runtime::Runtime;
 use std::time::Duration;
 
 #[derive(Parser, Debug)]
-#[clap(version)]
+#[command(version)]
 struct Args {
     /// Antenna
-    #[clap(short, long)]
+    #[arg(short, long)]
     antenna: Option<String>,
     /// Soapy Filter
-    #[clap(short, long)]
+    #[arg(long)]
     filter: Option<String>,
     /// Gain
-    #[clap(short, long, default_value_t = 30.0)]
+    #[arg(short, long, default_value_t = 30.0)]
     gain: f64,
     /// Sample rate
-    #[clap(short, long, default_value_t = 2.2e6, value_parser = sample_rate_parser)]
+    #[arg(short, long, default_value_t = 2.2e6, value_parser = sample_rate_parser)]
     sample_rate: f64,
     /// Preamble detection threshold
-    #[clap(short, long, default_value_t = 10.0)]
+    #[arg(short, long, default_value_t = 10.0)]
     preamble_threshold: f32,
     /// Use a file instead of a device
-    #[clap(short, long)]
+    #[arg(short, long)]
     file: Option<String>,
     /// Remove aircrafts when no packets have been received for the specified number of seconds
-    #[clap(short, long)]
+    #[arg(short, long)]
     lifetime: Option<u64>,
 }
 

--- a/examples/adsb/src/decoder.rs
+++ b/examples/adsb/src/decoder.rs
@@ -1,0 +1,163 @@
+use crate::DemodPacket;
+use adsb_deku::deku::DekuContainerRead;
+use futuresdr::anyhow::{bail, Result};
+use futuresdr::async_trait::async_trait;
+use futuresdr::futures::FutureExt;
+use futuresdr::log::{debug, info, warn};
+use futuresdr::runtime::Block;
+use futuresdr::runtime::BlockMeta;
+use futuresdr::runtime::BlockMetaBuilder;
+use futuresdr::runtime::Kernel;
+use futuresdr::runtime::MessageIo;
+use futuresdr::runtime::MessageIoBuilder;
+use futuresdr::runtime::StreamIoBuilder;
+use futuresdr_pmt::Pmt;
+use serde::Serialize;
+use std::future::Future;
+use std::pin::Pin;
+use std::time::SystemTime;
+
+fn bin_to_u64(s: &[u8]) -> u64 {
+    s.iter().fold(0, |acc, &b| (acc << 1) + b as u64)
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct DecoderMetaData {
+    pub preamble_index: u64,
+    pub preamble_correlation: f32,
+    pub crc_passed: bool,
+    pub timestamp: SystemTime,
+}
+
+#[derive(Debug, Clone)]
+pub struct AdsbPacket {
+    pub message: adsb_deku::Frame,
+    pub decoder_metadata: DecoderMetaData,
+}
+
+pub struct Decoder {
+    forward_failed_crc: bool,
+    n_crc_ok: u64,
+    n_crc_fail: u64,
+}
+
+impl Decoder {
+    #[allow(clippy::new_ret_no_self)]
+    pub fn new(forward_failed_crc: bool) -> Block {
+        Block::new(
+            BlockMetaBuilder::new("Decoder").build(),
+            StreamIoBuilder::new().build(),
+            MessageIoBuilder::new()
+                .add_input("in", Self::packet_received)
+                .add_output("out")
+                .build(),
+            Self {
+                forward_failed_crc,
+                n_crc_ok: 0,
+                n_crc_fail: 0,
+            },
+        )
+    }
+
+    /// Checks if the CRC is valid
+    fn check_crc(&self, bits: &[u8]) -> bool {
+        let mut bits = bits.to_vec();
+        const GENERATOR_POLY: [u8; 25] = [
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 1,
+        ];
+        for i in 0..bits.len() - (GENERATOR_POLY.len() - 1) {
+            if bits[i] == 1 {
+                for j in 0..GENERATOR_POLY.len() {
+                    bits[i + j] ^= GENERATOR_POLY[j];
+                }
+            }
+        }
+        bits[(bits.len() - (GENERATOR_POLY.len() - 1))..bits.len()]
+            .iter()
+            .sum::<u8>()
+            == 0
+    }
+
+    /// Decodes demodulated packet bits
+    fn decode_packet(
+        &self,
+        packet: &DemodPacket,
+        crc_passed: bool,
+        timestamp: SystemTime,
+    ) -> Result<AdsbPacket> {
+        let decoder_metadata = DecoderMetaData {
+            preamble_index: packet.preamble_index,
+            preamble_correlation: packet.preamble_correlation,
+            crc_passed,
+            timestamp,
+        };
+        // Decode downlink format
+        let bytes: Vec<u8> = (0..packet.bits.len())
+            .step_by(8)
+            .map(|i| bin_to_u64(&packet.bits[i..i + 8]) as u8)
+            .collect();
+        match adsb_deku::Frame::from_bytes((&bytes, 0)) {
+            Ok((_, message)) => {
+                let packet = AdsbPacket {
+                    message,
+                    decoder_metadata,
+                };
+                Ok(packet)
+            }
+            Err(_) => bail!("adsb_deku could not parse packet"),
+        }
+    }
+
+    fn packet_received<'a>(
+        &'a mut self,
+        mio: &'a mut MessageIo<Self>,
+        _meta: &'a mut BlockMeta,
+        p: Pmt,
+    ) -> Pin<Box<dyn Future<Output = Result<Pmt>> + Send + 'a>> {
+        async move {
+            match p {
+                Pmt::Any(a) => {
+                    if let Some(pkt) = a.downcast_ref::<DemodPacket>()
+                    {
+                        // Validate the CRC before we start decoding
+                        let crc_passed = self.check_crc(&pkt.bits);
+                        if crc_passed {
+                            self.n_crc_ok += 1;
+                            debug!(
+                                "Decoded packet with CRC OK (index: {}, preamble correlation: {}, data: {:?})",
+                                pkt.preamble_index, pkt.preamble_correlation, pkt.bits
+                            );
+                        } else {
+                            self.n_crc_fail += 1;
+                            debug!(
+                                "Decoded packet with CRC error (index: {}, preamble correlation: {}, data: {:?})",
+                                pkt.preamble_index, pkt.preamble_correlation, pkt.bits
+                            );
+                        }
+
+                        if crc_passed || self.forward_failed_crc {
+                            match self.decode_packet(
+                                pkt,
+                                crc_passed,
+                                SystemTime::now(),
+                            ) {
+                                Ok(decoded_packet) => {
+                                    mio.output_mut(0).post(Pmt::Any(Box::new(decoded_packet))).await
+                                }
+                                _ => info!("Could not decode packet despite valid CRC"),
+                            }
+                        }
+                    }
+                }
+                x => {
+                    warn!("Received unexpected PMT type: {:?}", x);
+                }
+            }
+            Ok(Pmt::Null)
+        }
+        .boxed()
+    }
+}
+
+#[async_trait]
+impl Kernel for Decoder {}

--- a/examples/adsb/src/demodulator.rs
+++ b/examples/adsb/src/demodulator.rs
@@ -1,0 +1,108 @@
+use crate::{N_SAMPLES_PER_HALF_SYM, SYMBOL_ONE_TAPS, SYMBOL_ZERO_TAPS};
+use futuresdr::anyhow::Result;
+use futuresdr::async_trait::async_trait;
+use futuresdr::runtime::Block;
+use futuresdr::runtime::BlockMeta;
+use futuresdr::runtime::BlockMetaBuilder;
+use futuresdr::runtime::Kernel;
+use futuresdr::runtime::MessageIo;
+use futuresdr::runtime::MessageIoBuilder;
+use futuresdr::runtime::StreamIo;
+use futuresdr::runtime::StreamIoBuilder;
+use futuresdr::runtime::Tag;
+use futuresdr::runtime::WorkIo;
+use futuresdr_pmt::Pmt;
+
+#[derive(Clone, Debug)]
+pub struct DemodPacket {
+    pub preamble_index: u64,
+    pub preamble_correlation: f32,
+    pub bits: Vec<u8>,
+}
+
+pub struct Demodulator {
+    n_received: u64,
+}
+
+impl Demodulator {
+    #[allow(clippy::new_ret_no_self)]
+    pub fn new() -> Block {
+        Block::new(
+            BlockMetaBuilder::new("Demodulator").build(),
+            StreamIoBuilder::new().add_input::<f32>("in").build(),
+            MessageIoBuilder::new().add_output("out").build(),
+            Self { n_received: 0 },
+        )
+    }
+}
+
+#[async_trait]
+impl Kernel for Demodulator {
+    async fn work(
+        &mut self,
+        io: &mut WorkIo,
+        sio: &mut StreamIo,
+        mio: &mut MessageIo<Self>,
+        _meta: &mut BlockMeta,
+    ) -> Result<()> {
+        let samples = sio.input(0).slice::<f32>();
+        let tags = sio.input(0).tags();
+        let out = mio.output_mut(0);
+
+        let max_packet_len_samples: usize = 120 * 2 * N_SAMPLES_PER_HALF_SYM;
+        let max_packet_data_len_bits: usize = 112;
+        let preamble_len_samples: usize = 8 * 2 * N_SAMPLES_PER_HALF_SYM;
+
+        // Search for preamble_start tags
+        for tagitem in tags {
+            if tagitem.index + max_packet_len_samples < samples.len() {
+                let result = match &tagitem.tag {
+                    Tag::NamedF32(k, preamble_corr) if k == "preamble_start" => {
+                        let bits: Vec<u8> = (0..max_packet_data_len_bits)
+                            .map(|symbol_idx| {
+                                // Demodulate by correlating with 1 or 0 PPM symbols
+                                let symbol_start_idx = tagitem.index
+                                    + preamble_len_samples
+                                    + symbol_idx * 2 * N_SAMPLES_PER_HALF_SYM;
+                                let symbol_end_idx = symbol_start_idx + 2 * N_SAMPLES_PER_HALF_SYM;
+                                let corr = samples[symbol_start_idx..symbol_end_idx]
+                                    .iter()
+                                    .enumerate()
+                                    .fold((0.0f32, 0.0f32), |acc, (i, sample)| {
+                                        (
+                                            acc.0 + sample * SYMBOL_ZERO_TAPS[i],
+                                            acc.1 + sample * SYMBOL_ONE_TAPS[i],
+                                        )
+                                    });
+                                match corr.0 > corr.1 {
+                                    true => 0,
+                                    false => 1,
+                                }
+                            })
+                            .collect();
+                        Some(DemodPacket {
+                            preamble_index: self.n_received + tagitem.index as u64,
+                            preamble_correlation: *preamble_corr,
+                            bits,
+                        })
+                    }
+                    _ => None,
+                };
+                if let Some(r) = result {
+                    out.post(Pmt::Any(Box::new(r))).await;
+                }
+            }
+        }
+
+        if samples.len() >= max_packet_len_samples {
+            sio.input(0).consume(samples.len() - max_packet_len_samples);
+            self.n_received += (samples.len() - max_packet_len_samples) as u64;
+        }
+
+        if sio.input(0).finished() {
+            io.finished = true;
+        }
+
+        Ok(())
+    }
+}

--- a/examples/adsb/src/lib.rs
+++ b/examples/adsb/src/lib.rs
@@ -1,0 +1,104 @@
+//! An ADS-B receiver
+use serde::Serialize;
+use serde_with::{serde_as, DisplayFromStr};
+use std::collections::HashMap;
+use std::time::SystemTime;
+
+/// Demodulator sample rate
+pub const DEMOD_SAMPLE_RATE: usize = 4000000;
+/// Number of samples per PPM half-symbol at `DEMOD_SAMPLE_RATE`.
+pub const N_SAMPLES_PER_HALF_SYM: usize = DEMOD_SAMPLE_RATE / 2000000;
+/// Taps representing a HIGH symbol
+pub const SYMBOL_ONE_TAPS: [f32; 2 * N_SAMPLES_PER_HALF_SYM] = [1.0, 1.0, -1.0, -1.0];
+/// Taps representing a LOW symbol
+pub const SYMBOL_ZERO_TAPS: [f32; 2 * N_SAMPLES_PER_HALF_SYM] = [-1.0, -1.0, 1.0, 1.0];
+
+mod preamble_detector;
+pub use preamble_detector::PreambleDetector;
+
+mod demodulator;
+pub use demodulator::DemodPacket;
+pub use demodulator::Demodulator;
+
+mod decoder;
+pub use decoder::AdsbPacket;
+pub use decoder::Decoder;
+
+mod tracker;
+pub use tracker::Tracker;
+
+type AdsbIcao = adsb_deku::ICAO;
+type AdsbIdentification = adsb_deku::adsb::Identification;
+type AdsbPosition = adsb_deku::Altitude;
+type AdsbVelocity = adsb_deku::adsb::AirborneVelocity;
+
+/// Represents the position of an aircraft.
+#[derive(Serialize, Clone, Debug)]
+pub struct AircraftPosition {
+    pub latitude: f64,
+    pub longitude: f64,
+    pub altitude: Option<u16>,
+    pub type_code: u8,
+}
+
+/// Represents the source of the vertical rate.
+#[derive(Serialize, Clone, Debug)]
+pub enum AircraftVerticalRateSource {
+    BarometricPressureAltitude,
+    GeometricAltitude,
+}
+
+/// Represents the velocity of an aircraft.
+#[derive(Serialize, Clone, Debug)]
+pub struct AircraftVelocity {
+    pub heading: f64,
+    pub ground_speed: f64,
+    pub vertical_rate: i16,
+    pub vertical_rate_source: AircraftVerticalRateSource,
+}
+
+/// Represents a received position of an aircraft.
+#[derive(Serialize, Clone, Debug)]
+pub struct AircraftPositionRecord {
+    pub position: AircraftPosition,
+    pub time: SystemTime,
+}
+
+/// Represents a received velocity of an aircraft.
+#[derive(Serialize, Clone, Debug)]
+pub struct AircraftVelocityRecord {
+    pub velocity: AircraftVelocity,
+    pub time: SystemTime,
+}
+
+/// Represents a received CPR frame.
+#[derive(Clone, Debug)]
+pub struct CprFrameRecord {
+    pub cpr_frame: AdsbPosition,
+    pub time: SystemTime,
+}
+
+/// Represents a summary of the received information about an aircraft.
+#[serde_as]
+#[derive(Serialize, Clone, Debug)]
+pub struct AircraftRecord {
+    #[serde_as(as = "DisplayFromStr")]
+    pub icao: AdsbIcao,
+    pub callsign: Option<String>,
+    pub emitter_category: Option<u8>,
+    pub positions: Vec<AircraftPositionRecord>,
+    pub velocities: Vec<AircraftVelocityRecord>,
+    #[serde(skip)]
+    pub last_cpr_even: Option<CprFrameRecord>,
+    #[serde(skip)]
+    pub last_cpr_odd: Option<CprFrameRecord>,
+    pub last_seen: SystemTime,
+}
+
+/// Represents a collection of received aircrafts.
+#[serde_as]
+#[derive(Serialize, Clone, Debug)]
+pub struct AircraftRegister {
+    #[serde_as(as = "HashMap<DisplayFromStr, _>")]
+    register: HashMap<AdsbIcao, AircraftRecord>,
+}

--- a/examples/adsb/src/preamble_detector.rs
+++ b/examples/adsb/src/preamble_detector.rs
@@ -1,0 +1,142 @@
+use crate::N_SAMPLES_PER_HALF_SYM;
+use futuresdr::anyhow::Result;
+use futuresdr::async_trait::async_trait;
+use futuresdr::runtime::Block;
+use futuresdr::runtime::BlockMeta;
+use futuresdr::runtime::BlockMetaBuilder;
+use futuresdr::runtime::Kernel;
+use futuresdr::runtime::MessageIo;
+use futuresdr::runtime::MessageIoBuilder;
+use futuresdr::runtime::StreamIo;
+use futuresdr::runtime::StreamIoBuilder;
+use futuresdr::runtime::Tag;
+use futuresdr::runtime::WorkIo;
+
+pub struct PreambleDetector {
+    detection_threshold: f32,
+}
+
+impl PreambleDetector {
+    pub const PREAMBLE: [f32; 16] = [
+        1.0f32, -1.0f32, // Symbol 1
+        1.0f32, -1.0f32, // Symbol 2
+        -1.0f32, -1.0f32, // ...
+        -1.0f32, 1.0f32, //
+        -1.0f32, 1.0f32, //
+        -1.0f32, -1.0f32, //
+        -1.0f32, -1.0f32, //
+        -1.0f32, -1.0f32, // Symbol 8
+    ];
+
+    /// Returns taps for the preamble correlation filter
+    pub fn preamble_correlator_taps() -> Vec<f32> {
+        PreambleDetector::PREAMBLE
+            .into_iter()
+            .rev()
+            .flat_map(|n| std::iter::repeat(n).take(N_SAMPLES_PER_HALF_SYM))
+            .collect()
+    }
+
+    #[allow(clippy::new_ret_no_self)]
+    pub fn new(detection_threshold: f32) -> Block {
+        Block::new(
+            BlockMetaBuilder::new("PreambleDetector").build(),
+            StreamIoBuilder::new()
+                .add_input::<f32>("in_samples")
+                .add_input::<f32>("in_nf")
+                .add_input::<f32>("in_preamble_corr")
+                .add_output::<f32>("out")
+                .build(),
+            MessageIoBuilder::new().build(),
+            Self {
+                detection_threshold,
+            },
+        )
+    }
+}
+
+#[async_trait]
+impl Kernel for PreambleDetector {
+    async fn work(
+        &mut self,
+        io: &mut WorkIo,
+        sio: &mut StreamIo,
+        _mio: &mut MessageIo<Self>,
+        _meta: &mut BlockMeta,
+    ) -> Result<()> {
+        let samples = sio.input(0).slice::<f32>();
+        let nf = sio.input(1).slice::<f32>();
+        let corr = sio.input(2).slice::<f32>();
+        let out = sio.output(0).slice::<f32>();
+
+        let samples_to_read = [samples.len(), nf.len(), corr.len(), out.len()]
+            .iter()
+            .min()
+            .copied()
+            .unwrap();
+        let samples_to_read = std::cmp::max(
+            0,
+            samples_to_read as isize - 2 * 16 * N_SAMPLES_PER_HALF_SYM as isize,
+        ) as usize; // Ensure we have enough samples to find the peak
+        let mut num_read = 0;
+        while num_read < samples_to_read {
+            if corr[num_read] > self.detection_threshold * nf[num_read] {
+                // We detected a preamble. Now find the index that gives the highest correlation.
+                let mut max_corr = corr[num_read] / nf[num_read];
+                let mut max_corr_idx = num_read;
+                for _i in 1..16 * N_SAMPLES_PER_HALF_SYM {
+                    out[num_read] = samples[num_read];
+                    num_read += 1;
+                    // Check if we have a new highest peak
+                    if corr[num_read] / nf[num_read] > max_corr {
+                        max_corr = corr[num_read] / nf[num_read];
+                        max_corr_idx = num_read;
+                    }
+                }
+                // Do an extra sanity check to get rid of noise-triggered preambles.
+                // This seems to filter quite well.
+                // Calculate the power of each of the high half-symbols.
+                let high_pwr = [0, 2, 7, 9].iter().map(|i| {
+                    samples[max_corr_idx + i * N_SAMPLES_PER_HALF_SYM
+                        ..max_corr_idx + (i + 1) * N_SAMPLES_PER_HALF_SYM]
+                        .iter()
+                        .sum::<f32>()
+                });
+                // Calculate the power of each of the low half-symbols.
+                let low_pwr = [1, 3, 4, 5, 6, 8, 10, 11, 12, 13, 14, 15].iter().map(|i| {
+                    samples[max_corr_idx + i * N_SAMPLES_PER_HALF_SYM
+                        ..max_corr_idx + (i + 1) * N_SAMPLES_PER_HALF_SYM]
+                        .iter()
+                        .sum::<f32>()
+                });
+                let min_high_pwr = high_pwr.clone().reduce(f32::min).unwrap();
+                let max_high_pwr = high_pwr.reduce(f32::max).unwrap();
+                let max_low_pwr = low_pwr.reduce(f32::max).unwrap();
+                // The minimum power of the high half-symbols should not be too far from
+                // the maximum high power, and the maximum power of the low half-symbols
+                // should be less than the maximum high power.
+                if min_high_pwr > 0.1 * max_high_pwr && max_low_pwr < max_high_pwr {
+                    // Tag preamble.
+                    sio.output(0).add_tag(
+                        max_corr_idx,
+                        Tag::NamedF32("preamble_start".to_string(), max_corr),
+                    );
+                }
+            } else {
+                out[num_read] = samples[num_read];
+                num_read += 1;
+            }
+        }
+
+        sio.input(0).consume(num_read);
+        sio.input(1).consume(num_read);
+        sio.input(2).consume(num_read);
+        sio.output(0).produce(num_read);
+
+        if sio.input(0).finished() || sio.input(1).finished() || sio.input(2).finished() {
+            io.finished = true;
+        }
+
+        Ok(())
+    }
+}

--- a/examples/adsb/src/tracker.rs
+++ b/examples/adsb/src/tracker.rs
@@ -1,0 +1,298 @@
+use crate::decoder::{AdsbPacket, DecoderMetaData};
+use futuresdr::anyhow::Result;
+use futuresdr::async_io::Timer;
+use futuresdr::async_trait::async_trait;
+use futuresdr::futures::FutureExt;
+use futuresdr::log::{info, warn};
+use futuresdr::runtime::Block;
+use futuresdr::runtime::BlockMeta;
+use futuresdr::runtime::BlockMetaBuilder;
+use futuresdr::runtime::Kernel;
+use futuresdr::runtime::MessageIo;
+use futuresdr::runtime::MessageIoBuilder;
+use futuresdr::runtime::StreamIo;
+use futuresdr::runtime::StreamIoBuilder;
+use futuresdr::runtime::WorkIo;
+use futuresdr_pmt::Pmt;
+
+use std::cmp::Ordering;
+use std::collections::HashMap;
+use std::future::Future;
+use std::pin::Pin;
+use std::time::{Duration, SystemTime};
+
+use crate::*;
+
+/// The duration considered to be recent when decoding CPR frames
+const ADSB_TIME_RECENT: Duration = Duration::new(10, 0);
+
+pub struct Tracker {
+    /// When to prune aircraft from the register.
+    prune_after: Option<Duration>,
+    /// A register of the received aircrafts.
+    aircraft_register: AircraftRegister,
+}
+
+impl Tracker {
+    /// Creates a new tracker without pruning.
+    #[allow(clippy::new_ret_no_self)]
+    pub fn new() -> Block {
+        Tracker::new_with_optional_args(None)
+    }
+
+    pub fn with_pruning(after: Duration) -> Block {
+        Tracker::new_with_optional_args(Some(after))
+    }
+
+    fn new_with_optional_args(prune_after: Option<Duration>) -> Block {
+        let aircraft_register = AircraftRegister {
+            register: HashMap::new(),
+        };
+        Block::new(
+            BlockMetaBuilder::new("Tracker").build(),
+            StreamIoBuilder::new().build(),
+            MessageIoBuilder::new()
+                .add_input("in", Self::packet_received)
+                .add_input("ctrl_port", Self::handle_ctrl_port)
+                .build(),
+            Self {
+                prune_after,
+                aircraft_register,
+            },
+        )
+    }
+
+    /// This function handles control port messages.
+    fn handle_ctrl_port<'a>(
+        &'a mut self,
+        _mio: &'a mut MessageIo<Self>,
+        _meta: &'a mut BlockMeta,
+        p: Pmt,
+    ) -> Pin<Box<dyn Future<Output = Result<Pmt>> + Send + 'a>> {
+        async move {
+            match p {
+                Pmt::Null => {
+                    // Reply with register
+                    let json = serde_json::to_string(&self.aircraft_register).unwrap();
+                    Ok(Pmt::String(json))
+                }
+                x => {
+                    warn!("Received unexpected PMT type: {:?}", x);
+                    Ok(Pmt::Null)
+                }
+            }
+        }
+        .boxed()
+    }
+
+    /// This function handles received packets passed to the block.
+    fn packet_received<'a>(
+        &'a mut self,
+        _mio: &'a mut MessageIo<Self>,
+        _meta: &'a mut BlockMeta,
+        p: Pmt,
+    ) -> Pin<Box<dyn Future<Output = Result<Pmt>> + Send + 'a>> {
+        async move {
+            match p {
+                Pmt::Any(a) => {
+                    if let Some(adsb_packet) = a.downcast_ref::<AdsbPacket>() {
+                        // We received a packet. Update the register.
+                        info!("Received {:?}", adsb_packet);
+                        if let adsb_deku::DF::ADSB(adsb) = &adsb_packet.message.df {
+                            let metadata = &adsb_packet.decoder_metadata;
+                            match &adsb.me {
+                                adsb_deku::adsb::ME::AircraftIdentification(identification) => self
+                                    .aircraft_identification_received(
+                                        &adsb.icao,
+                                        identification,
+                                        metadata,
+                                    ),
+                                adsb_deku::adsb::ME::AirbornePositionBaroAltitude(altitude)
+                                | adsb_deku::adsb::ME::AirbornePositionGNSSAltitude(altitude) => {
+                                    self.airborne_position_received(&adsb.icao, altitude, metadata)
+                                }
+                                adsb_deku::adsb::ME::AirborneVelocity(velocity) => {
+                                    self.airborne_velocity_received(&adsb.icao, velocity, metadata)
+                                }
+                                _ => (),
+                            }
+                        }
+                    }
+                }
+                x => {
+                    warn!("Received unexpected PMT type: {:?}", x);
+                }
+            }
+            Ok(Pmt::Null)
+        }
+        .boxed()
+    }
+
+    fn update_last_seen(&mut self, icao: &AdsbIcao) {
+        if let Some(rec) = self.aircraft_register.register.get_mut(icao) {
+            // Update the time stamp in the register record
+            rec.last_seen = SystemTime::now();
+        }
+    }
+
+    fn register_aircraft(&mut self, icao: &AdsbIcao) {
+        // Add an aircraft record to our register map
+        let now = SystemTime::now();
+        let record = AircraftRecord {
+            icao: *icao,
+            callsign: None,
+            emitter_category: None,
+            positions: Vec::new(),
+            velocities: Vec::new(),
+            last_cpr_even: None,
+            last_cpr_odd: None,
+            last_seen: now,
+        };
+        if self.aircraft_register.register.contains_key(icao) {
+            warn!("Aircraft {} is already registered and will be reset", icao);
+        }
+        self.aircraft_register.register.insert(*icao, record);
+    }
+
+    fn prune_records(&mut self) {
+        if let Some(prune_time) = self.prune_after {
+            let now = SystemTime::now();
+            self.aircraft_register
+                .register
+                .retain(|_, v| v.last_seen + prune_time >= now);
+        }
+    }
+
+    fn aircraft_identification_received(
+        &mut self,
+        icao: &AdsbIcao,
+        identification: &AdsbIdentification,
+        _metadata: &DecoderMetaData,
+    ) {
+        if !self.aircraft_register.register.contains_key(icao) {
+            self.register_aircraft(icao);
+        }
+        let rec = self.aircraft_register.register.get_mut(icao).unwrap();
+        rec.callsign = Some(identification.cn.clone());
+        rec.emitter_category = Some(identification.ca);
+        self.update_last_seen(icao);
+    }
+
+    fn airborne_position_received(
+        &mut self,
+        icao: &AdsbIcao,
+        altitude: &AdsbPosition,
+        _metadata: &DecoderMetaData,
+    ) {
+        if !self.aircraft_register.register.contains_key(icao) {
+            self.register_aircraft(icao);
+        }
+        let now = SystemTime::now();
+        let rec = self.aircraft_register.register.get_mut(icao).unwrap();
+
+        // Update record
+        let cpr_rec = CprFrameRecord {
+            cpr_frame: *altitude,
+            time: now,
+        };
+        match altitude.odd_flag {
+            adsb_deku::CPRFormat::Even => rec.last_cpr_even = Some(cpr_rec),
+            adsb_deku::CPRFormat::Odd => rec.last_cpr_odd = Some(cpr_rec),
+        }
+
+        // Check if we can calculate the position. This requires both an odd
+        // and an even frame.
+        // Make rec immutable
+        let rec = self.aircraft_register.register.get(icao).unwrap();
+        if rec.last_cpr_even.is_some() && rec.last_cpr_odd.is_some() {
+            // The frames must be recent
+            let even_cpr_rec = rec.last_cpr_even.as_ref().unwrap();
+            let odd_cpr_rec = rec.last_cpr_odd.as_ref().unwrap();
+            if even_cpr_rec.time < now + ADSB_TIME_RECENT
+                && odd_cpr_rec.time < now + ADSB_TIME_RECENT
+            {
+                // The CPR frames must be orderd by time
+                let (cpr1, cpr2) = match even_cpr_rec.time.cmp(&odd_cpr_rec.time) {
+                    Ordering::Less => (even_cpr_rec, odd_cpr_rec),
+                    Ordering::Greater | Ordering::Equal => (odd_cpr_rec, even_cpr_rec),
+                };
+                if let Some(pos) = adsb_deku::cpr::get_position((&cpr1.cpr_frame, &cpr2.cpr_frame))
+                {
+                    // We got a position!
+                    // Add it to the record
+                    let new_pos = AircraftPosition {
+                        latitude: pos.latitude,
+                        longitude: pos.longitude,
+                        altitude: altitude.alt,
+                        type_code: altitude.tc,
+                    };
+                    let new_rec = AircraftPositionRecord {
+                        position: new_pos,
+                        time: now,
+                    };
+                    let rec = self.aircraft_register.register.get_mut(icao).unwrap();
+                    rec.positions.push(new_rec);
+                }
+            }
+        }
+        self.update_last_seen(icao);
+    }
+
+    fn airborne_velocity_received(
+        &mut self,
+        icao: &AdsbIcao,
+        velocity: &AdsbVelocity,
+        _metadata: &DecoderMetaData,
+    ) {
+        if !self.aircraft_register.register.contains_key(icao) {
+            self.register_aircraft(icao);
+        }
+        let now = SystemTime::now();
+        // Calculate the velocity
+        if let Some((heading, ground_speed, vertical_rate)) = velocity.calculate() {
+            // Add it to the record
+            let new_velocity = AircraftVelocity {
+                heading: heading as f64,
+                ground_speed,
+                vertical_rate,
+                vertical_rate_source: match velocity.vrate_src {
+                    adsb_deku::adsb::VerticalRateSource::BarometricPressureAltitude => {
+                        AircraftVerticalRateSource::BarometricPressureAltitude
+                    }
+                    adsb_deku::adsb::VerticalRateSource::GeometricAltitude => {
+                        AircraftVerticalRateSource::GeometricAltitude
+                    }
+                },
+            };
+            let new_record = AircraftVelocityRecord {
+                velocity: new_velocity,
+                time: now,
+            };
+            let rec = self.aircraft_register.register.get_mut(icao).unwrap();
+            rec.velocities.push(new_record);
+        }
+        self.update_last_seen(icao);
+    }
+}
+
+#[async_trait]
+impl Kernel for Tracker {
+    async fn work(
+        &mut self,
+        _io: &mut WorkIo,
+        _sio: &mut StreamIo,
+        _mio: &mut MessageIo<Self>,
+        _meta: &mut BlockMeta,
+    ) -> Result<()> {
+        // Set up pruning timer.
+        // To keep things simple, we just run the prune
+        // function every second, although this means that any
+        // item may remain for sec. longer than the prune duration.
+        if self.prune_after.is_some() {
+            Timer::after(Duration::from_millis(1000)).await;
+            self.prune_records();
+        }
+
+        Ok(())
+    }
+}


### PR DESCRIPTION
I implemented an ADS-B decoder with FutureSDR, and thought it could be nice to include as an example.

It also contains a simple web-based map that uses the ctrl_port to interact with the flowgraph.

It relies on [adsb_deku](https://github.com/rsadsb/adsb_deku) for decoding the packets. While it supports a lot of formats, I have only implemented the most common ones, and the ones that were easiest to integrate.

I have not performed any actual comparison to other ADS-B implementations, but it seems to perform quite well on my recordings and with an RTL-SDR with the stock telescopic antenna.

Considering that many people are likely to use this example (along with the others) as an example of how to implement a decoder with FutureSDR, I think it should be as close as possible to "idiomatic" FutureSDR. So suggestions are very welcome. For instance, maybe it could make sense to merge some of the blocks, such as the preamble detector and demodulator.

Also note that I copied the web server code from the zigbee example and only made some minor modifications. I am not familiar with gulp, so there might be some unnecessary stuff that can be removed.