### PR TITLE
Replace removed with_min_level method in android_logger

### DIFF
--- a/src/runtime/logging_android.rs
+++ b/src/runtime/logging_android.rs
@@ -1,7 +1,7 @@
-use log::Level;
+use log::LevelFilter;
 
 use android_logger::Config;
 
 pub fn init() {
-    android_logger::init_once(Config::default().with_min_level(Level::Debug));
+    android_logger::init_once(Config::default().with_max_level(LevelFilter::Debug));
 }


### PR DESCRIPTION
The android_logger crate marked the with_min_level method deprecated in version in 0.12.0 and removed it in 0.13.0. Because futuresdr is currently using "0.13" of the crate, this breaks the Android build with "no method named with_min_level` found". Also see
https://github.com/rust-mobile/android_logger-rs/pull/62

This replaces the method call with the new "with_max_level".