### PR TITLE
Add documentation for examples

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,8 @@
+# Examples
+
+## FM Radio
+`examples/fm-receiver`
+
+A simple FM receiver that you can tune to nearby radio stations.
+
+

--- a/examples/fm-receiver/README.md
+++ b/examples/fm-receiver/README.md
@@ -20,3 +20,5 @@ by your SDR and may cause a crash.
 
   $ argo run
   ```
+  
+- enter a frequency in MHz in the prompt, e.g. `89.1` (and press Enter) to tune the radio to 89.1 MHz. This prompt for a new frequency runs in a loop, so can change the frequency over and over again. 

--- a/examples/fm-receiver/README.md
+++ b/examples/fm-receiver/README.md
@@ -1,0 +1,22 @@
+# fm-receiver
+A simple FM receiver that you can tune to nearby radio stations
+
+## How it works:
+When you run the example, it will build a flowgraph consisting of the following blocks:
+* SeifySource: Gets data from your SDR
+* Demodulator: Demodulates the FM signal
+* AudioSink: Plays the demodulated signal on your device
+
+After giving it some time to start up the SDR, it enters a loop where you will
+be periodically asked to enter a new frequency that the SDR will be tuned to.
+**Watch out** though: Some frequencies (very high or very low) might be unsupported
+by your SDR and may cause a crash.
+
+## How to run:
+- plug in your SDR
+- go to the example folder and run it
+  ```bash
+  $ cd FutureSDR/examples/fm-receiver
+
+  $ argo run
+  ```


### PR DESCRIPTION
Since there are already many different cool examples, it makes quite difficult for new users to figure out what they all do.
Not all examples have documentation in the code and some require extra setup (i.e. going to the folder and executing `cargo run` does not work) or have some other constraints.

This PR should serve as a starting point for giving an overview of the examples and adding some "how-to" for each example.

It's probably best if the authors of the examples add some info themselves. I am only somewhat familiar with the fm-receiver, so I took that as a start.