### PR TITLE
Added ability to query current Source/Sink config via message.

### DIFF
--- a/src/blocks/seify/sink.rs
+++ b/src/blocks/seify/sink.rs
@@ -1,6 +1,6 @@
 use seify::Device;
 use seify::DeviceTrait;
-use seify::Direction::{Rx, Tx};
+use seify::Direction::Tx;
 use seify::GenericDevice;
 use seify::TxStreamer;
 use std::time::Duration;
@@ -27,6 +27,21 @@ use crate::runtime::WorkIo;
 use super::builder::BuilderType;
 
 /// Seify Sink block
+///
+/// # Ports
+///
+/// * Stream inputs:
+///     - `"in"` (if single channel): `Complex32` I/Q samples
+///     - `"in1"`, `"in2"`, ... (if multiple channels): `Complex32` I/Q samples
+/// * Stream outputs: None
+/// * Message inputs:
+///     - `"freq"`: `f32`, `f64`, `u32`, or `u64` (Hertz) set center tuning frequency, or `Null` to query
+///     - `"gain"`: `f32`, `f64`, `u32`, or `u64` (dB) set gain, or `Null` to query
+///     - `"sample_rate"`: `f32`, `f64`, `u32`, or `u64` (Hertz) sample rate frequency, or `Null` to query
+///     - `"cmd"`: `Pmt` encoded `Config` to apply to all channels at once
+///     - `"config"`: (input ignored) returns the current `Config` for each channel as a `Pmt::VecPmt<Pmt::MapStrPmt>`
+/// * Message outputs:
+///     - `"terminate_out"`: `Pmt::Ok` when stream has finished
 pub struct Sink<D: DeviceTrait + Clone> {
     channels: Vec<usize>,
     dev: Device<D>,

--- a/src/blocks/seify/source.rs
+++ b/src/blocks/seify/source.rs
@@ -24,6 +24,21 @@ use crate::runtime::TypedBlock;
 use crate::runtime::WorkIo;
 
 /// Seify Source block
+///
+/// # Ports
+///
+/// * Stream inputs: None
+/// * Stream outputs:
+///     - `"out"` (if single channel): `Complex32` I/Q samples
+///     - `"out1"`, `"out2"`, ... (if multiple channels): `Complex32` I/Q samples
+/// * Message inputs:
+///     - `"freq"`: `f32`, `f64`, `u32`, or `u64` (Hertz) center tuning frequency, or `Null` to query
+///     - `"gain"`: `f32`, `f64`, `u32`, or `u64` (dB) gain setting, or `Null` to query
+///     - `"sample_rate"`: `f32`, `f64`, `u32`, or `u64` (Hertz) sample rate frequency, or `Null` to query
+///     - `"cmd"`: `Pmt` encoded `Config` to apply to all channels at once
+///     - `"terminate"`: `Pmt::Ok` to terminate the block
+///     - `"config"`: (input ignored) returns the current `Config` for each channel as a `Pmt::VecPmt<Pmt::MapStrPmt>`
+/// * Message outputs: None
 pub struct Source<D: DeviceTrait + Clone> {
     channels: Vec<usize>,
     dev: Device<D>,

--- a/src/blocks/seify/source.rs
+++ b/src/blocks/seify/source.rs
@@ -62,6 +62,7 @@ impl<D: DeviceTrait + Clone> Source<D> {
                 .add_input("sample_rate", Self::sample_rate_handler)
                 .add_input("cmd", Self::cmd_handler)
                 .add_input("terminate", Self::terminate_handler)
+                .add_input("config", Self::get_config_handler)
                 .build(),
             Source {
                 channels,
@@ -165,6 +166,22 @@ impl<D: DeviceTrait + Clone> Source<D> {
             };
         }
         Ok(Pmt::Ok)
+    }
+
+    #[message_handler]
+    fn get_config_handler(
+        &mut self,
+        _io: &mut WorkIo,
+        _mio: &mut MessageIo<Self>,
+        _meta: &mut BlockMeta,
+        _p: Pmt, // Input value is ignored
+    ) -> Result<Pmt> {
+        let mut configs = Vec::with_capacity(self.channels.len());
+        for c in &self.channels {
+            let config = Config::from(&self.dev, Rx, *c)?;
+            configs.push(config.to_serializable_pmt());
+        }
+        Ok(Pmt::VecPmt(configs))
     }
 }
 

--- a/tests/seify.rs
+++ b/tests/seify.rs
@@ -1,3 +1,4 @@
+use anyhow::Context;
 use float_cmp::assert_approx_eq;
 use futuresdr::anyhow::Result;
 use futuresdr::async_io::block_on;
@@ -162,13 +163,10 @@ fn config_cmd_map() -> Result<()> {
     let conf = block_on(fg_handle.callback(src, cfg_port_id, Pmt::Ok))?;
 
     match conf {
-        Pmt::VecPmt(v) => match v.as_slice() {
-            [Pmt::MapStrPmt(m), ..] => {
-                assert_eq!(m.get("freq").unwrap(), &Pmt::F64(102e6));
-                assert_eq!(m.get("sample_rate").unwrap(), &Pmt::F64(1e6));
-            }
-            o => panic!("unexpected pmt type {o:?}"),
-        },
+        Pmt::MapStrPmt(m) => {
+            assert_eq!(m.get("freq").unwrap(), &Pmt::F64(102e6));
+            assert_eq!(m.get("sample_rate").unwrap(), &Pmt::F64(1e6));
+        }
         o => panic!("unexpected pmt type {o:?}"),
     }
     Ok(())


### PR DESCRIPTION
The purpose of this PR is to provide the ability to send a message to the `seify::{Source|Sink}` blocks and get a `Config` with the currently active configuration settings. This is useful for remote operation where it may be important to represent the current settings in a user interface or other coordinating software.