### PR TITLE
futuredsp: Fix syntax for doctests.

### DIFF
--- a/crates/futuredsp/src/fir.rs
+++ b/crates/futuredsp/src/fir.rs
@@ -22,7 +22,7 @@ use num_traits::{Float, Zero};
 /// use futuredsp::UnaryKernel;
 /// use futuredsp::fir::NonResamplingFirKernel;
 ///
-/// let fir = NonResamplingFirKernel::<f32, f32, _, _>::new([1.0, 2.0, 3.0]);
+/// let fir = NonResamplingFirKernel::<f32, f32, _, _>::new([1f32, 2f32, 3f32]);
 ///
 /// let input = [1.0, 2.0, 3.0];
 /// let mut output = [0.0];
@@ -244,7 +244,7 @@ where
 ///
 /// let decim = 2;
 /// let interp = 3;
-/// let taps = [1.0, 2.0, 3.0, 4.0, 5.0, 6.0];
+/// let taps: [f32; 6] = [1.0, 2.0, 3.0, 4.0, 5.0, 6.0];
 /// let fir = PolyphaseResamplingFirKernel::<f32, f32, _, _>::new(interp, decim, taps);
 ///
 /// let input = [1.0, 2.0, 3.0];

--- a/crates/futuredsp/src/firdes.rs
+++ b/crates/futuredsp/src/firdes.rs
@@ -186,8 +186,8 @@ pub fn root_raised_cosine<T: FromPrimitive>(span: usize, sps: usize, roll_off: f
 /// ```
 /// use futuredsp::{firdes, windows};
 ///
-/// let window = windows::hamming(65);
-/// let taps = firdes::hilbert::<f32>(window);
+/// let window = windows::hamming(65, false);
+/// let taps = firdes::hilbert::<f32>(&window);
 /// ```
 pub fn hilbert<T: FromPrimitive>(window: &[f64]) -> Vec<T> {
     let ntaps = window.len();

--- a/crates/futuredsp/src/iir.rs
+++ b/crates/futuredsp/src/iir.rs
@@ -21,7 +21,7 @@ use num_traits::Zero;
 /// use futuredsp::StatefulUnaryKernel;
 /// use futuredsp::iir::IirKernel;
 ///
-/// let mut iir = IirKernel::<f32, f32, _>::new([1.0, 2.0, 3.0], [4.0, 5.0, 6.0]);
+/// let mut iir = IirKernel::<f32, f32, _>::new([1f32, 2f32, 3f32], [4.0, 5.0, 6.0]);
 ///
 /// let input = [1.0, 2.0, 3.0, 4.0, 5.0];
 /// let mut output = [0.0];

--- a/crates/futuredsp/src/windows.rs
+++ b/crates/futuredsp/src/windows.rs
@@ -16,7 +16,7 @@ use num_traits::{AsPrimitive, Float, One};
 /// ```
 /// use futuredsp::windows;
 ///
-/// let taps = windows::rect(64);
+/// let taps: Vec<f32> = windows::rect(64);
 /// ```
 pub fn rect<T: Float + One>(len: usize) -> Vec<T> {
     vec![T::one(); len]
@@ -28,7 +28,7 @@ pub fn rect<T: Float + One>(len: usize) -> Vec<T> {
 /// ```
 /// use futuredsp::windows;
 ///
-/// let taps = windows::bartlett(38);
+/// let taps: Vec<f32> = windows::bartlett(38);
 /// ```
 pub fn bartlett<T>(len: usize) -> Vec<T>
 where


### PR DESCRIPTION
The `cargo test` command raises multiple doctests errors in the futuredsp crate.

This commit fixes them.