### PR TITLE
Fix use of `std::time::Instant` in Throttle block

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -96,6 +96,7 @@ spin = "0.9"
 serde = { version = "1.0", features = ["derive"] }
 thiserror = "1.0"
 wgpu = { version = "0.19", optional = true }
+web-time = { version = "1.1.0" }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 console_log = "1.0"

--- a/src/blocks/message_source.rs
+++ b/src/blocks/message_source.rs
@@ -1,6 +1,6 @@
 use async_io::Timer;
 use std::time::Duration;
-use std::time::Instant;
+use web_time::Instant;
 
 use crate::anyhow::Result;
 use crate::runtime::Block;


### PR DESCRIPTION
In wasm you cannot use `std::time::Instant` so their uses have to be replaced. I hopefully caught all cases where it might be used from a wasm context.