### PR TITLE
Upgraded Axum to 0.8, migrating breaking changes.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -123,7 +123,7 @@ async-native-tls = { version = "0.5", optional = true }
 async-net = "2.0"
 async-task = "4.7"
 async-tungstenite = "0.28"
-axum = "0.7"
+axum = "0.8"
 blocking = "1.6"
 concurrent-queue = "2.5"
 core_affinity = "0.8"

--- a/examples/custom-routes/Cargo.toml
+++ b/examples/custom-routes/Cargo.toml
@@ -7,5 +7,5 @@ edition = "2021"
 
 [dependencies]
 anyhow = "1.0"
-axum = "0.7"
+axum = "0.8"
 futuresdr = { path = "../../" }

--- a/src/runtime/ctrl_port.rs
+++ b/src/runtime/ctrl_port.rs
@@ -127,14 +127,14 @@ impl ControlPort {
 
         let mut app = Router::new()
             .route("/api/fg/", get(flowgraphs))
-            .route("/api/fg/:fg/", get(flowgraph_description))
-            .route("/api/fg/:fg/block/:blk/", get(block_description))
+            .route("/api/fg/{fg}/", get(flowgraph_description))
+            .route("/api/fg/{fg}/block/{blk}/", get(block_description))
             .route(
-                "/api/fg/:fg/block/:blk/call/:handler/",
+                "/api/fg/{fg}/block/{blk}/call/{handler}/",
                 get(handler_id).post(handler_id_post),
             )
             .route(
-                "/api/block/*foo",
+                "/api/block/{*foo}",
                 any(|uri: Uri| async move {
                     let u = uri.to_string().split_off(11);
                     Redirect::permanent(&format!("/api/fg/0/block/{u}/"))
@@ -144,7 +144,7 @@ impl ControlPort {
             .with_state(self.handle.clone());
 
         if let Some(c) = custom_routes {
-            app = app.nest("/", c);
+            app = app.merge(c);
         }
 
         let frontend = if let Some(ref p) = config::config().frontend_path {


### PR DESCRIPTION
This pull request includes updates to dependencies in `Cargo.toml` and improvements to route handling in `src/runtime/ctrl_port.rs`. The most important changes focus on upgrading the `axum` dependency and modifying route definitions for better consistency and maintainability.

Dependency updates:

* Upgraded `axum` from version `0.7` to `0.8` in `Cargo.toml`.

Route handling migrations required for 0.8:

* Changed route parameter syntax from `:param` to `{param}` in `impl ControlPort`.
* Replaced `nest` method with `merge` for combining routes in `impl ControlPort`.