### PR TITLE
Added Block to enable message transformation via a provided function.

### DIFF
--- a/src/blocks/message_apply.rs
+++ b/src/blocks/message_apply.rs
@@ -1,0 +1,56 @@
+use crate::runtime::BlockMeta;
+use crate::runtime::BlockMetaBuilder;
+use crate::runtime::Kernel;
+use crate::runtime::MessageIo;
+use crate::runtime::MessageIoBuilder;
+use crate::runtime::Pmt;
+use crate::runtime::StreamIoBuilder;
+use crate::runtime::TypedBlock;
+use crate::runtime::WorkIo;
+
+/// This [`Block`] applies a callback function to incoming messages, emitting the result as a new message.
+pub struct MessageApply<F> {
+    callback: F,
+}
+
+impl<F> MessageApply<F>
+where
+    F: FnMut(Pmt) -> crate::runtime::Result<Option<Pmt>> + Send + 'static,
+{
+    /// Apply a function to each incoming message.
+    ///
+    /// `None` values are filtered out.
+    ///
+    /// # Arguments
+    ///
+    /// * `callback`: Function to apply to each incoming message, filtering `None` values.
+    ///
+    pub fn new(callback: F) -> TypedBlock<Self> {
+        TypedBlock::new(
+            BlockMetaBuilder::new("MessageApply").build(),
+            StreamIoBuilder::new().build(),
+            MessageIoBuilder::new()
+                .add_input("in", Self::msg_handler)
+                .add_output("out")
+                .build(),
+            Self { callback },
+        )
+    }
+
+    #[message_handler]
+    async fn msg_handler(
+        &mut self,
+        _io: &mut WorkIo,
+        mio: &mut MessageIo<Self>,
+        _meta: &mut BlockMeta,
+        p: Pmt,
+    ) -> Result<Pmt> {
+        let r = (self.callback)(p)?;
+        if let Some(r) = r {
+            mio.output_mut(0).post(r).await;
+        }
+        Ok(Pmt::Ok)
+    }
+}
+
+impl<F: Send> Kernel for MessageApply<F> {}

--- a/src/blocks/mod.rs
+++ b/src/blocks/mod.rs
@@ -48,6 +48,7 @@
 //! | Block | Usage | WebAssembly? |
 //! |---|---|---|
 //! | [MessageAnnotator] | Wrap every message in a DictStrPmt and add fixed additional fields, to facilitate multiplexing w/o losing the source association | ✅ |
+//! | [MessageApply] | Apply a function to each message, emitting the result as a new message. | ✅ |
 //! | [MessageBurst] | Output a given number of messages in one burst and terminate. | ✅ |
 //! | [MessageCopy] | Forward messages. | ✅ |
 //! | [MessagePipe] | Push received messages into a channel. | ✅ |
@@ -167,6 +168,8 @@ pub mod lttng;
 
 mod message_annotator;
 pub use message_annotator::MessageAnnotator;
+mod message_apply;
+pub use message_apply::MessageApply;
 mod message_burst;
 pub use message_burst::MessageBurst;
 mod message_copy;


### PR DESCRIPTION
This pull request introduces a new block called `MessageApply` to the codebase. The `MessageApply` block applies a callback function to incoming messages and emits the result as a new message. The changes include the implementation of the `MessageApply` block, updates to the module documentation, and the addition of the new block to the module exports.

The most important changes are:

### Implementation of `MessageApply` block:

* [`src/blocks/message_apply.rs`](diffhunk://#diff-21dcc423d8f6fa15d9d327b0ddddf849398f1c133d5aac48ae909c2511e90901R1-R49): Added the implementation of the `MessageApply` block, which includes the struct definition, constructor, and message handler.

### Documentation updates:

* [`src/blocks/mod.rs`](diffhunk://#diff-8366df386de1191fdc893fda226b6f236cab87656a095ba710372aa1f9c9d6caR51): Updated the documentation to include the `MessageApply` block in the list of available blocks.

### Module exports:

* [`src/blocks/mod.rs`](diffhunk://#diff-8366df386de1191fdc893fda226b6f236cab87656a095ba710372aa1f9c9d6caR171-R172): Added `message_apply` module and exported `MessageApply` block.