### PR TITLE
Implement GUI blocks and default interface

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,10 @@ wgpu = ["dep:wgpu"]
 zeromq = ["dep:zmq"]
 zynq = ["dep:xilinx-dma"]
 
+gui = []
+egui = ["gui", "dep:egui", "dep:eframe", "dep:egui_plot", "dep:colorgrad"]
+textplots = ["gui", "dep:textplots", "dep:drawille", "dep:console", "dep:ctrlc", "dep:rgb"]
+
 [[bench]]
 name = "flowgraph"
 harness = false
@@ -97,6 +101,17 @@ serde = { version = "1.0", features = ["derive"] }
 thiserror = "1.0"
 web-time = { version = "1.1" }
 wgpu = { version = "0.19", optional = true }
+
+egui = { version = "0.27", optional = true }
+eframe = { version = "0.27", optional = true }
+egui_plot = { version = "0.27", optional = true }
+colorgrad = { version = "0.6", optional = true }
+
+textplots = { version = "0.8", optional = true }
+drawille = { version = "0.3", optional = true }
+console = { version = "0.15", optional = true }
+ctrlc = { version = "3", optional = true }
+rgb = { version = "0.8", optional = true }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 console_log = "1.0"

--- a/crates/types/src/pmt.rs
+++ b/crates/types/src/pmt.rs
@@ -215,12 +215,50 @@ impl Pmt {
     }
 }
 
+impl From<f32> for Pmt {
+    fn from(f: f32) -> Self {
+        Pmt::F32(f)
+    }
+}
+
+impl From<f64> for Pmt {
+    fn from(f: f64) -> Self {
+        Pmt::F64(f)
+    }
+}
+
+impl From<u32> for Pmt {
+    fn from(f: u32) -> Self {
+        Pmt::U32(f)
+    }
+}
+
+impl From<u64> for Pmt {
+    fn from(f: u64) -> Self {
+        Pmt::U64(f)
+    }
+}
+
 /// PMT conversion error.
 ///
 /// This error is returned, if conversion to/from PMTs fail.
 #[derive(Debug, Clone, Error, PartialEq)]
 #[error("PMt conversion error")]
 pub struct PmtConversionError;
+
+impl TryInto<f32> for Pmt {
+    type Error = PmtConversionError;
+
+    fn try_into(self) -> Result<f32, Self::Error> {
+        match self {
+            Pmt::F32(f) => Ok(f),
+            Pmt::F64(f) => Ok(f as f32),
+            Pmt::U32(f) => Ok(f as f32),
+            Pmt::U64(f) => Ok(f as f32),
+            _ => Err(PmtConversionError),
+        }
+    }
+}
 
 impl TryInto<f64> for Pmt {
     type Error = PmtConversionError;

--- a/examples/gui/Cargo.toml
+++ b/examples/gui/Cargo.toml
@@ -1,0 +1,30 @@
+[package]
+name = "futuresdr-gui"
+version = "0.1.0"
+edition = "2021"
+default-run = "basic"
+
+[workspace]
+
+# Basic example using the default, "batteries included" interface
+[[bin]]
+name = "basic"
+path = "src/basic.rs"
+
+# A more complex example that manually handles the layout. Only works with `egui`.
+[[bin]]
+name = "detached"
+path = "src/detached.rs"
+
+[features]
+egui = ["futuresdr/egui"]
+textplots = ["futuresdr/textplots"]
+default = ["egui"]
+
+[dependencies]
+eframe = "0.27"
+env_logger = { version = "0.11", default-features = false, features = [
+    "auto-color",
+    "humantime",
+] }
+futuresdr = { path = "../..", features = ["seify", "soapy"] }

--- a/examples/gui/src/basic.rs
+++ b/examples/gui/src/basic.rs
@@ -1,0 +1,81 @@
+#![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
+
+use futuresdr::anyhow::Result;
+use futuresdr::blocks::gui::*;
+use futuresdr::blocks::seify::SourceBuilder;
+use futuresdr::blocks::{MessageCopy, Split};
+use futuresdr::gui::{Gui, GuiFrontend};
+use futuresdr::macros::connect;
+use futuresdr::num_complex::Complex32;
+use futuresdr::runtime::Flowgraph;
+use futuresdr::seify::Direction;
+
+// Initial values. In theory, sample rate could also be configured via GUI, but
+// most drivers really don't like quick updates at runtime.
+const SAMPLE_RATE: f64 = 20e6;
+const FREQUENCY: f64 = 868e6;
+const GAIN: f64 = 50.0;
+
+fn main() -> Result<()> {
+    env_logger::init();
+
+    let device = futuresdr::seify::Device::new().expect("Failed to find a Seify device");
+    let freq_range = device.frequency_range(Direction::Rx, 0).unwrap();
+    let gain_range = device.gain_range(Direction::Rx, 0).unwrap();
+
+    let mut fg = Flowgraph::new();
+
+    let src = SourceBuilder::new()
+        .device(device)
+        .frequency(FREQUENCY)
+        .sample_rate(SAMPLE_RATE)
+        .gain(GAIN)
+        .build()
+        .unwrap();
+
+    let split = Split::new(|x: &Complex32| (*x, *x));
+
+    let spectrum = SpectrumPlotBuilder::new(SAMPLE_RATE)
+        .center_frequency(FREQUENCY)
+        .fft_size(2048)
+        .build();
+
+    let waterfall = WaterfallBuilder::new(SAMPLE_RATE)
+        .center_frequency(FREQUENCY)
+        .build();
+
+    let freq_min = freq_range.at_least(0.0).unwrap() / 1e6;
+    let freq_max = freq_range.at_max(1e12).unwrap() / 1e6;
+    let freq_slider = MessageSliderBuilder::<f64>::new(freq_min..=freq_max)
+        .step_size(0.1)
+        .initial_value(FREQUENCY / 1e6)
+        .label("Frequency")
+        .suffix("MHz")
+        .multiplier(1e6)
+        .build();
+
+    let gain_min = gain_range.at_least(-1000.0).unwrap();
+    let gain_max = gain_range.at_max(1000.0).unwrap();
+    let gain_slider = MessageSliderBuilder::<f64>::new(gain_min..=gain_max)
+        .step_size(0.1)
+        .initial_value(GAIN)
+        .label("Gain")
+        .suffix("dB")
+        .build();
+
+    // A whole bunch of blocks need access to the center frequency so we push all changes
+    // in here for convenience, so we don't have to do point-to-point connections.
+    let center_freq_hub = MessageCopy::new();
+
+    connect!(fg,
+             src > split;
+             split.out0 > spectrum;
+             split.out1 > waterfall;
+             freq_slider | center_freq_hub | freq_slider;
+             waterfall.drag_freq | center_freq_hub | waterfall.center_freq;
+             spectrum.drag_freq | center_freq_hub | spectrum.center_freq;
+             center_freq_hub | src.freq;
+             gain_slider | src.gain);
+
+    Gui::run(fg) // instead of rt.run(fg)
+}

--- a/examples/gui/src/detached.rs
+++ b/examples/gui/src/detached.rs
@@ -1,0 +1,159 @@
+#![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
+
+use std::thread;
+
+use futuresdr::anyhow::Result;
+use futuresdr::blocks::seify::SourceBuilder;
+use futuresdr::blocks::{MessageCopy, Split};
+use futuresdr::blocks::gui::*;
+use futuresdr::macros::connect;
+use futuresdr::num_complex::Complex32;
+use futuresdr::runtime::Flowgraph;
+use futuresdr::runtime::Runtime;
+use futuresdr::seify::Direction;
+
+use eframe::egui;
+
+// Initial values. In theory, sample rate could also be configured via GUI, but
+// most drivers really don't like quick updates at runtime.
+const SAMPLE_RATE: f64 = 20e6;
+const FREQUENCY: f64 = 868e6;
+const GAIN: f64 = 50.0;
+
+struct MyApp {
+    device_id: String,
+    device_args: futuresdr::seify::Args,
+    frequency_slider_handle: MessageSliderHandle<f64>,
+    gain_slider_handle: MessageSliderHandle<f64>,
+    spectrum_plot_handle: SpectrumPlotHandle,
+    waterfall_handle: WaterfallHandle,
+}
+
+impl MyApp {
+    fn build_flowgraph() -> Result<(Flowgraph, Self)> {
+        let device = futuresdr::seify::Device::new().expect("Failed to find a Seify device");
+        let device_id = device.id()?;
+        let device_args = device.info()?;
+        let freq_range = device.frequency_range(Direction::Rx, 0)?;
+        let gain_range = device.gain_range(Direction::Rx, 0)?;
+
+        let mut fg = Flowgraph::new();
+
+        let src = SourceBuilder::new()
+            .device(device)
+            .frequency(FREQUENCY)
+            .sample_rate(SAMPLE_RATE)
+            .gain(GAIN)
+            .build()
+            .unwrap();
+
+        let split = Split::new(|x: &Complex32| (*x, *x));
+
+        let (spectrum, spectrum_handle) = SpectrumPlotBuilder::new(SAMPLE_RATE)
+            .center_frequency(FREQUENCY)
+            .fft_size(2048)
+            .build_detached();
+
+        let (waterfall, waterfall_handle) = WaterfallBuilder::new(SAMPLE_RATE)
+            .center_frequency(FREQUENCY)
+            .build_detached();
+
+        let freq_min = freq_range.at_least(0.0).unwrap() / 1e6;
+        let freq_max = freq_range.at_max(1e12).unwrap() / 1e6;
+        let (freq_slider, freq_handle) = MessageSliderBuilder::<f64>::new(freq_min..=freq_max)
+            .step_size(0.1)
+            .initial_value(FREQUENCY / 1e6)
+            .label("Frequency")
+            .suffix("MHz")
+            .multiplier(1e6)
+            .build_detached();
+
+        let gain_min = gain_range.at_least(-1000.0).unwrap();
+        let gain_max = gain_range.at_max(1000.0).unwrap();
+        let (gain_slider, gain_handle) = MessageSliderBuilder::<f64>::new(gain_min..=gain_max)
+            .step_size(0.1)
+            .initial_value(GAIN)
+            .label("Gain")
+            .suffix("dB")
+            .build_detached();
+
+        // A whole bunch of blocks need access to the center frequency so we push all changes
+        // in here for convenience, so we don't have to do point-to-point connections.
+        let center_freq_hub = MessageCopy::new();
+
+        connect!(fg,
+                 src > split;
+                 split.out0 > spectrum;
+                 split.out1 > waterfall;
+                 freq_slider | center_freq_hub | freq_slider;
+                 waterfall.drag_freq | center_freq_hub | waterfall.center_freq;
+                 spectrum.drag_freq | center_freq_hub | spectrum.center_freq;
+                 center_freq_hub | src.freq;
+                 gain_slider | src.gain);
+
+        let app = Self {
+            device_id,
+            device_args,
+            frequency_slider_handle: freq_handle,
+            gain_slider_handle: gain_handle,
+            spectrum_plot_handle: spectrum_handle,
+            waterfall_handle,
+        };
+
+        Ok((fg, app))
+    }
+
+    fn new(_cc: &eframe::CreationContext<'_>) -> Self {
+        let (fg, app) = Self::build_flowgraph().unwrap();
+
+        thread::spawn(move || -> Result<()> {
+            let rt = Runtime::new();
+            let _ = rt.run(fg);
+            Ok(())
+        });
+
+        app
+    }
+}
+
+impl eframe::App for MyApp {
+    fn update(&mut self, ctx: &egui::Context, _frame: &mut eframe::Frame) {
+        egui::SidePanel::left("sdr_settings").show(ctx, |ui| {
+            ui.heading(format!("Device #{}", self.device_id));
+            for (key, value) in self.device_args.iter() {
+                ui.monospace(format!("{}: {}", key, value));
+            }
+
+            ui.separator();
+
+            ui.add(&mut self.frequency_slider_handle);
+            ui.add(&mut self.gain_slider_handle);
+        });
+
+        egui::CentralPanel::default().show(ctx, |ui| {
+            let size = egui::Vec2::new(ui.available_width(), ui.available_height() * 0.3);
+            ui.allocate_ui(size, |ui| {
+                ui.add(&mut self.spectrum_plot_handle);
+            });
+
+            ui.add(&mut self.waterfall_handle);
+        });
+    }
+}
+
+fn main() -> Result<(), eframe::Error> {
+    env_logger::init();
+
+    let options = eframe::NativeOptions {
+        viewport: egui::ViewportBuilder::default().with_inner_size([1000.0, 1200.0]),
+        multisampling: 4,
+        renderer: eframe::Renderer::Glow,
+        ..Default::default()
+    };
+
+    eframe::run_native(
+        "FutureSDR GUI Demo",
+        options,
+        Box::new(|cc| Box::new(MyApp::new(cc))),
+    )
+}

--- a/src/blocks/gui/message_slider.rs
+++ b/src/blocks/gui/message_slider.rs
@@ -1,0 +1,271 @@
+// We don't draw the sliders with the textplots backend, so disable the warnings
+#![cfg_attr(feature = "textplots", allow(unused_imports))]
+#![cfg_attr(feature = "textplots", allow(dead_code))]
+
+use std::marker::PhantomData;
+use std::ops::{Div, Mul};
+use std::time::Duration;
+
+use tokio::sync::mpsc::channel;
+use tokio::sync::mpsc::Receiver;
+use tokio::sync::mpsc::Sender;
+
+use crate::anyhow::Result;
+use crate::async_io::Timer;
+use crate::futures::select;
+use crate::futures::FutureExt;
+use crate::gui::GuiWidget;
+use crate::runtime::{
+    Block, BlockMeta, BlockMetaBuilder, Kernel, MessageIo, MessageIoBuilder, Pmt, StreamIo,
+    StreamIoBuilder, WorkIo,
+};
+
+/// Handle for the slider block that is passed to the GUI implementation.
+///
+/// Primarily, the handle's sender is used to update the flowgraph with new
+/// values from user interaction. If the value is changed by something else
+/// inside the flowgraph, the receiver can be used to update the value in
+/// the interface.
+pub struct MessageSliderHandle<T> {
+    /// The current value to be displayed in the UI
+    pub value: T,
+    /// The range of valid input values
+    pub range: std::ops::RangeInclusive<T>,
+    /// Minimum step size when dragging the slider
+    pub step_size: Option<f64>,
+    /// Multiplier that is applied to values input in the UI before they are
+    /// emitted as messages
+    pub multiplier: Option<T>,
+    /// Suffix to be added to the value in the UI, like a unit
+    pub suffix: Option<String>,
+    /// Label for the slider
+    pub label: Option<String>,
+    /// Sender for newly changed values
+    pub sender: Sender<Pmt>,
+    /// Receiver for changes to the value made inside the flowgraph, via the
+    /// message input
+    pub receiver: Receiver<Pmt>,
+}
+
+#[cfg(feature = "egui")]
+impl<T: Send + Mul<Output = T> + Div<Output = T> + egui::emath::Numeric> egui::Widget
+    for &mut MessageSliderHandle<T>
+where
+    Pmt: From<T> + TryInto<T>,
+{
+    fn ui(self, ui: &mut egui::Ui) -> egui::Response {
+        while let Ok(pmt) = self.receiver.try_recv() {
+            if let Ok(val) = pmt.try_into() {
+                self.value = self.multiplier.map(|mul| val / mul).unwrap_or(val);
+            }
+        }
+
+        let mut slider =
+            egui::Slider::new(&mut self.value, self.range.clone()).clamp_to_range(false);
+
+        if let Some(step_size) = &self.step_size {
+            slider = slider.step_by(*step_size).drag_value_speed(*step_size);
+        }
+
+        if let Some(suffix) = &self.suffix {
+            slider = slider.suffix(suffix);
+        }
+
+        if let Some(label) = &self.label {
+            slider = slider.text(label);
+        }
+
+        let response = ui.add(slider);
+        if response.changed() {
+            let val = self
+                .multiplier
+                .map(|mul| self.value * mul)
+                .unwrap_or(self.value);
+            let _ = self.sender.try_send(val.into());
+        }
+
+        response
+    }
+}
+
+#[cfg(feature = "egui")]
+impl<T> GuiWidget for MessageSliderHandle<T>
+where
+    for<'a> &'a mut MessageSliderHandle<T>: egui::Widget,
+    T: Send,
+{
+    fn widget_type(&self) -> crate::gui::GuiWidgetType {
+        crate::gui::GuiWidgetType::Control
+    }
+
+    fn egui_ui(&mut self, ui: &mut egui::Ui) -> egui::Response {
+        ui.add(self)
+    }
+}
+
+#[cfg(feature = "textplots")]
+impl<T: Send> GuiWidget for MessageSliderHandle<T> {
+    fn widget_type(&self) -> crate::gui::GuiWidgetType {
+        crate::gui::GuiWidgetType::Control
+    }
+
+    // We don't actually display these in textplots mode
+}
+
+/// Block that emits values configured via a GUI slider.
+///
+/// New values from user interaction are emitted as messages. If the value can
+/// be changed from somewhere else in the flowgraph, the UI can be synchronized
+/// using the input port.
+pub struct MessageSlider<T> {
+    sender: Sender<Pmt>,
+    receiver: Receiver<Pmt>,
+    _type: PhantomData<T>,
+}
+
+impl<T: Send + Sync + 'static> MessageSlider<T> {
+    /// Construct a new block that exchanges Pmts with the GUI handle
+    pub fn new(sender: Sender<Pmt>, receiver: Receiver<Pmt>) -> Block {
+        Block::new(
+            BlockMetaBuilder::new("MessageSlider").build(),
+            StreamIoBuilder::new().build(),
+            MessageIoBuilder::new()
+                .add_input("in", Self::receiver_handler)
+                .add_output("out")
+                .build(),
+            MessageSlider {
+                sender,
+                receiver,
+                _type: PhantomData::<T>,
+            },
+        )
+    }
+
+    #[message_handler]
+    async fn receiver_handler(
+        &mut self,
+        _io: &mut WorkIo,
+        _mio: &mut MessageIo<Self>,
+        _meta: &mut BlockMeta,
+        p: Pmt,
+    ) -> Result<Pmt> {
+        let _ = self.sender.try_send(p);
+        Ok(Pmt::Ok)
+    }
+}
+
+#[doc(hidden)]
+#[async_trait]
+impl<T: Send + Sync + 'static> Kernel for MessageSlider<T> {
+    async fn work(
+        &mut self,
+        io: &mut WorkIo,
+        _sio: &mut StreamIo,
+        mio: &mut MessageIo<Self>,
+        _meta: &mut BlockMeta,
+    ) -> Result<()> {
+        let pmt = select! {
+            pmt = self.receiver.recv().fuse() => pmt,
+            _ = Timer::after(Duration::from_millis(100)).fuse() => None,
+        };
+
+        if let Some(pmt) = pmt {
+            mio.post(0, pmt).await;
+        }
+
+        io.call_again = true;
+
+        Ok(())
+    }
+}
+
+/// Builder for a [MessageSlider]
+pub struct MessageSliderBuilder<T> {
+    range: std::ops::RangeInclusive<T>,
+    initial_value: T,
+    step_size: Option<f64>,
+    multiplier: Option<T>,
+    label: Option<String>,
+    suffix: Option<String>,
+}
+
+impl<T: Copy + Clone + Send + Sync + 'static> MessageSliderBuilder<T> {
+    /// Start building a new slider
+    pub fn new(range: std::ops::RangeInclusive<T>) -> Self {
+        let initial_value = *range.start();
+        Self {
+            range,
+            initial_value,
+            step_size: None,
+            multiplier: None,
+            label: None,
+            suffix: None,
+        }
+    }
+
+    /// Set the initial value for the UI element
+    pub fn initial_value(mut self, value: T) -> Self {
+        self.initial_value = value;
+        self
+    }
+
+    /// Set the slider's step size
+    pub fn step_size(mut self, step: f64) -> Self {
+        self.step_size = Some(step);
+        self
+    }
+
+    /// Set the slider's multiplier, applied to values before being emitted
+    /// as messages
+    pub fn multiplier(mut self, multiplier: T) -> Self {
+        self.multiplier = Some(multiplier);
+        self
+    }
+
+    /// Sets the label for the slider
+    pub fn label<S: ToString>(mut self, label: S) -> Self {
+        self.label = Some(label.to_string());
+        self
+    }
+
+    /// Sets the suffix for the slider's value, for instance a unit
+    pub fn suffix<S: ToString>(mut self, suffix: S) -> Self {
+        self.suffix = Some(suffix.to_string());
+        self
+    }
+
+    /// Build the block and return both the block and a handle
+    /// for the corresponding GUI widget.
+    ///
+    /// Use if you want to handle drawing the UI yourself.
+    pub fn build_detached(self) -> (Block, MessageSliderHandle<T>) {
+        let (to_flowgraph_sender, to_flowgraph_receiver) = channel(10);
+        let (from_flowgraph_sender, from_flowgraph_receiver) = channel(10);
+
+        let handle = MessageSliderHandle {
+            value: self.initial_value,
+            range: self.range,
+            step_size: self.step_size,
+            multiplier: self.multiplier,
+            label: self.label,
+            suffix: self.suffix,
+            sender: to_flowgraph_sender,
+            receiver: from_flowgraph_receiver,
+        };
+
+        let block = MessageSlider::<T>::new(from_flowgraph_sender, to_flowgraph_receiver);
+
+        (block, handle)
+    }
+
+    /// Build the block, leaving the GUI widget attached. In order to
+    /// draw the UI, pass the flowgraph to [crate::gui::Gui::run].
+    pub fn build(self) -> Block
+    where
+        MessageSliderHandle<T>: GuiWidget,
+    {
+        let (mut block, handle) = self.build_detached();
+        block.attach_gui_handle(Box::new(handle));
+        block
+    }
+}

--- a/src/blocks/gui/mod.rs
+++ b/src/blocks/gui/mod.rs
@@ -1,0 +1,12 @@
+//! Blocks that have corresponding GUI widgets.
+//!
+//! These can either be drawn manually when integrating into other applications
+//! or drawn using the default UI implementation [crate::gui::Gui].
+
+mod message_slider;
+mod spectrum;
+mod waterfall;
+
+pub use message_slider::*;
+pub use spectrum::*;
+pub use waterfall::*;

--- a/src/blocks/gui/spectrum.rs
+++ b/src/blocks/gui/spectrum.rs
@@ -1,0 +1,485 @@
+use std::fmt::Debug;
+use std::sync::Arc;
+
+use rustfft::num_complex::Complex32;
+use rustfft::num_traits::FromPrimitive;
+use rustfft::{self, FftPlanner};
+use tokio::sync::mpsc::channel;
+use tokio::sync::mpsc::Receiver;
+use tokio::sync::mpsc::Sender;
+
+use crate::anyhow::Result;
+use crate::gui::{Color, GuiWidget};
+use crate::runtime::{
+    Block, BlockMeta, BlockMetaBuilder, Kernel, MessageIo, MessageIoBuilder, Pmt, StreamIo,
+    StreamIoBuilder, WorkIo,
+};
+
+/// Handle for a single line in a spectrum plot
+pub struct SpectrumPlotLineHandle {
+    receiver: Receiver<Vec<f64>>,
+    /// Currently plotted values
+    pub values: Vec<f64>,
+    /// Label for the line
+    pub label: String,
+    /// Color for the label
+    pub color: Color,
+}
+
+/// GUI handle for a spectrum plot.
+pub struct SpectrumPlotHandle {
+    center_freq_receiver: Receiver<f64>,
+    /// A handle for each line being plotted
+    pub lines: Vec<SpectrumPlotLineHandle>,
+    /// Sender for sending center frequency updates to the block
+    pub drag_freq_sender: Sender<f64>,
+    /// The plot's title, to be painted above the plot
+    pub title: Option<String>,
+    /// The current center frequency
+    pub center_frequency: f64,
+    /// The stream's sample rate
+    pub sample_rate: f64,
+    /// The current minimum value. IIR filtered for smoothness
+    pub min: f64,
+    /// The current maximum value. IIR filtered for smoothness
+    pub max: f64,
+}
+
+/// Block that plots Fourier transforms of incoming samples.
+///
+/// Multiple input streams are supported. Center frequency is only used for
+/// displaying the correct X-axis values in the UI, and can be updated from
+/// somewhere else in the flowgraph and via user interaction like dragging.
+pub struct SpectrumPlot<T> {
+    senders: Vec<Sender<Vec<f64>>>,
+    center_freq_sender: Sender<f64>,
+    drag_freq_receiver: Receiver<f64>,
+    plan: Arc<dyn rustfft::Fft<f32>>,
+    scratch: Box<[T]>,
+    fft_size: usize,
+}
+
+impl SpectrumPlotHandle {
+    /// Process changes received from the flowgraph block. Called by GUI
+    /// implementations before drawing the UI.
+    pub fn process_updates(&mut self) {
+        while let Ok(center_freq) = self.center_freq_receiver.try_recv() {
+            self.center_frequency = center_freq;
+        }
+
+        for line in self.lines.iter_mut() {
+            let mut new = Vec::new();
+            while let Ok(buffer) = line.receiver.try_recv() {
+                new.push(buffer);
+            }
+
+            if new.len() == 0 {
+                continue;
+            }
+
+            // If we received multiple FFT buffers since the last frame,
+            // take the maximum of all of them for each frequency. This
+            // way, we can't miss anything.
+            line.values = new
+                .iter()
+                .fold(vec![f64::NEG_INFINITY; new[0].len()], |a, b| {
+                    a.iter()
+                        .zip(b.iter())
+                        .map(|(a, b)| f64::max(*a, *b))
+                        .collect()
+                });
+
+            let new_min = line
+                .values
+                .iter()
+                .fold(f64::INFINITY, |a, b| f64::min(a, *b));
+            let new_max = line
+                .values
+                .iter()
+                .fold(f64::NEG_INFINITY, |a, b| f64::max(a, *b));
+
+            const ALPHA: f64 = 0.002;
+            self.min = f64::min(new_min, (1.0 - ALPHA) * self.min + ALPHA * new_min);
+            self.max = f64::max(new_max, (1.0 - ALPHA) * self.max + ALPHA * new_max);
+        }
+    }
+}
+
+#[cfg(feature = "egui")]
+impl egui::Widget for &mut SpectrumPlotHandle {
+    fn ui(self, ui: &mut egui::Ui) -> egui::Response {
+        self.process_updates();
+
+        ui.ctx()
+            .request_repaint_after(std::time::Duration::from_millis(16));
+
+        let width = ui.available_width();
+
+        if let Some(title) = &self.title {
+            ui.heading(title);
+        }
+
+        let mut plot = egui_plot::Plot::new(ui.next_auto_id())
+            .set_margin_fraction(egui::Vec2::new(0.0, 0.1))
+            .allow_drag(false)
+            .allow_zoom(false)
+            .allow_scroll(false)
+            .include_x(self.center_frequency - self.sample_rate / 2.0)
+            .include_x(self.center_frequency + self.sample_rate / 2.0)
+            .include_y(self.min)
+            .include_y(self.max)
+            .show_axes(egui::Vec2b::new(true, false))
+            .height(ui.available_height())
+            .allow_double_click_reset(true)
+            .x_axis_formatter(|x, _len, _range| {
+                if x.value.abs() >= 1e9 {
+                    format!("{}GHz", (x.value / 1e6).round() / 1000.0)
+                } else if x.value.abs() >= 1e6 {
+                    format!("{}MHz", (x.value / 1e3).round() / 1000.0)
+                } else if x.value.abs() >= 1e3 {
+                    format!("{}kHz", x.value.round() / 1000.0)
+                } else {
+                    format!("{}Hz", x.value)
+                }
+            })
+            .label_formatter(|name, value| {
+                let x = value.x;
+                let y = (value.y * 100.0).round() / 100.0;
+                if x.abs() >= 1e9 {
+                    format!("{}: {}dB @ {}GHz", name, y, (x / 1e7).round() / 100.0)
+                } else if x.abs() >= 1e6 {
+                    format!("{}: {}dB @ {}MHz", name, y, (x / 1e4).round() / 100.0)
+                } else if x.abs() >= 1e3 {
+                    format!("{}: {}dB @ {}kHz", name, y, (x / 1e1).round() / 100.0)
+                } else {
+                    format!("{}: {}dB @ {}Hz", name, y, x)
+                }
+            })
+            .reset();
+
+        if self.lines.len() > 1 || self.lines[0].label != "in" {
+            plot = plot.legend(egui_plot::Legend::default().position(egui_plot::Corner::LeftTop));
+        }
+
+        let response = plot
+            .show(ui, |plot_ui| {
+                for line in self.lines.iter_mut() {
+                    if line.values.len() > 0 {
+                        let points: Vec<_> = line
+                            .values
+                            .iter()
+                            .enumerate()
+                            .map(|(i, y)| {
+                                [
+                                    self.center_frequency
+                                        + ((i as f64 / line.values.len() as f64) - 0.5)
+                                            * self.sample_rate,
+                                    *y,
+                                ]
+                            })
+                            .collect();
+                        let line_color: egui::Color32 = line.color.into();
+                        let egui_line = egui_plot::Line::new(points)
+                            .name(&line.label)
+                            .color(line_color);
+                        plot_ui.line(egui_line);
+                    }
+                }
+            })
+            .response;
+
+        if response.dragged_by(egui::PointerButton::Primary) {
+            let drag_delta = (response.drag_motion().x / width) as f64;
+            self.center_frequency -= drag_delta * self.sample_rate;
+            let _ = self.drag_freq_sender.try_send(self.center_frequency);
+        }
+
+        response
+    }
+}
+
+impl GuiWidget for SpectrumPlotHandle {
+    #[cfg(feature = "egui")]
+    fn egui_ui(&mut self, ui: &mut egui::Ui) -> egui::Response {
+        ui.add(self)
+    }
+
+    #[cfg(feature = "textplots")]
+    fn textplots_ui(&mut self, size: (u16, u16)) {
+        use textplots::ColorPlot;
+
+        self.process_updates();
+
+        let min_freq = (self.center_frequency - self.sample_rate / 2.0) as f32;
+        let max_freq = (self.center_frequency + self.sample_rate / 2.0) as f32;
+
+        let line_points: Vec<Vec<_>> = self
+            .lines
+            .iter()
+            .map(|line| {
+                line.values
+                    .iter()
+                    .enumerate()
+                    .map(|(i, y)| {
+                        (
+                            (self.center_frequency
+                                + ((i as f64 / line.values.len() as f64) - 0.5) * self.sample_rate)
+                                as f32,
+                            *y as f32,
+                        )
+                    })
+                    .collect()
+            })
+            .collect();
+
+        let line_shapes: Vec<_> = line_points
+            .iter()
+            .map(|points| textplots::Shape::Lines(&points))
+            .collect();
+
+        let mut chart = textplots::Chart::new_with_y_range(
+            (size.0 as u32 - 10) * 2,
+            (size.1 as u32 - 2) * 4,
+            min_freq,
+            max_freq,
+            (self.min - (self.max - self.min) * 0.1) as f32,
+            (self.max + (self.max - self.min) * 0.1) as f32,
+        );
+        let mut chart_ref = &mut chart;
+        for (line, shape) in self.lines.iter_mut().zip(line_shapes.iter()) {
+            chart_ref = chart_ref.linecolorplot(&shape, line.color.into());
+        }
+
+        chart_ref.display();
+    }
+}
+
+impl<T: FromPrimitive + Copy + Clone + Debug + Default + Send + Sync + 'static> SpectrumPlot<T>
+where
+    SpectrumPlot<T>: Kernel,
+{
+    /// Construct a new spectrum block
+    pub fn new(
+        fft_size: usize,
+        senders: Vec<Sender<Vec<f64>>>,
+        center_freq_sender: Sender<f64>,
+        drag_freq_receiver: Receiver<f64>,
+        inputs: Vec<String>,
+    ) -> Block {
+        let mut stream_io = StreamIoBuilder::new();
+        for l in &inputs {
+            stream_io = stream_io.add_input::<T>(l);
+        }
+
+        let mut planner = FftPlanner::<f32>::new();
+        let plan = planner.plan_fft_forward(fft_size);
+
+        Block::new(
+            BlockMetaBuilder::new("SpectrumPlot").build(),
+            stream_io.build(),
+            MessageIoBuilder::new()
+                .add_input("center_freq", Self::center_freq_handler)
+                .add_output("drag_freq")
+                .build(),
+            SpectrumPlot {
+                senders,
+                center_freq_sender,
+                drag_freq_receiver,
+                fft_size,
+                plan,
+                scratch: vec![T::default(); fft_size * 10].into_boxed_slice(),
+            },
+        )
+    }
+
+    #[message_handler]
+    async fn center_freq_handler(
+        &mut self,
+        _io: &mut WorkIo,
+        _mio: &mut MessageIo<Self>,
+        _meta: &mut BlockMeta,
+        p: Pmt,
+    ) -> Result<Pmt> {
+        let freq = match &p {
+            Pmt::F32(v) => Some(*v as f64),
+            Pmt::F64(v) => Some(*v),
+            Pmt::U32(v) => Some(*v as f64),
+            Pmt::U64(v) => Some(*v as f64),
+            _ => None,
+        };
+
+        if let Some(freq) = freq {
+            let _ = self.center_freq_sender.try_send(freq);
+        }
+
+        Ok(Pmt::Ok)
+    }
+}
+
+// TODO: implementation for f32/f64
+
+#[doc(hidden)]
+#[async_trait]
+impl Kernel for SpectrumPlot<Complex32> {
+    async fn work(
+        &mut self,
+        io: &mut WorkIo,
+        sio: &mut StreamIo,
+        mio: &mut MessageIo<Self>,
+        _meta: &mut BlockMeta,
+    ) -> Result<()> {
+        if let Ok(frequency) = self.drag_freq_receiver.try_recv() {
+            mio.post(0, Pmt::F64(frequency)).await;
+        }
+
+        for (i, sender) in self.senders.iter_mut().enumerate() {
+            let input = unsafe { sio.input(i).slice_mut::<Complex32>() };
+            let m = (input.len() / self.fft_size) * self.fft_size;
+
+            if m == 0 {
+                continue;
+            }
+
+            let mut output = vec![Complex32::default(); m];
+            self.plan.process_outofplace_with_scratch(
+                &mut input[0..m],
+                &mut output[0..m],
+                &mut self.scratch,
+            );
+
+            sio.input(i).consume(m);
+
+            for chunk in output.chunks(self.fft_size) {
+                let db: Vec<_> = chunk
+                    .iter()
+                    .map(|c| 10.0 * c.norm_sqr().log10() as f64)
+                    .collect();
+                let reordered = [&db[self.fft_size / 2..], &db[..self.fft_size / 2]].concat();
+                let _ = sender.try_send(reordered);
+            }
+        }
+
+        io.finished = self
+            .senders
+            .iter()
+            .enumerate()
+            .all(|(i, _)| sio.input(i).finished());
+
+        Ok(())
+    }
+}
+
+/// Builder for a [SpectrumPlot]
+///
+/// If no lines are added manually, a single line is added with the default
+/// input port name 'in'.
+#[derive(Default)]
+pub struct SpectrumPlotBuilder {
+    lines: Vec<(String, Color)>,
+    sample_rate: f64,
+    fft_size: usize,
+    center_frequency: f64,
+    title: Option<String>,
+}
+
+impl SpectrumPlotBuilder {
+    /// Start building a new spectrum plot
+    pub fn new(sample_rate: f64) -> Self {
+        Self {
+            sample_rate,
+            fft_size: 1024,
+            center_frequency: 0.0,
+            ..Default::default()
+        }
+    }
+
+    /// Set the FFT size
+    pub fn fft_size(mut self, fft_size: usize) -> Self {
+        self.fft_size = fft_size;
+        self
+    }
+
+    /// Set the initial center frequency
+    pub fn center_frequency(mut self, frequency: f64) -> Self {
+        self.center_frequency = frequency;
+        self
+    }
+
+    /// Set the plot's title
+    pub fn title(mut self, title: impl ToString) -> Self {
+        self.title = Some(title.to_string());
+        self
+    }
+
+    /// Add a new line to the plot with the given color
+    pub fn line(mut self, label: impl ToString, color: Color) -> Self {
+        self.lines.push((label.to_string(), color));
+        self
+    }
+
+    /// Build the block and return both the block and a handle
+    /// for the corresponding GUI widget.
+    ///
+    /// Use if you want to handle drawing the UI yourself.
+    pub fn build_detached(mut self) -> (Block, SpectrumPlotHandle) {
+        if self.lines.len() == 0 {
+            self.lines.push((
+                "in".to_string(),
+                Color {
+                    r: 0xfa,
+                    g: 0xbd,
+                    b: 0x2f,
+                },
+            ));
+        }
+
+        let mut senders = Vec::new();
+        let mut lines = Vec::new();
+        let mut labels = Vec::new();
+        for (label, color) in self.lines.into_iter() {
+            let (sender, receiver) = channel(256);
+            let line = SpectrumPlotLineHandle {
+                receiver,
+                values: vec![],
+                label: label.clone(),
+                color,
+            };
+
+            senders.push(sender);
+            lines.push(line);
+            labels.push(label);
+        }
+
+        let (center_freq_sender, center_freq_receiver) = channel(10);
+        let (drag_freq_sender, drag_freq_receiver) = channel(10);
+
+        let block = SpectrumPlot::<Complex32>::new(
+            self.fft_size,
+            senders,
+            center_freq_sender,
+            drag_freq_receiver,
+            labels,
+        );
+
+        let handle = SpectrumPlotHandle {
+            lines,
+            center_freq_receiver,
+            drag_freq_sender,
+            title: self.title,
+            center_frequency: self.center_frequency,
+            sample_rate: self.sample_rate,
+            min: f64::INFINITY,
+            max: f64::NEG_INFINITY,
+        };
+
+        (block, handle)
+    }
+
+    /// Build the block, leaving the GUI widget attached. In order to
+    /// draw the UI, pass the flowgraph to [crate::gui::Gui::run].
+    pub fn build(self) -> Block {
+        let (mut block, handle) = self.build_detached();
+        block.attach_gui_handle(Box::new(handle));
+        block
+    }
+}

--- a/src/blocks/gui/waterfall.rs
+++ b/src/blocks/gui/waterfall.rs
@@ -1,0 +1,350 @@
+use std::collections::VecDeque;
+use std::time::Duration;
+
+use rustfft::num_complex::Complex32;
+use tokio::sync::mpsc::channel;
+use tokio::sync::mpsc::Receiver;
+use tokio::sync::mpsc::Sender;
+
+use crate::blocks::gui::SpectrumPlot;
+use crate::gui::GuiWidget;
+use crate::runtime::Block;
+
+#[cfg(feature = "egui")]
+const COLORGRAD_LOOKUP_SIZE: usize = 128;
+
+/// GUI handle for a waterfall plot. The corresponding flowgraph block is a
+/// [SpectrumPlot].
+pub struct WaterfallHandle {
+    receiver: Receiver<Vec<f64>>,
+    center_freq_receiver: Receiver<f64>,
+    /// Sender for sending center frequency updates to the block
+    pub drag_freq_sender: Sender<f64>,
+    /// Raw lines of values received from the flowgraph. Drained and
+    /// processed by GUI implementations
+    pub lines: VecDeque<Vec<f64>>,
+    /// The plot's title, to be painted above the plot
+    pub title: Option<String>,
+    /// The current center frequency
+    pub center_frequency: f64,
+    /// The stream's sample rate
+    pub sample_rate: f64,
+    /// The used FFT size
+    pub fft_size: usize,
+    /// The current minimum value. IIR filtered for smoothness
+    pub min: f64,
+    /// The current maximum value. IIR filtered for smoothness
+    pub max: f64,
+    /// The amount of history to keep
+    pub history: Duration,
+    #[cfg(feature = "egui")]
+    textures: VecDeque<(std::time::Instant, egui::TextureHandle)>,
+    #[cfg(feature = "egui")]
+    colorgrad_lookup: [egui::Color32; COLORGRAD_LOOKUP_SIZE],
+    #[cfg(feature = "textplots")]
+    canvas_lines: VecDeque<String>,
+}
+
+impl WaterfallHandle {
+    /// Process changes received from the flowgraph block. Called by GUI
+    /// implementations before drawing the UI.
+    pub fn process_updates(&mut self) {
+        while let Ok(center_freq) = self.center_freq_receiver.try_recv() {
+            self.center_frequency = center_freq;
+        }
+
+        while let Ok(line) = self.receiver.try_recv() {
+            self.fft_size = line.len();
+            self.lines.push_back(line);
+        }
+    }
+
+    /// Update the limits with the given data. Due to differences between
+    /// GUI frontends, the chunk sizes and value downsampling is up to the
+    /// widget implementation.
+    pub fn update_limits(&mut self, data: &Vec<Vec<f64>>) {
+        let mut tex_min = f64::INFINITY;
+        let mut tex_max = f64::NEG_INFINITY;
+
+        for x in 0..data[0].len() {
+            for y in 0..data.len() {
+                let val = data[y][x];
+                if !val.is_nan() {
+                    tex_min = f64::min(tex_min, data[y][x]);
+                    tex_max = f64::max(tex_max, data[y][x]);
+                }
+            }
+        }
+
+        if tex_min.is_normal() && tex_max.is_normal() {
+            const ALPHA: f64 = 0.05;
+            self.min = self.min * (1.0 - ALPHA) + tex_min * ALPHA;
+            self.max = self.max * (1.0 - ALPHA) + tex_max * ALPHA;
+        }
+    }
+}
+
+#[cfg(feature = "egui")]
+impl egui::Widget for &mut WaterfallHandle {
+    fn ui(self, ui: &mut egui::Ui) -> egui::Response {
+        self.process_updates();
+
+        const WATERFALL_TEX_HEIGHT: usize = 256;
+
+        ui.ctx()
+            .request_repaint_after(std::time::Duration::from_millis(16));
+
+        let width = ui.available_width();
+
+        if let Some(title) = &self.title {
+            ui.heading(title);
+        }
+
+        let t_per_texture = (WATERFALL_TEX_HEIGHT * self.fft_size) as f64 / self.sample_rate;
+        while self.textures.len() > ((self.history.as_secs_f64() / t_per_texture) as usize) + 1 {
+            let _ = self.textures.pop_back();
+        }
+
+        if self.lines.len() > WATERFALL_TEX_HEIGHT {
+            let texture_data = self.lines.drain(..WATERFALL_TEX_HEIGHT).collect::<Vec<_>>();
+            let now = std::time::Instant::now();
+            let mut image = egui::ColorImage::new(
+                [texture_data[0].len(), texture_data.len()],
+                egui::Color32::TRANSPARENT,
+            );
+
+            self.update_limits(&texture_data);
+
+            for x in 0..texture_data[0].len() {
+                for y in 0..texture_data.len() {
+                    let val = texture_data[texture_data.len() - y - 1][x];
+                    let f = f64::max(0.0, (val - self.min) / (self.max - self.min));
+                    let i = (f * (COLORGRAD_LOOKUP_SIZE as f64)) as usize;
+                    let i = usize::min(i, COLORGRAD_LOOKUP_SIZE - 1);
+                    image[(x, y)] = self.colorgrad_lookup[i];
+                }
+            }
+
+            let tex_name = format!("waterfall_{:?}", now);
+            let tex_handle = ui.ctx().load_texture(tex_name, image, Default::default());
+            self.textures.push_front((now, tex_handle));
+        }
+
+        let response = egui_plot::Plot::new(ui.next_auto_id())
+            .legend(egui_plot::Legend::default())
+            .set_margin_fraction(egui::Vec2::new(0.0, 0.0))
+            .show_grid(false)
+            .allow_drag(false)
+            .allow_zoom(false)
+            .allow_scroll(false)
+            .include_x(self.center_frequency - self.sample_rate / 2.0)
+            .include_x(self.center_frequency + self.sample_rate / 2.0)
+            .include_y(0.0)
+            .include_y(-self.history.as_secs_f64())
+            .show_axes(egui::Vec2b::new(true, false))
+            .height(ui.available_height())
+            .x_axis_formatter(|x, _len, _range| {
+                if x.value.abs() >= 1e9 {
+                    format!("{}GHz", (x.value / 1e6).round() / 1000.0)
+                } else if x.value.abs() >= 1e6 {
+                    format!("{}MHz", (x.value / 1e3).round() / 1000.0)
+                } else if x.value.abs() >= 1e3 {
+                    format!("{}kHz", x.value.round() / 1000.0)
+                } else {
+                    format!("{}Hz", x.value)
+                }
+            })
+            .show(ui, |plot_ui| {
+                for (i, (_t, texture)) in self.textures.iter().enumerate() {
+                    let plot_image = egui_plot::PlotImage::new(
+                        texture,
+                        egui_plot::PlotPoint::new(
+                            self.center_frequency,
+                            -((i as f64) + 0.5) * t_per_texture,
+                        ),
+                        egui::Vec2::new(self.sample_rate as f32, t_per_texture as f32),
+                    );
+
+                    plot_ui.image(plot_image);
+                }
+            })
+            .response;
+
+        if response.dragged_by(egui::PointerButton::Primary) {
+            let drag_delta = (response.drag_motion().x / width) as f64;
+            self.center_frequency -= drag_delta * self.sample_rate;
+            let _ = self.drag_freq_sender.try_send(self.center_frequency);
+        }
+
+        response
+    }
+}
+
+impl GuiWidget for WaterfallHandle {
+    #[cfg(feature = "egui")]
+    fn egui_ui(&mut self, ui: &mut egui::Ui) -> egui::Response {
+        ui.add(self)
+    }
+
+    #[cfg(feature = "textplots")]
+    fn textplots_ui(&mut self, size: (u16, u16)) {
+        self.process_updates();
+
+        const COLOR: drawille::PixelColor = drawille::PixelColor::TrueColor {
+            r: 0xfa,
+            g: 0xbd,
+            b: 0x2f,
+        };
+
+        let fft_rate = (self.sample_rate as f32) / (self.fft_size as f32);
+        let per_canvas_line = ((fft_rate * self.history.as_secs_f32()) / (size.1 as f32)) as usize;
+        if self.lines.len() > per_canvas_line && per_canvas_line > 0 {
+            let texture_data = self.lines.drain(..per_canvas_line).collect::<Vec<_>>();
+
+            let canvas_width = (size.0 as usize - 10) * 2;
+            let mut downsampled: Vec<Vec<f64>> = (0..4)
+                .map(|_i| vec![f64::NEG_INFINITY; canvas_width])
+                .collect();
+
+            for x in 0..texture_data[0].len() {
+                for y in 0..texture_data.len() {
+                    let val = texture_data[y][x];
+                    if !val.is_nan() {
+                        let x_canvas = (((x as f32) / (texture_data[y].len() as f32))
+                            * (canvas_width as f32))
+                            as usize;
+                        let y_canvas = (4.0 * (y as f32) / (per_canvas_line as f32)) as usize;
+                        downsampled[y_canvas][x_canvas] =
+                            f64::max(downsampled[y_canvas][x_canvas], val);
+                    }
+                }
+            }
+
+            self.update_limits(&downsampled);
+
+            let threshold = (self.min + self.max) / 2.0;
+            let mut canvas = drawille::Canvas::new(canvas_width as u32, 4);
+            for x in 0..downsampled[0].len() {
+                for y in 0..downsampled.len() {
+                    if downsampled[y][x] > threshold {
+                        canvas.set_colored(x as u32, y as u32, COLOR);
+                    }
+                }
+            }
+
+            self.canvas_lines.push_front(canvas.rows()[0].clone());
+        }
+
+        while self.canvas_lines.len() >= (size.1 as usize) {
+            let _ = self.canvas_lines.pop_back();
+        }
+
+        for line in &self.canvas_lines {
+            println!("{}", line);
+        }
+    }
+}
+
+/// Builder for a waterfall plot. The flowgraph block is a [SpectrumPlot],
+/// only the GUI handle differs.
+#[derive(Default)]
+pub struct WaterfallBuilder {
+    sample_rate: f64,
+    fft_size: usize,
+    center_frequency: f64,
+    title: Option<String>,
+    history: Duration,
+}
+
+impl WaterfallBuilder {
+    /// Start building a new waterfall plot
+    pub fn new(sample_rate: f64) -> Self {
+        Self {
+            sample_rate,
+            fft_size: 1024,
+            center_frequency: 0.0,
+            history: Duration::from_secs_f32(1.0),
+            ..Default::default()
+        }
+    }
+
+    /// Set the FFT size
+    pub fn fft_size(mut self, fft_size: usize) -> Self {
+        self.fft_size = fft_size;
+        self
+    }
+
+    /// Set the initial center frequency
+    pub fn center_frequency(mut self, frequency: f64) -> Self {
+        self.center_frequency = frequency;
+        self
+    }
+
+    /// Set the plot's title
+    pub fn title(mut self, title: impl ToString) -> Self {
+        self.title = Some(title.to_string());
+        self
+    }
+
+    /// Set the amount of history to keep, i.e. the height of the Y axis
+    pub fn history(mut self, history: Duration) -> Self {
+        self.history = history;
+        self
+    }
+
+    /// Build the block and return both the block and a handle
+    /// for the corresponding GUI widget.
+    ///
+    /// Use if you want to handle drawing the UI yourself.
+    pub fn build_detached(self) -> (Block, WaterfallHandle) {
+        let (sender, receiver) = channel(256);
+        let (center_freq_sender, center_freq_receiver) = channel(10);
+        let (drag_freq_sender, drag_freq_receiver) = channel(10);
+
+        let block = SpectrumPlot::<Complex32>::new(
+            self.fft_size,
+            vec![sender],
+            center_freq_sender,
+            drag_freq_receiver,
+            vec!["in".to_string()],
+        );
+
+        let handle = WaterfallHandle {
+            receiver,
+            center_freq_receiver,
+            drag_freq_sender,
+            title: self.title,
+            center_frequency: self.center_frequency,
+            sample_rate: self.sample_rate,
+            fft_size: self.fft_size,
+            history: self.history,
+            min: -50.0,
+            max: 50.0,
+            lines: VecDeque::new(),
+            #[cfg(feature = "egui")]
+            textures: VecDeque::new(),
+            #[cfg(feature = "egui")]
+            colorgrad_lookup: (0..COLORGRAD_LOOKUP_SIZE)
+                .map(move |i| {
+                    let f = (i as f64) / (COLORGRAD_LOOKUP_SIZE as f64);
+                    let rgba = colorgrad::inferno().at(f).to_rgba8();
+                    egui::Color32::from_rgb(rgba[0], rgba[1], rgba[2])
+                })
+                .collect::<Vec<_>>()
+                .try_into()
+                .unwrap(),
+            #[cfg(feature = "textplots")]
+            canvas_lines: VecDeque::new(),
+        };
+
+        (block, handle)
+    }
+
+    /// Build the block, leaving the GUI widget attached. In order to
+    /// draw the UI, pass the flowgraph to [crate::gui::Gui::run].
+    pub fn build(self) -> Block {
+        let (mut block, handle) = self.build_detached();
+        block.attach_gui_handle(Box::new(handle));
+        block
+    }
+}

--- a/src/blocks/mod.rs
+++ b/src/blocks/mod.rs
@@ -273,3 +273,6 @@ pub use zynq::Zynq;
 mod zynq_sync;
 #[cfg(feature = "zynq")]
 pub use zynq_sync::ZynqSync;
+
+#[cfg(feature = "gui")]
+pub mod gui;

--- a/src/gui/egui_frontend.rs
+++ b/src/gui/egui_frontend.rs
@@ -1,0 +1,59 @@
+use eframe;
+
+use crate::gui::{GuiFrontend, GuiWidget, GuiWidgetType};
+
+/// The default GUI implementation when using the `egui` feature
+#[derive(Default)]
+pub struct EguiFrontend {
+    controls: Vec<Box<dyn GuiWidget>>,
+    plots: Vec<Box<dyn GuiWidget>>,
+}
+
+impl eframe::App for EguiFrontend {
+    fn update(&mut self, ctx: &egui::Context, _frame: &mut eframe::Frame) {
+        egui::CentralPanel::default().show(ctx, |ui| {
+            // TODO: layout
+            ui.columns(self.controls.len(), |columns| {
+                for (i, control) in self.controls.iter_mut().enumerate() {
+                    control.egui_ui(&mut columns[i]);
+                }
+            });
+
+            egui::Grid::new(ui.next_auto_id())
+                .min_col_width(ui.available_width())
+                .min_row_height(ui.available_height() / (self.plots.len() as f32))
+                .show(ui, |ui| {
+                    for plot in self.plots.iter_mut() {
+                        ui.allocate_ui(ui.available_size(), |ui| {
+                            plot.egui_ui(ui);
+                        });
+                        ui.end_row();
+                    }
+                });
+        });
+    }
+}
+
+impl GuiFrontend for EguiFrontend {
+    fn register(&mut self, widget: Box<dyn GuiWidget + Send>) {
+        if widget.widget_type() == GuiWidgetType::Control {
+            self.controls.push(widget);
+        } else {
+            self.plots.push(widget);
+        }
+    }
+
+    fn run_impl(self) {
+        let options = eframe::NativeOptions {
+            viewport: egui::ViewportBuilder::default().with_inner_size([1000.0, 1200.0]),
+            multisampling: 4,
+            renderer: eframe::Renderer::Glow,
+            ..Default::default()
+        };
+
+        // TODO: if we actually do something with the cc, we probably need
+        // to create another app struct and implement eframe::App for that
+        // instead.
+        eframe::run_native("FutureSDR", options, Box::new(|_cc| Box::new(self))).unwrap();
+    }
+}

--- a/src/gui/mod.rs
+++ b/src/gui/mod.rs
@@ -1,0 +1,111 @@
+//! Default GUI implementations for the implemented GUI frontends and
+//! corresponding traits
+
+use crate::runtime::{Flowgraph, Runtime};
+
+use crate::anyhow::Result;
+
+#[cfg(feature = "egui")]
+mod egui_frontend;
+#[cfg(feature = "egui")]
+pub use egui_frontend::*;
+
+#[cfg(feature = "textplots")]
+mod textplots_frontend;
+#[cfg(feature = "textplots")]
+pub use textplots_frontend::*;
+
+/// Default `egui` GUI implementation.
+#[cfg(feature = "egui")]
+pub type Gui = EguiFrontend;
+
+/// Default `textplots` GUI implementation.
+#[cfg(feature = "textplots")]
+pub type Gui = TextplotsFrontend;
+
+/// GUI frontend agnostic color type
+#[derive(Copy, Clone)]
+pub struct Color {
+    /// red
+    pub r: u8,
+    /// green
+    pub g: u8,
+    /// blue
+    pub b: u8,
+}
+
+#[cfg(feature = "egui")]
+impl Into<egui::Color32> for Color {
+    fn into(self) -> egui::Color32 {
+        egui::Color32::from_rgb(self.r, self.g, self.b)
+    }
+}
+
+#[cfg(feature = "textplots")]
+impl Into<rgb::RGB<u8>> for Color {
+    fn into(self) -> rgb::RGB<u8> {
+        rgb::RGB::new(self.r, self.g, self.b)
+    }
+}
+
+/// Type of a GUI widget. Determines the size and placement of the widget
+#[derive(PartialEq)]
+pub enum GuiWidgetType {
+    /// Control widget. Given as little space as possible
+    Control,
+    /// Plot widget. Given as much space as possible
+    Plot,
+}
+
+/// Trait implemented by all GUI handles
+pub trait GuiWidget: Send {
+    /// This widget's type
+    fn widget_type(&self) -> GuiWidgetType {
+        GuiWidgetType::Plot
+    }
+
+    /// Draw the egui UI for the widget. Mutable references to the widgets are
+    /// expected to implement [egui::Widget], so this might be `ui.add(self)`.
+    #[cfg(feature = "egui")]
+    fn egui_ui(&mut self, ui: &mut egui::Ui) -> egui::Response;
+
+    /// Draw the textplots UI for the widget
+    #[cfg(feature = "textplots")]
+    fn textplots_ui(&mut self, _size: (u16, u16)) {}
+}
+
+/// Trait implemented by the default GUI frontend for the currently active
+/// GUI feature
+pub trait GuiFrontend: Default {
+    /// Register a new GUI handle to be displayed
+    fn register(&mut self, _widget: Box<dyn GuiWidget + Send>);
+
+    /// Run the GUI with the registered widgets
+    fn run_impl(self);
+
+    /// Run the given flowgraph and the corresponding UI. Since egui prefers to
+    /// be run on the main thread, this also takes care of spawning a new
+    /// thread and runtime for the flowgraph.
+    fn run(mut fg: Flowgraph) -> Result<()> {
+        let gui_handles = fg.detach_gui_handles();
+
+        if gui_handles.is_empty() {
+            let rt = Runtime::new();
+            rt.run(fg)?;
+        } else {
+            std::thread::spawn(move || {
+                let rt = Runtime::new();
+                rt.run(fg)
+            });
+
+            let mut gui = Self::default();
+            for handle in gui_handles {
+                gui.register(handle);
+            }
+
+            gui.run_impl();
+        }
+
+        Ok(())
+    }
+}

--- a/src/gui/textplots_frontend.rs
+++ b/src/gui/textplots_frontend.rs
@@ -1,0 +1,48 @@
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+use std::time::Duration;
+
+use crate::gui::{GuiFrontend, GuiWidget, GuiWidgetType};
+
+/// The default GUI implementation when using the `textplots` feature
+#[derive(Default)]
+pub struct TextplotsFrontend {
+    plots: Vec<Box<dyn GuiWidget>>,
+}
+
+impl GuiFrontend for TextplotsFrontend {
+    fn register(&mut self, widget: Box<dyn GuiWidget + Send>) {
+        if widget.widget_type() != GuiWidgetType::Control {
+            self.plots.push(widget);
+        }
+    }
+
+    fn run_impl(mut self) {
+        let term = console::Term::stdout();
+        term.hide_cursor().unwrap();
+        term.clear_screen().unwrap();
+
+        let should_run = Arc::new(AtomicBool::new(true));
+        let should_run2 = should_run.clone();
+        ctrlc::set_handler(move || {
+            should_run2.as_ref().store(false, Ordering::Relaxed);
+        })
+        .unwrap();
+
+        while should_run.as_ref().load(Ordering::Acquire) {
+            term.clear_screen().unwrap();
+
+            let (rows, columns) = term.size();
+            let plot_height = (rows as usize) / self.plots.len();
+
+            for (i, plot) in self.plots.iter_mut().enumerate() {
+                term.move_cursor_to(0, i * plot_height).unwrap();
+                plot.textplots_ui((columns, plot_height as u16));
+            }
+
+            std::thread::sleep(Duration::from_millis(16));
+        }
+
+        term.show_cursor().unwrap();
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,6 +38,9 @@
 pub mod blocks;
 pub mod runtime;
 
+#[cfg(feature = "gui")]
+pub mod gui;
+
 // re-exports
 pub use anyhow;
 #[cfg(not(target_arch = "wasm32"))]

--- a/src/runtime/block.rs
+++ b/src/runtime/block.rs
@@ -133,6 +133,11 @@ pub trait BlockT: Send + Any {
     fn message_input_name_to_id(&self, name: &str) -> Option<usize>;
     fn message_outputs(&self) -> &Vec<MessageOutput>;
     fn message_output_name_to_id(&self, name: &str) -> Option<usize>;
+
+    #[cfg(feature = "gui")]
+    fn attach_gui_handle(&mut self, handle: Box<dyn crate::gui::GuiWidget + Send>);
+    #[cfg(feature = "gui")]
+    fn detach_gui_handle(&mut self) -> Option<Box<dyn crate::gui::GuiWidget + Send>>;
 }
 
 /// Typed Block
@@ -145,6 +150,9 @@ pub struct TypedBlock<T> {
     pub mio: MessageIo<T>,
     /// Kernel
     pub kernel: T,
+    #[cfg(feature = "gui")]
+    /// GUI widget handle
+    pub gui_handle: Option<Box<dyn crate::gui::GuiWidget + Send>>,
 }
 
 impl<T: Kernel + Send + 'static> TypedBlock<T> {
@@ -155,6 +163,8 @@ impl<T: Kernel + Send + 'static> TypedBlock<T> {
             sio,
             mio,
             kernel,
+            #[cfg(feature = "gui")]
+            gui_handle: None,
         }
     }
 }
@@ -203,6 +213,7 @@ impl<T: Kernel + Send + 'static> TypedBlockWrapper<T> {
             mut sio,
             mut mio,
             mut kernel,
+            ..
         }: TypedBlock<T>,
         block_id: usize,
         mut main_inbox: Sender<FlowgraphMessage>,
@@ -228,12 +239,7 @@ impl<T: Kernel + Send + 'static> TypedBlockWrapper<T> {
                             .send(FlowgraphMessage::BlockError {
                                 block_id,
                                 block: Block(Box::new(TypedBlockWrapper {
-                                    inner: Some(TypedBlock {
-                                        sio,
-                                        mio,
-                                        meta,
-                                        kernel,
-                                    }),
+                                    inner: Some(TypedBlock::new(meta, sio, mio, kernel)),
                                 })),
                             })
                             .await?;
@@ -326,12 +332,7 @@ impl<T: Kernel + Send + 'static> TypedBlockWrapper<T> {
                                     .send(FlowgraphMessage::BlockError {
                                         block_id,
                                         block: Block(Box::new(TypedBlockWrapper {
-                                            inner: Some(TypedBlock {
-                                                sio,
-                                                mio,
-                                                meta,
-                                                kernel,
-                                            }),
+                                            inner: Some(TypedBlock::new(meta, sio, mio, kernel)),
                                         })),
                                     })
                                     .await?;
@@ -361,12 +362,7 @@ impl<T: Kernel + Send + 'static> TypedBlockWrapper<T> {
                                     .send(FlowgraphMessage::BlockError {
                                         block_id,
                                         block: Block(Box::new(TypedBlockWrapper {
-                                            inner: Some(TypedBlock {
-                                                sio,
-                                                mio,
-                                                meta,
-                                                kernel,
-                                            }),
+                                            inner: Some(TypedBlock::new(meta, sio, mio, kernel)),
                                         })),
                                     })
                                     .await?;
@@ -398,12 +394,7 @@ impl<T: Kernel + Send + 'static> TypedBlockWrapper<T> {
                             .send(FlowgraphMessage::BlockDone {
                                 block_id,
                                 block: Block(Box::new(TypedBlockWrapper {
-                                    inner: Some(TypedBlock {
-                                        sio,
-                                        mio,
-                                        meta,
-                                        kernel,
-                                    }),
+                                    inner: Some(TypedBlock::new(meta, sio, mio, kernel)),
                                 })),
                             })
                             .await;
@@ -419,12 +410,7 @@ impl<T: Kernel + Send + 'static> TypedBlockWrapper<T> {
                             .send(FlowgraphMessage::BlockError {
                                 block_id,
                                 block: Block(Box::new(TypedBlockWrapper {
-                                    inner: Some(TypedBlock {
-                                        sio,
-                                        mio,
-                                        meta,
-                                        kernel,
-                                    }),
+                                    inner: Some(TypedBlock::new(meta, sio, mio, kernel)),
                                 })),
                             })
                             .await?;
@@ -468,12 +454,7 @@ impl<T: Kernel + Send + 'static> TypedBlockWrapper<T> {
                     .send(FlowgraphMessage::BlockError {
                         block_id,
                         block: Block(Box::new(TypedBlockWrapper {
-                            inner: Some(TypedBlock {
-                                sio,
-                                mio,
-                                meta,
-                                kernel,
-                            }),
+                            inner: Some(TypedBlock::new(meta, sio, mio, kernel)),
                         })),
                     })
                     .await?;
@@ -583,6 +564,18 @@ impl<T: Kernel + Send + 'static> BlockT for TypedBlockWrapper<T> {
             .map(|i| i.mio.output_name_to_id(name))
             .unwrap()
     }
+
+    #[cfg(feature = "gui")]
+    fn attach_gui_handle(&mut self, handle: Box<dyn crate::gui::GuiWidget + Send>) {
+        if let Some(handle_ref) = self.inner.as_mut().map(|b| &mut b.gui_handle) {
+            let _ = handle_ref.replace(handle);
+        }
+    }
+
+    #[cfg(feature = "gui")]
+    fn detach_gui_handle(&mut self) -> Option<Box<dyn crate::gui::GuiWidget + Send>> {
+        self.inner.as_mut().and_then(|b| b.gui_handle.take())
+    }
 }
 
 /// Block
@@ -600,12 +593,7 @@ impl Block {
         kernel: T,
     ) -> Block {
         Self(Box::new(TypedBlockWrapper {
-            inner: Some(TypedBlock {
-                meta,
-                sio,
-                mio,
-                kernel,
-            }),
+            inner: Some(TypedBlock::new(meta, sio, mio, kernel)),
         }))
     }
     /// Create block by wrapping a [`TypedBlock`].
@@ -702,6 +690,18 @@ impl Block {
     /// Map message output port name to id
     pub fn message_output_name_to_id(&self, name: &str) -> Option<usize> {
         self.0.message_output_name_to_id(name)
+    }
+
+    /// Attach a GUI handle to the block
+    #[cfg(feature = "gui")]
+    pub fn attach_gui_handle(&mut self, handle: Box<dyn crate::gui::GuiWidget + Send>) {
+        self.0.attach_gui_handle(handle);
+    }
+
+    /// Detach the block's GUI handle if present
+    #[cfg(feature = "gui")]
+    pub fn detach_gui_handle(&mut self) -> Option<Box<dyn crate::gui::GuiWidget + Send>> {
+        self.0.detach_gui_handle()
     }
 }
 

--- a/src/runtime/flowgraph.rs
+++ b/src/runtime/flowgraph.rs
@@ -111,6 +111,19 @@ impl Flowgraph {
             .and_then(|t| t.block_mut(id))
             .and_then(|b| b.kernel_mut())
     }
+
+    /// Detach GUI handles from all blocks in the flowgraph
+    #[cfg(feature = "gui")]
+    pub fn detach_gui_handles(&mut self) -> Vec<Box<dyn crate::gui::GuiWidget + Send>> {
+        self.topology
+            .as_mut()
+            .map(|top| {
+                top.blocks_mut()
+                    .filter_map(|block| block.detach_gui_handle())
+                    .collect()
+            })
+            .unwrap_or_default()
+    }
 }
 
 impl Default for Flowgraph {

--- a/src/runtime/topology.rs
+++ b/src/runtime/topology.rs
@@ -358,6 +358,18 @@ impl Topology {
     pub fn block_mut(&mut self, id: usize) -> Option<&mut Block> {
         self.blocks.get_mut(id).and_then(|v| v.as_mut())
     }
+
+    /// Iterate over all blocks
+    pub fn blocks(&self) -> impl Iterator<Item = &Block> {
+        self.blocks.iter().filter_map(|(_id, block)| block.as_ref())
+    }
+
+    /// Mutably iterate over all blocks
+    pub fn blocks_mut(&mut self) -> impl Iterator<Item = &mut Block> {
+        self.blocks
+            .iter_mut()
+            .filter_map(|(_id, block)| block.as_mut())
+    }
 }
 
 impl Default for Topology {


### PR DESCRIPTION
Adds a new sub-module of GUI blocks (message sliders, spectrum and waterfall plots for now), gated behind the `gui` feature. These blocks are present in the flowgraph and communicate with some sort of handle which is drawn by the frontend implementation. Applications can either draw these handles themselves or use a "batteries-included" UI. I have implemented frontends using `egui`, and a basic TUI interface using `textplots`. The frontend is selected with the appropriate feature flag.

GUI block builders implement `build_detached()` and `build()`. The latter behaves just like other block builders. Behind the scenes the GUI handle is attached to the block, and then extracted when passing the flowgraph to the default UI. `build_detached` returns both the block and the GUI handle, which can then be drawn manually.

The `gui` examples has binaries for both the batteries-included UI and a custom one:
![`egui` example screencast](https://github.com/FutureSDR/FutureSDR/assets/2438809/8d3ea755-3abd-46af-a97b-bbd9e89a8d93)
![`textplots` example screencast](https://github.com/FutureSDR/FutureSDR/assets/2438809/8a4495f1-7e95-4150-ac28-4bdcf1b46d57)