### PR TITLE
Add CPU pin scheduler

### DIFF
--- a/src/runtime/scheduler/cpu_pin.rs
+++ b/src/runtime/scheduler/cpu_pin.rs
@@ -1,0 +1,166 @@
+use super::flow::FlowExecutor;
+use crate::runtime::{config, scheduler::Scheduler, BlockMessage, FlowgraphMessage, Topology};
+use async_io::block_on;
+use async_lock::Barrier;
+use async_task::Task;
+use futures::channel::{
+    mpsc::{channel, Sender},
+    oneshot,
+};
+use futures_lite::future::Future;
+use slab::Slab;
+use std::{collections::HashMap, fmt, sync::Arc, thread};
+
+type CpuPins = HashMap<usize, usize>;
+
+/// CPU pin scheduler
+///
+/// Pins blocks to worker threads fixed to CPUs according to a hashmap.
+#[derive(Clone, Debug)]
+pub struct CpuPinScheduler {
+    inner: Arc<CpuPinSchedulerInner>,
+}
+
+struct CpuPinSchedulerInner {
+    executor: Arc<FlowExecutor>,
+    workers: Vec<(thread::JoinHandle<()>, oneshot::Sender<()>)>,
+    cpu_pins: CpuPins,
+}
+
+impl fmt::Debug for CpuPinSchedulerInner {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("CpuPinSchedulerInner").finish()
+    }
+}
+
+impl Drop for CpuPinSchedulerInner {
+    fn drop(&mut self) {
+        for i in self.workers.drain(..) {
+            i.1.send(()).unwrap();
+            i.0.join().unwrap();
+        }
+    }
+}
+
+impl CpuPinScheduler {
+    /// Create CPU pin scheduler
+    pub fn new(cpu_pins: CpuPins) -> CpuPinScheduler {
+        let executor = Arc::new(FlowExecutor::new());
+        let mut workers = Vec::new();
+
+        let core_ids = core_affinity::get_core_ids().unwrap();
+        debug!("flowsched: core ids {}", core_ids.len());
+
+        let barrier = Arc::new(Barrier::new(core_ids.len() + 1));
+
+        for id in core_ids {
+            let b = barrier.clone();
+            let e = executor.clone();
+            let (sender, receiver) = oneshot::channel::<()>();
+
+            let handle = thread::Builder::new()
+                .stack_size(config::config().stack_size)
+                .name(format!("flow-{}", id.id))
+                .spawn(move || {
+                    debug!("starting executor thread on core id {}", id.id);
+                    core_affinity::set_for_current(id);
+                    let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                        async_io::block_on(e.run(async {
+                            b.wait().await;
+                            receiver.await
+                        }))
+                        .unwrap();
+                    }));
+                    if result.is_err() {
+                        eprintln!("flow worker panicked {result:?}");
+                        std::process::exit(1);
+                    }
+                })
+                .expect("cannot spawn executor thread");
+
+            workers.push((handle, sender));
+        }
+
+        async_io::block_on(barrier.wait());
+
+        CpuPinScheduler {
+            inner: Arc::new(CpuPinSchedulerInner {
+                executor,
+                workers,
+                cpu_pins,
+            }),
+        }
+    }
+}
+
+impl Scheduler for CpuPinScheduler {
+    fn run_topology(
+        &self,
+        topology: &mut Topology,
+        main_channel: &Sender<FlowgraphMessage>,
+    ) -> Slab<Option<Sender<BlockMessage>>> {
+        let mut inboxes = Slab::new();
+        let max = topology.blocks.iter().map(|(i, _)| i).max().unwrap_or(0);
+        for _ in 0..=max {
+            inboxes.insert(None);
+        }
+        let queue_size = config::config().queue_size;
+
+        let _n_blocks = topology.blocks.len();
+        let _n_cores = self.inner.workers.len();
+
+        // spawn block executors
+        for (id, block_o) in topology.blocks.iter_mut() {
+            let block = block_o.take().unwrap();
+            // println!("{}: {}", id, block.instance_name().unwrap());
+
+            let (sender, receiver) = channel::<BlockMessage>(queue_size);
+            inboxes[id] = Some(sender.clone());
+
+            if block.is_blocking() {
+                let main = main_channel.clone();
+                debug!("spawing block on executor");
+
+                if let Some(&c) = self.inner.cpu_pins.get(&id) {
+                    self.inner
+                        .executor
+                        .spawn_executor(
+                            blocking::unblock(move || block_on(block.run(id, main, receiver))),
+                            c,
+                        )
+                        .detach();
+                } else {
+                    panic!("foo");
+                }
+            } else if let Some(&c) = self.inner.cpu_pins.get(&id) {
+                self.inner
+                    .executor
+                    .spawn_executor(block.run(id, main_channel.clone(), receiver), c)
+                    .detach();
+            } else {
+                self.inner
+                    .executor
+                    .spawn(block.run(id, main_channel.clone(), receiver))
+                    .detach();
+            }
+        }
+
+        inboxes
+    }
+
+    fn spawn<T: Send + 'static>(
+        &self,
+        future: impl Future<Output = T> + Send + 'static,
+    ) -> Task<T> {
+        self.inner.executor.spawn(future)
+    }
+
+    fn spawn_blocking<T: Send + 'static>(
+        &self,
+        future: impl Future<Output = T> + Send + 'static,
+    ) -> Task<T> {
+        self.inner
+            .executor
+            .spawn(blocking::unblock(|| async_io::block_on(future)))
+    }
+}

--- a/src/runtime/scheduler/mod.rs
+++ b/src/runtime/scheduler/mod.rs
@@ -1,5 +1,10 @@
 //! Flowgraph Scheduler Trait and Implementations
 #[cfg(feature = "flow_scheduler")]
+mod cpu_pin;
+#[cfg(feature = "flow_scheduler")]
+pub use crate::runtime::scheduler::cpu_pin::CpuPinScheduler;
+
+#[cfg(feature = "flow_scheduler")]
 mod flow;
 #[cfg(feature = "flow_scheduler")]
 pub use crate::runtime::scheduler::flow::FlowScheduler;


### PR DESCRIPTION
This adds a new scheduler that takes a HashMap that indicates to which CPU each block should be pinned.

---

Background: To do some benchmarking, I wanted to have a scheduler in which I could specify manually in which CPU each block should run, similarly to using `set_processor_affinity()` in GNU Radio (this is one of the things I want to compare with in my benchmarks). I have implemented this as a variant of the `FlowScheduler` that takes a `HashMap` defining in which worker each block should go. The reason why I've implemented this custom scheduler in the `futuresdr` crate is because it doesn't seem possible to implement schedulers in an external crate (for instance, `topology.blocks` is private). So now that I have this written, I was wondering if it made sense to contribute this upstream. My initial benchmarks show that this custom scheduler is worse than the regular smol scheduler with no CPU pinning. So this custom scheduler doesn't have much practical use. It can be useful for benchmark/comparison and also in case someone wants to investigate why it performs worse, since the kind of flowgraphs I'm benchmarking should be able to benefit from manual CPU pinning.

I've marked the PR as draft because I'm asking for comment about whether it makes sense to merge this to upstream.