### PR TITLE
Added ability to query `seify` source capabilities, such as frequency range, sample rates, etc.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,6 +74,10 @@ required-features = ["tpb_scheduler"]
 name = "seify"
 required-features = ["seify_dummy"]
 
+[[test]]
+name = "capabilities"
+required-features = ["seify", "soapy"]
+
 [dependencies]
 anyhow = "1.0"
 async-trait = "0.1"
@@ -104,7 +108,7 @@ async-std = "1.12.0"
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 cpal = { version = "0.15", optional = true, features = ['wasm-bindgen'] }
 getrandom = { version = "0.2", features = ["js"] }
-gloo-net = {version = "0.6", default-features = false, features = ["websocket", "json"]}
+gloo-net = { version = "0.6", default-features = false, features = ["websocket", "json"] }
 gloo-timers = { version = "0.3", features = ["futures"] }
 js-sys = "0.3"
 rodio = { version = "0.19", default-features = false, optional = true }
@@ -128,7 +132,7 @@ blocking = "1.6"
 concurrent-queue = "2.5"
 core_affinity = "0.8"
 cpal = { version = "0.15", optional = true }
-hound = {version = "3.5", optional = true }
+hound = { version = "3.5", optional = true }
 libc = "0.2"
 rodio = { version = "0.19", default-features = false, features = ["symphonia-all"], optional = true }
 tokio = { version = "1", features = ["rt"] }
@@ -140,7 +144,7 @@ vulkano-shaders = { version = "0.34", optional = true }
 zmq = { version = "0.10", optional = true }
 
 [target.'cfg(target_os = "linux")'.dependencies]
-lttng-ust = { git = "https://github.com/sprt/lttng-ust-rs.git", version = "0.1.0", optional = true}
+lttng-ust = { git = "https://github.com/sprt/lttng-ust-rs.git", version = "0.1.0", optional = true }
 xilinx-dma = { version = "0.0.10", features = ["async"], optional = true }
 
 [target.'cfg(target_os = "android")'.dependencies]
@@ -149,24 +153,24 @@ android_logger = "0.14"
 [target.'cfg(target_arch = "wasm32")'.dependencies.web-sys]
 version = "0.3"
 features = [
-  'Document',
-  'Element',
-  'HtmlElement',
-  'Navigator',
-  'Node',
-  'Usb',
-  'UsbConfiguration',
-  'UsbControlTransferParameters',
-  'UsbDevice',
-  'UsbDeviceFilter',
-  'UsbDeviceRequestOptions',
-  'UsbInTransferResult',
-  'UsbOutTransferResult',
-  'UsbRecipient',
-  'UsbRequestType',
-  'Window',
-  'WorkerGlobalScope',
-  'WorkerNavigator',
+    'Document',
+    'Element',
+    'HtmlElement',
+    'Navigator',
+    'Node',
+    'Usb',
+    'UsbConfiguration',
+    'UsbControlTransferParameters',
+    'UsbDevice',
+    'UsbDeviceFilter',
+    'UsbDeviceRequestOptions',
+    'UsbInTransferResult',
+    'UsbOutTransferResult',
+    'UsbRecipient',
+    'UsbRequestType',
+    'Window',
+    'WorkerGlobalScope',
+    'WorkerNavigator',
 ]
 
 [build-dependencies]

--- a/src/blocks/seify/capabilities.rs
+++ b/src/blocks/seify/capabilities.rs
@@ -153,35 +153,32 @@ impl TryFrom<&Pmt> for Capabilities {
                 let bandwidth_range = m
                     .get("bandwidth_range")
                     .and_then(|v| Conv(v).try_into().ok());
-                let antennas = m
-                    .get("antennas")
-                    .map(|v| {
-                        if let Pmt::VecPmt(v) = v {
-                            Some(
-                                v.iter()
-                                    .map(|v| {
-                                        if let Pmt::String(s) = v {
-                                            Ok(s.to_string())
-                                        } else {
-                                            Err(Error::msg("unexpected pmt type"))
-                                        }
-                                    })
-                                    .collect::<Result<Vec<String>>>()
-                                    .ok()?,
-                            )
-                        } else {
-                            None
-                        }
-                    })
-                    .flatten();
-                let gain_range = m
-                    .get("gain_range")
-                    .map(|v| Conv(v).try_into().ok())
-                    .flatten();
-                let supports_agc = m
-                    .get("supports_agc")
-                    .map(|v| if let Pmt::Bool(v) = v { Some(*v) } else { None })
-                    .flatten();
+                let antennas = m.get("antennas").and_then(|v| {
+                    if let Pmt::VecPmt(v) = v {
+                        Some(
+                            v.iter()
+                                .map(|v| {
+                                    if let Pmt::String(s) = v {
+                                        Ok(s.to_string())
+                                    } else {
+                                        Err(Error::msg("unexpected pmt type"))
+                                    }
+                                })
+                                .collect::<Result<Vec<String>>>()
+                                .ok()?,
+                        )
+                    } else {
+                        None
+                    }
+                });
+                let gain_range = m.get("gain_range").and_then(|v| Conv(v).try_into().ok());
+                let supports_agc = m.get("supports_agc").and_then(|v| {
+                    if let Pmt::Bool(v) = v {
+                        Some(*v)
+                    } else {
+                        None
+                    }
+                });
 
                 Ok(Capabilities {
                     frequency_range,

--- a/src/blocks/seify/capabilities.rs
+++ b/src/blocks/seify/capabilities.rs
@@ -1,0 +1,205 @@
+use crate::anyhow::Error;
+use crate::anyhow::Result;
+use anyhow::Context;
+use futuresdr_types::Pmt;
+use seify::Device;
+use seify::DeviceTrait;
+use seify::Direction;
+use seify::Range;
+use seify::RangeItem;
+use std::collections::HashMap;
+
+/// Record describing the reported capabilities of a seify [`Device`].
+#[derive(Debug, Clone)]
+pub struct Capabilities {
+    /// Frequency range supported by the device.
+    pub frequency_range: Option<Range>,
+    /// Sample rate range supported by the device.
+    pub sample_rate_range: Option<Range>,
+    /// Bandwidth range supported by the device.
+    pub bandwidth_range: Option<Range>,
+    /// Antennas identified by the device.
+    pub antennas: Option<Vec<String>>,
+    /// General gain ranges supported by the device.
+    pub gain_range: Option<Range>,
+    /// Whether the device supports automatic gain control.
+    pub supports_agc: Option<bool>,
+    // TODO: Frequency components, gain elements, etc.
+}
+
+impl Capabilities {
+    /// Extracts a [`Capabilities`] from a [`Device`], [`Direction`], and channel id.
+    pub fn try_from<D: DeviceTrait + Clone>(
+        dev: &Device<D>,
+        dir: Direction,
+        channel: usize,
+    ) -> Result<Self, Error> {
+        let inner = dev.impl_ref::<D>()?;
+        Ok(Capabilities {
+            frequency_range: inner.frequency_range(dir, channel).ok(),
+            sample_rate_range: inner.get_sample_rate_range(dir, channel).ok(),
+            bandwidth_range: inner.get_bandwidth_range(dir, channel).ok(),
+            antennas: inner.antennas(dir, channel).ok(),
+            gain_range: inner.gain_range(dir, channel).ok(),
+            supports_agc: inner.supports_agc(dir, channel).ok(),
+        })
+    }
+}
+
+/// Newtype to assist in converting between a seify [`Range`] and [`Pmt`].
+struct Conv<'a, T>(&'a T);
+
+impl<'a> From<Conv<'a, Range>> for Pmt {
+    fn from(range: Conv<'a, Range>) -> Self {
+        Pmt::VecPmt(
+            range
+                .0
+                .items
+                .iter()
+                .map(|x| match x {
+                    RangeItem::Interval(min, max) => Pmt::MapStrPmt(HashMap::from([
+                        ("min".to_owned(), Pmt::F64(*min)),
+                        ("max".to_owned(), Pmt::F64(*max)),
+                    ])),
+                    RangeItem::Value(v) => Pmt::F64(*v),
+                    RangeItem::Step(min, max, step) => Pmt::MapStrPmt(HashMap::from([
+                        ("min".to_owned(), Pmt::F64(*min)),
+                        ("max".to_owned(), Pmt::F64(*max)),
+                        ("step".to_owned(), Pmt::F64(*step)),
+                    ])),
+                })
+                .collect(),
+        )
+    }
+}
+
+impl<'a> TryFrom<Conv<'a, Pmt>> for Range {
+    type Error = Error;
+
+    fn try_from(value: Conv<'a, Pmt>) -> Result<Self> {
+        match value.0 {
+            Pmt::VecPmt(v) => {
+                let items = v
+                    .iter()
+                    .map(|x| match x {
+                        Pmt::MapStrPmt(m) => {
+                            let min: f64 =
+                                m.get("min").context("missing min")?.to_owned().try_into()?;
+                            let max = m.get("max").context("missing max")?.to_owned().try_into()?;
+                            let step = m.get("step");
+                            if let Some(step) = step {
+                                Ok(RangeItem::Step(
+                                    min,
+                                    max,
+                                    step.to_owned().try_into().context("step not f64")?,
+                                ))
+                            } else {
+                                Ok(RangeItem::Interval(min, max))
+                            }
+                        }
+                        Pmt::F64(v) => Ok(RangeItem::Value(*v)),
+                        _ => Err(Error::msg("unexpected pmt type")),
+                    })
+                    .collect::<Result<Vec<RangeItem>>>()?;
+                Ok(Range { items })
+            }
+            o => Err(Error::msg(format!("unexpected Pmt value: {:?}", o))),
+        }
+    }
+}
+
+impl From<&Capabilities> for Pmt {
+    fn from(value: &Capabilities) -> Self {
+        let mut m = HashMap::new();
+
+        if let Some(r) = &value.frequency_range {
+            m.insert("frequency_range".to_owned(), Conv(r).into());
+        }
+        if let Some(r) = &value.sample_rate_range {
+            m.insert("sample_rate_range".to_owned(), Conv(r).into());
+        }
+        if let Some(r) = &value.bandwidth_range {
+            m.insert("bandwidth_range".to_owned(), Conv(r).into());
+        }
+        if let Some(v) = &value.antennas {
+            m.insert(
+                "antennas".to_owned(),
+                Pmt::VecPmt(v.iter().map(|v| Pmt::String(v.to_string())).collect()),
+            );
+        }
+        if let Some(r) = &value.gain_range {
+            m.insert("gain_range".to_owned(), Conv(r).into());
+        }
+        if let Some(v) = &value.supports_agc {
+            m.insert("supports_agc".to_owned(), Pmt::Bool(*v));
+        }
+
+        Pmt::MapStrPmt(m)
+    }
+}
+
+impl TryFrom<&Pmt> for Capabilities {
+    type Error = Error;
+
+    fn try_from(value: &Pmt) -> Result<Self> {
+        match value {
+            Pmt::MapStrPmt(m) => {
+                let frequency_range = m
+                    .get("frequency_range")
+                    .and_then(|v| Conv(v).try_into().ok());
+                let sample_rate_range = m
+                    .get("sample_rate_range")
+                    .and_then(|v| Conv(v).try_into().ok());
+                let bandwidth_range = m
+                    .get("bandwidth_range")
+                    .and_then(|v| Conv(v).try_into().ok());
+                let antennas = m
+                    .get("antennas")
+                    .map(|v| {
+                        if let Pmt::VecPmt(v) = v {
+                            Some(
+                                v.iter()
+                                    .map(|v| {
+                                        if let Pmt::String(s) = v {
+                                            Ok(s.to_string())
+                                        } else {
+                                            Err(Error::msg("unexpected pmt type"))
+                                        }
+                                    })
+                                    .collect::<Result<Vec<String>>>()
+                                    .ok()?,
+                            )
+                        } else {
+                            None
+                        }
+                    })
+                    .flatten();
+                let gain_range = m
+                    .get("gain_range")
+                    .map(|v| Conv(v).try_into().ok())
+                    .flatten();
+                let supports_agc = m
+                    .get("supports_agc")
+                    .map(|v| if let Pmt::Bool(v) = v { Some(*v) } else { None })
+                    .flatten();
+
+                Ok(Capabilities {
+                    frequency_range,
+                    sample_rate_range,
+                    bandwidth_range,
+                    antennas,
+                    gain_range,
+                    supports_agc,
+                })
+            }
+            o => Err(Error::msg(format!("unexpected Pmt value: {:?}", o))),
+        }
+    }
+}
+
+impl TryFrom<Pmt> for Capabilities {
+    type Error = Error;
+    fn try_from(value: Pmt) -> Result<Self> {
+        (&value).try_into()
+    }
+}

--- a/src/blocks/seify/mod.rs
+++ b/src/blocks/seify/mod.rs
@@ -8,6 +8,9 @@ mod sink;
 pub use sink::Sink;
 pub use sink::SinkBuilder;
 
+mod capabilities;
 mod source;
+
+pub use capabilities::Capabilities;
 pub use source::Source;
 pub use source::SourceBuilder;

--- a/src/blocks/seify/sink.rs
+++ b/src/blocks/seify/sink.rs
@@ -1,6 +1,6 @@
 use seify::Device;
 use seify::DeviceTrait;
-use seify::Direction::{Rx, Tx};
+use seify::Direction::Tx;
 use seify::GenericDevice;
 use seify::TxStreamer;
 use std::time::Duration;

--- a/src/blocks/seify/sink.rs
+++ b/src/blocks/seify/sink.rs
@@ -1,6 +1,6 @@
 use seify::Device;
 use seify::DeviceTrait;
-use seify::Direction::Tx;
+use seify::Direction::{Rx, Tx};
 use seify::GenericDevice;
 use seify::TxStreamer;
 use std::time::Duration;

--- a/src/blocks/seify/sink.rs
+++ b/src/blocks/seify/sink.rs
@@ -1,6 +1,6 @@
 use seify::Device;
 use seify::DeviceTrait;
-use seify::Direction::{Rx, Tx};
+use seify::Direction::Tx;
 use seify::GenericDevice;
 use seify::TxStreamer;
 use std::time::Duration;
@@ -27,6 +27,21 @@ use crate::runtime::WorkIo;
 use super::builder::BuilderType;
 
 /// Seify Sink block
+///
+/// # Ports
+///
+/// * Stream inputs:
+///     - `"in"` (if single channel): `Complex32` I/Q samples
+///     - `"in1"`, `"in2"`, ... (if multiple channels): `Complex32` I/Q samples
+/// * Stream outputs: None
+/// * Message inputs:
+///     - `"freq"`: `f32`, `f64`, `u32`, or `u64` (Hertz) set center tuning frequency, or `Null` to query
+///     - `"gain"`: `f32`, `f64`, `u32`, or `u64` (dB) set gain, or `Null` to query
+///     - `"sample_rate"`: `f32`, `f64`, `u32`, or `u64` (Hertz) sample rate frequency, or `Null` to query
+///     - `"cmd"`: `Pmt` encoded `Config` to apply to all channels at once
+///     - `"config"`: (input ignored) returns the current `Config` for each channel as a `Pmt::VecPmt<Pmt::MapStrPmt>`
+/// * Message outputs:
+///     - `"terminate_out"`: `Pmt::Ok` when stream has finished
 pub struct Sink<D: DeviceTrait + Clone> {
     channels: Vec<usize>,
     dev: Device<D>,

--- a/src/blocks/seify/source.rs
+++ b/src/blocks/seify/source.rs
@@ -39,6 +39,7 @@ use crate::runtime::WorkIo;
 ///     - `"cmd"`: `Pmt` encoded `Config` to apply to all channels at once
 ///     - `"terminate"`: `Pmt::Ok` to terminate the block
 ///     - `"config"`: `u32`, `u64`, `usize` (channel id) returns the `Config` for the specified channel as a `Pmt::MapStrPmt`
+///     - `"capabilities"`: `u32`, `u64`, `usize` (channel id) returns the for the specified channel as a `Pmt::MapStrPmt`
 /// * Message outputs: None
 pub struct Source<D: DeviceTrait + Clone> {
     channels: Vec<usize>,

--- a/src/blocks/seify/source.rs
+++ b/src/blocks/seify/source.rs
@@ -24,6 +24,21 @@ use crate::runtime::TypedBlock;
 use crate::runtime::WorkIo;
 
 /// Seify Source block
+///
+/// # Ports
+///
+/// * Stream inputs: None
+/// * Stream outputs:
+///     - `"out"` (if single channel): `Complex32` I/Q samples
+///     - `"out1"`, `"out2"`, ... (if multiple channels): `Complex32` I/Q samples
+/// * Message inputs:
+///     - `"freq"`: `f32`, `f64`, `u32`, or `u64` (Hertz) center tuning frequency, or `Null` to query
+///     - `"gain"`: `f32`, `f64`, `u32`, or `u64` (dB) gain setting, or `Null` to query
+///     - `"sample_rate"`: `f32`, `f64`, `u32`, or `u64` (Hertz) sample rate frequency, or `Null` to query
+///     - `"cmd"`: `Pmt` encoded `Config` to apply to all channels at once
+///     - `"terminate"`: `Pmt::Ok` to terminate the block
+///     - `"config"`: (input ignored) returns the current `Config` for each channel as a `Pmt::VecPmt<Pmt::MapStrPmt>`
+/// * Message outputs: None
 pub struct Source<D: DeviceTrait + Clone> {
     channels: Vec<usize>,
     dev: Device<D>,

--- a/src/blocks/seify/source.rs
+++ b/src/blocks/seify/source.rs
@@ -62,6 +62,7 @@ impl<D: DeviceTrait + Clone> Source<D> {
                 .add_input("sample_rate", Self::sample_rate_handler)
                 .add_input("cmd", Self::cmd_handler)
                 .add_input("terminate", Self::terminate_handler)
+                .add_input("config", Self::get_config_handler)
                 .build(),
             Source {
                 channels,
@@ -165,6 +166,22 @@ impl<D: DeviceTrait + Clone> Source<D> {
             };
         }
         Ok(Pmt::Ok)
+    }
+
+    #[message_handler]
+    fn get_config_handler(
+        &mut self,
+        _io: &mut WorkIo,
+        _mio: &mut MessageIo<Self>,
+        _meta: &mut BlockMeta,
+        _p: Pmt, // Input value is ignored
+    ) -> Result<Pmt> {
+        let mut configs = Vec::with_capacity(self.channels.len());
+        for c in &self.channels {
+            let config = Config::from(&self.dev, Rx, *c)?;
+            configs.push(config.to_serializable_pmt());
+        }
+        Ok(Pmt::VecPmt(configs))
     }
 }
 

--- a/tests/capabilities.rs
+++ b/tests/capabilities.rs
@@ -1,7 +1,8 @@
 use futuresdr::anyhow::Result;
-use futuresdr::blocks::seify::{Capabilities, SourceBuilder};
+use futuresdr::blocks::seify::Capabilities;
 use futuresdr_types::Pmt;
-use seify::{Range, RangeItem};
+use seify::Range;
+use seify::RangeItem;
 
 #[test]
 fn cap_pmt_serde() -> Result<()> {
@@ -27,9 +28,10 @@ fn cap_pmt_serde() -> Result<()> {
     };
 
     let pmt = Pmt::from(&capabilities);
-    let back: Capabilities = pmt.try_into()?;
+    let _back: Capabilities = pmt.try_into()?;
 
-    dbg!(back);
+    // TODO: enable after `Capabilities` is `PartialEq`
+    //assert_eq!(capabilities, back);
 
     Ok(())
 }

--- a/tests/capabilities.rs
+++ b/tests/capabilities.rs
@@ -1,0 +1,35 @@
+use futuresdr::anyhow::Result;
+use futuresdr::blocks::seify::{Capabilities, SourceBuilder};
+use futuresdr_types::Pmt;
+use seify::{Range, RangeItem};
+
+#[test]
+fn cap_pmt_serde() -> Result<()> {
+    let capabilities = Capabilities {
+        frequency_range: Some(Range {
+            items: vec![RangeItem::Interval(100.0, 200.0)],
+        }),
+        sample_rate_range: Some(Range {
+            items: vec![RangeItem::Step(1.0, 2.0, 3.0)],
+        }),
+        bandwidth_range: Some(Range {
+            items: vec![RangeItem::Value(10.0)],
+        }),
+        antennas: Some(vec!["antenna1".to_string(), "antenna2".to_string()]),
+        gain_range: Some(Range {
+            items: vec![
+                RangeItem::Interval(0.0, 10.0),
+                RangeItem::Value(20.0),
+                RangeItem::Step(30.0, 40.0, 50.0),
+            ],
+        }),
+        supports_agc: Some(true),
+    };
+
+    let pmt = Pmt::from(&capabilities);
+    let back: Capabilities = pmt.try_into()?;
+
+    dbg!(back);
+
+    Ok(())
+}

--- a/tests/seify.rs
+++ b/tests/seify.rs
@@ -1,3 +1,4 @@
+use anyhow::Context;
 use float_cmp::assert_approx_eq;
 use futuresdr::anyhow::Result;
 use futuresdr::async_io::block_on;
@@ -162,13 +163,10 @@ fn config_cmd_map() -> Result<()> {
     let conf = block_on(fg_handle.callback(src, cfg_port_id, Pmt::Ok))?;
 
     match conf {
-        Pmt::VecPmt(v) => match v.as_slice() {
-            [Pmt::MapStrPmt(m), ..] => {
-                assert_eq!(m.get("freq").unwrap(), &Pmt::F64(102e6));
-                assert_eq!(m.get("sample_rate").unwrap(), &Pmt::F64(1e6));
-            }
-            o => panic!("unexpected pmt type {o:?}"),
-        },
+        Pmt::MapStrPmt(m) => {
+            assert_eq!(m.get("freq").unwrap(), &Pmt::F64(102e6));
+            assert_eq!(m.get("sample_rate").unwrap(), &Pmt::F64(1e6));
+        }
         o => panic!("unexpected pmt type {o:?}"),
     }
     Ok(())

--- a/tests/seify.rs
+++ b/tests/seify.rs
@@ -208,7 +208,7 @@ fn capabilities_query() -> Result<()> {
     assert!(caps.bandwidth_range.is_some());
     assert!(caps.antennas.is_some());
     assert!(caps.supports_agc.is_some());
-    assert!(caps.frequency_range.clone().unwrap().items.len() > 0);
+    assert!(!caps.frequency_range.clone().unwrap().items.is_empty());
     matches!(
         caps.frequency_range.unwrap().items[0],
         RangeItem::Step(min, max, inc) if min > 30e6 && max < 8e9 && inc > 0.0


### PR DESCRIPTION
_NOTE: I need a better understanding of the design goals around sending structures across network channels, i.e. is it `Pmt`-only and the client-side needs to transform into structures, or "serde" over Pmt, or `serde-json`?_

(PR base repository should be the branch for https://github.com/FutureSDR/FutureSDR/pull/163)


WIP; Awaiting: 

* https://github.com/FutureSDR/seify/pull/14
* https://github.com/FutureSDR/FutureSDR/pull/161 
* https://github.com/FutureSDR/FutureSDR/pull/163

## Issues:

* `Range` exists in `seify`, and is only available with the `seify` feature.
* The `Capabilities` type herein needs to be available to both `futuresdr` and `futuresdr-remote`. `futuresdr-types` would be the appropriate place for shared types, but to get the `Range` type would require adding a _feature_ to `futuresdr-types`, pulling in code that shouldn't be a part of a remote client.
* Possible options (none great):
  - Mirror `Range` in a serde-compatible fashion in `futuresdr-types`.
  - Use some other type than `seify::Range` (std `Range` is inadequate)
  - Have `seify` depend on `futuresdr-types`
  - Create a `Pmt` variant for ranges.
  - Leave it to clients to deserialize from [the nested `Pmt` structures](https://github.com/FutureSDR/FutureSDR/pull/164/files#diff-b1b064d2b6f6994a83568d1e539cb119fc034f70d9a3d6192a49ab5ec258ca0cR141-R197).
  - Consider a completely different approach to this capability.
  - Abort adding this to FutureSDR, and implement own custom source.


