### PR TITLE
Lifted `fft_tag_propagation` to `copy_tag_propagation` public API.

### DIFF
--- a/examples/wlan/src/bin/loopback.rs
+++ b/examples/wlan/src/bin/loopback.rs
@@ -14,11 +14,10 @@ use futuresdr::blocks::MessagePipe;
 use futuresdr::blocks::WebsocketPmtSink;
 use futuresdr::num_complex::Complex32;
 use futuresdr::runtime::buffer::circular::Circular;
-use futuresdr::runtime::Flowgraph;
 use futuresdr::runtime::Pmt;
 use futuresdr::runtime::Runtime;
+use futuresdr::runtime::{copy_tag_propagation, Flowgraph};
 
-use wlan::fft_tag_propagation;
 use wlan::Decoder;
 use wlan::Encoder;
 use wlan::FrameEqualizer;
@@ -62,7 +61,7 @@ fn main() -> Result<()> {
         true,
         Some((1.0f32 / 52.0).sqrt()),
     );
-    fft.set_tag_propagation(Box::new(fft_tag_propagation));
+    fft.set_tag_propagation(Box::new(copy_tag_propagation));
     let fft = fg.add_block(fft);
     fg.connect_stream(mapper, "out", fft, "in")?;
     let prefix = fg.add_block(Prefix::new(PAD_FRONT, PAD_TAIL));
@@ -120,7 +119,7 @@ fn main() -> Result<()> {
     fg.connect_stream(sync_short, "out", sync_long, "in")?;
 
     let mut fft = Fft::new(64);
-    fft.set_tag_propagation(Box::new(fft_tag_propagation));
+    fft.set_tag_propagation(Box::new(copy_tag_propagation));
     let fft = fg.add_block(fft);
     fg.connect_stream(sync_long, "out", fft, "in")?;
 

--- a/examples/wlan/src/bin/rx.rs
+++ b/examples/wlan/src/bin/rx.rs
@@ -12,11 +12,10 @@ use futuresdr::blocks::MessagePipe;
 use futuresdr::blocks::WebsocketPmtSink;
 use futuresdr::macros::connect;
 use futuresdr::num_complex::Complex32;
-use futuresdr::runtime::Flowgraph;
 use futuresdr::runtime::Pmt;
 use futuresdr::runtime::Runtime;
+use futuresdr::runtime::{copy_tag_propagation, Flowgraph};
 
-use wlan::fft_tag_propagation;
 use wlan::parse_channel;
 use wlan::Decoder;
 use wlan::FrameEqualizer;
@@ -104,7 +103,7 @@ fn main() -> Result<()> {
     connect!(fg, sync_short > sync_long);
 
     let mut fft = Fft::new(64);
-    fft.set_tag_propagation(Box::new(fft_tag_propagation));
+    fft.set_tag_propagation(Box::new(copy_tag_propagation));
     let frame_equalizer = FrameEqualizer::new();
     let decoder = Decoder::new();
     let symbol_sink = WebsocketPmtSink::new(9002);

--- a/examples/wlan/src/bin/rx_udp.rs
+++ b/examples/wlan/src/bin/rx_udp.rs
@@ -12,11 +12,10 @@ use futuresdr::blocks::UdpSource;
 use futuresdr::blocks::WebsocketPmtSink;
 use futuresdr::macros::connect;
 use futuresdr::num_complex::Complex32;
-use futuresdr::runtime::Flowgraph;
 use futuresdr::runtime::Pmt;
 use futuresdr::runtime::Runtime;
+use futuresdr::runtime::{copy_tag_propagation, Flowgraph};
 
-use wlan::fft_tag_propagation;
 use wlan::Decoder;
 use wlan::FrameEqualizer;
 use wlan::MovingAverage;
@@ -64,7 +63,7 @@ fn main() -> Result<()> {
     connect!(fg, sync_short > sync_long);
 
     let mut fft = Fft::new(64);
-    fft.set_tag_propagation(Box::new(fft_tag_propagation));
+    fft.set_tag_propagation(Box::new(copy_tag_propagation));
     let frame_equalizer = FrameEqualizer::new();
     let decoder = Decoder::new();
     let symbol_sink = WebsocketPmtSink::new(9002);

--- a/examples/wlan/src/bin/tx.rs
+++ b/examples/wlan/src/bin/tx.rs
@@ -7,11 +7,10 @@ use futuresdr::blocks::seify::SinkBuilder;
 use futuresdr::blocks::Fft;
 use futuresdr::blocks::FftDirection;
 use futuresdr::runtime::buffer::circular::Circular;
-use futuresdr::runtime::Flowgraph;
 use futuresdr::runtime::Pmt;
 use futuresdr::runtime::Runtime;
+use futuresdr::runtime::{copy_tag_propagation, Flowgraph};
 
-use wlan::fft_tag_propagation;
 use wlan::parse_channel;
 use wlan::Encoder;
 use wlan::Mac;
@@ -75,7 +74,7 @@ fn main() -> Result<()> {
         true,
         Some((1.0f32 / 52.0).sqrt()),
     );
-    fft.set_tag_propagation(Box::new(fft_tag_propagation));
+    fft.set_tag_propagation(Box::new(copy_tag_propagation));
     let fft = fg.add_block(fft);
     fg.connect_stream(mapper, "out", fft, "in")?;
     let prefix = fg.add_block(Prefix::new(PAD_FRONT, PAD_TAIL));

--- a/examples/wlan/src/lib.rs
+++ b/examples/wlan/src/lib.rs
@@ -2,8 +2,6 @@
 #![allow(clippy::needless_range_loop)]
 #![allow(clippy::excessive_precision)]
 use futuresdr::num_complex::Complex32;
-use futuresdr::runtime::StreamInput;
-use futuresdr::runtime::StreamOutput;
 
 mod channels;
 pub use channels::channel_to_freq;
@@ -46,15 +44,6 @@ pub const MAX_PAYLOAD_SIZE: usize = 1500;
 pub const MAX_PSDU_SIZE: usize = MAX_PAYLOAD_SIZE + 28; // MAC, CRC
 pub const MAX_SYM: usize = ((16 + 8 * MAX_PSDU_SIZE + 6) / 24) + 1;
 pub const MAX_ENCODED_BITS: usize = (16 + 8 * MAX_PSDU_SIZE + 6) * 2 + 288;
-
-#[allow(clippy::needless_pass_by_ref_mut)]
-pub fn fft_tag_propagation(inputs: &mut [StreamInput], outputs: &mut [StreamOutput]) {
-    debug_assert_eq!(inputs[0].consumed().0, outputs[0].produced());
-    let (n, tags) = inputs[0].consumed();
-    for t in tags.iter().filter(|x| x.index < n) {
-        outputs[0].add_tag_abs(t.index, t.tag.clone());
-    }
-}
 
 #[derive(Clone, Copy, Debug)]
 pub enum Modulation {

--- a/examples/wlan/tests/prefix-vs-tags.rs
+++ b/examples/wlan/tests/prefix-vs-tags.rs
@@ -5,11 +5,10 @@ use futuresdr::blocks::MessageBurst;
 use futuresdr::blocks::NullSink;
 use futuresdr::num_complex::Complex32;
 use futuresdr::runtime::buffer::circular::Circular;
-use futuresdr::runtime::Flowgraph;
 use futuresdr::runtime::Pmt;
 use futuresdr::runtime::Runtime;
+use futuresdr::runtime::{copy_tag_propagation, Flowgraph};
 
-use wlan::fft_tag_propagation;
 use wlan::Encoder;
 use wlan::Mac;
 use wlan::Mapper;
@@ -54,7 +53,7 @@ fn tags_vs_prefix() -> Result<()> {
         true,
         Some((1.0f32 / 52.0).sqrt() * 0.6),
     );
-    fft.set_tag_propagation(Box::new(fft_tag_propagation));
+    fft.set_tag_propagation(Box::new(copy_tag_propagation));
     let fft = fg.add_block(fft);
     fg.connect_stream(mapper, "out", fft, "in")?;
     let prefix = fg.add_block(Prefix::new(PAD_FRONT, PAD_TAIL));

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -58,6 +58,7 @@ pub use stream_io::StreamInput;
 pub use stream_io::StreamIo;
 pub use stream_io::StreamIoBuilder;
 pub use stream_io::StreamOutput;
+pub use tag::copy_tag_propagation;
 pub use tag::ItemTag;
 pub use tag::Tag;
 pub use topology::Topology;

--- a/src/runtime/tag.rs
+++ b/src/runtime/tag.rs
@@ -63,4 +63,27 @@ pub struct ItemTag {
     pub tag: Tag,
 }
 
+/// No-op tag propagation strategy.
 pub fn default_tag_propagation(_inputs: &mut [StreamInput], _outputs: &mut [StreamOutput]) {}
+
+/// Tag propagation strategy where all tags are copied from input to output.
+///
+/// # Note
+///
+/// Assumes `inputs[..].consumed() == outputs[..].produced()`
+///
+/// # Example
+///
+/// ```rust, no_run
+/// # use futuresdr::blocks::Fft;
+/// # use futuresdr::runtime::copy_tag_propagation;
+/// let mut fft = Fft::new(1024);
+/// fft.set_tag_propagation(Box::new(copy_tag_propagation));
+/// ```
+pub fn copy_tag_propagation(inputs: &mut [StreamInput], outputs: &mut [StreamOutput]) {
+    debug_assert_eq!(inputs[0].consumed().0, outputs[0].produced());
+    let (n, tags) = inputs[0].consumed();
+    for t in tags.iter().filter(|x| x.index < n) {
+        outputs[0].add_tag_abs(t.index, t.tag.clone());
+    }
+}


### PR DESCRIPTION
Useful in user code to have this as a canonical means of transferring tags.