### PR TITLE
Improved error reporting when a port is mis-specified on a `Block`.

### DIFF
--- a/src/runtime/topology.rs
+++ b/src/runtime/topology.rs
@@ -170,12 +170,12 @@ impl Topology {
         let src_port_id = match src_port {
             PortId::Name(ref s) => src
                 .stream_output_name_to_id(s)
-                .ok_or(Error::InvalidStreamPort(src_block, src_port.clone()))?,
+                .ok_or(Error::InvalidStreamPort(src.into(), src_port.clone()))?,
             PortId::Index(i) => {
                 if i < src.stream_outputs().len() {
                     i
                 } else {
-                    return Err(Error::InvalidStreamPort(src_block, src_port));
+                    return Err(Error::InvalidStreamPort(src.into(), src_port));
                 }
             }
         };
@@ -184,12 +184,12 @@ impl Topology {
         let dst_port_id = match dst_port {
             PortId::Name(ref s) => dst
                 .stream_input_name_to_id(s)
-                .ok_or(Error::InvalidStreamPort(dst_block, dst_port.clone()))?,
+                .ok_or(Error::InvalidStreamPort(dst.into(), dst_port.clone()))?,
             PortId::Index(i) => {
                 if i < dst.stream_inputs().len() {
                     i
                 } else {
-                    return Err(Error::InvalidStreamPort(dst_block, dst_port));
+                    return Err(Error::InvalidStreamPort(dst.into(), dst_port));
                 }
             }
         };
@@ -238,24 +238,24 @@ impl Topology {
         let src_port_id = match src_port {
             PortId::Name(ref s) => src
                 .message_output_name_to_id(s)
-                .ok_or(Error::InvalidMessagePort(Some(src_block), src_port.clone()))?,
+                .ok_or(Error::InvalidMessagePort(src.into(), src_port.clone()))?,
             PortId::Index(i) => {
                 if i < src.message_outputs().len() {
                     i
                 } else {
-                    return Err(Error::InvalidMessagePort(Some(src_block), src_port.clone()));
+                    return Err(Error::InvalidMessagePort(src.into(), src_port.clone()));
                 }
             }
         };
         let dst_port_id = match dst_port {
             PortId::Name(ref s) => dst
                 .message_input_name_to_id(s)
-                .ok_or(Error::InvalidMessagePort(Some(dst_block), dst_port.clone()))?,
+                .ok_or(Error::InvalidMessagePort(dst.into(), dst_port.clone()))?,
             PortId::Index(i) => {
                 if i < dst.message_outputs().len() {
                     i
                 } else {
-                    return Err(Error::InvalidMessagePort(Some(dst_block), dst_port));
+                    return Err(Error::InvalidMessagePort(dst.into(), dst_port));
                 }
             }
         };

--- a/tests/connect_error.rs
+++ b/tests/connect_error.rs
@@ -1,8 +1,13 @@
 use futuresdr::blocks::Fft;
+use futuresdr::blocks::MessageSink;
+use futuresdr::blocks::MessageSource;
 use futuresdr::blocks::NullSink;
+use futuresdr::blocks::NullSource;
 use futuresdr::runtime::Error;
 use futuresdr::runtime::Flowgraph;
+use futuresdr_types::Pmt;
 use num_complex::Complex;
+use std::time::Duration;
 
 #[test]
 fn connect_type_error() {
@@ -20,10 +25,105 @@ fn connect_type_error() {
     match error {
         o @ Error::ConnectError { .. } => {
             let msg = o.to_string();
-            // println!("{}", msg);
             // Token test for type info.
             assert!(msg.contains("num_complex::Complex<f32>"));
         }
         _ => panic!("Expected ConnectError"),
+    };
+}
+
+#[test]
+fn message_invalid_in_port() {
+    let mut fg = Flowgraph::new();
+    let source = MessageSource::new(Pmt::Ok, Duration::from_secs(1), Some(1));
+    let source = fg.add_block(source);
+    let sink = MessageSink::new();
+    let sink = fg.add_block(sink);
+
+    let result = fg.connect_message(source, "out", sink, "non_existent");
+    assert!(result.is_err());
+
+    let error = result.unwrap_err();
+    match error {
+        o @ Error::InvalidMessagePort { .. } => {
+            let msg = o.to_string();
+            assert!(
+                msg.contains("MessageSink"),
+                "\"{msg}\" does not contain 'MessageSink'"
+            );
+        }
+        _ => panic!("Expected ConnectError"),
+    };
+}
+
+#[test]
+fn message_invalid_out_port() {
+    let mut fg = Flowgraph::new();
+    let source = MessageSource::new(Pmt::Ok, Duration::from_secs(1), Some(1));
+    let source = fg.add_block(source);
+    let sink = MessageSink::new();
+    let sink = fg.add_block(sink);
+
+    let result = fg.connect_message(source, "fictitious", sink, "in");
+    assert!(result.is_err());
+
+    let error = result.unwrap_err();
+    match error {
+        o @ Error::InvalidMessagePort { .. } => {
+            let msg = o.to_string();
+            assert!(
+                msg.contains("MessageSource"),
+                "\"{msg}\" does not contain 'MessageSource'"
+            );
+        }
+        _ => panic!("Expected InvalidMessagePort"),
+    };
+}
+
+#[test]
+fn stream_invalid_in_port() {
+    let mut fg = Flowgraph::new();
+    let source = NullSource::<f32>::new();
+    let source = fg.add_block(source);
+    let sink = NullSink::<f32>::new();
+    let sink = fg.add_block(sink);
+
+    let result = fg.connect_stream(source, "out", sink, "non_existent");
+    assert!(result.is_err());
+
+    let error = result.unwrap_err();
+    match error {
+        o @ Error::InvalidStreamPort { .. } => {
+            let msg = o.to_string();
+            assert!(
+                msg.contains("NullSink"),
+                "\"{msg}\" does not contain 'NullSink'"
+            );
+        }
+        _ => panic!("Expected InvalidStreamPort"),
+    };
+}
+
+#[test]
+fn stream_invalid_out_port() {
+    let mut fg = Flowgraph::new();
+    let source = NullSource::<f32>::new();
+    let source = fg.add_block(source);
+    let sink = NullSink::<f32>::new();
+    let sink = fg.add_block(sink);
+
+    let result = fg.connect_stream(source, "fictitious", sink, "in");
+    assert!(result.is_err());
+
+    let error = result.unwrap_err();
+    match error {
+        o @ Error::InvalidStreamPort { .. } => {
+            let msg = o.to_string();
+            assert!(
+                msg.contains("NullSource"),
+                "\"{msg}\" does not contain 'NullSource'"
+            );
+        }
+        _ => panic!("Expected InvalidStreamPort"),
     };
 }


### PR DESCRIPTION
Update to provide more human-friendly error messages on invalid port specifications:

| Context | Before | After |
|--------|--------|--------|
| Stream | `Block 2 does not have stream port (Name("inner"))` | `Block 'Source' does not have stream port 'inner'` |
| Message | `Block Some(5) does not have message port (Name("out2"))`  | `Block 'MessageSource' does not have message port 'out2'` |


