### PR TITLE
Replaced `unwrap` with error message.

### DIFF
--- a/src/runtime/runtime.rs
+++ b/src/runtime/runtime.rs
@@ -600,11 +600,14 @@ pub(crate) async fn run_flowgraph<S: Scheduler>(
                     .collect();
                 let message_edges = topology.message_edges.clone();
 
-                if tx.send(FlowgraphDescription {
-                    blocks,
-                    stream_edges,
-                    message_edges,
-                }).is_err() {
+                if tx
+                    .send(FlowgraphDescription {
+                        blocks,
+                        stream_edges,
+                        message_edges,
+                    })
+                    .is_err()
+                {
                     error!("Failed to send flowgraph description. Receiver may have disconnected.");
                 }
             }


### PR DESCRIPTION
I had a case where a remote disconnected right after sending requesting a `FlowgraphDescription`, and the `unwrap` after a channel `send` caused the runtime to panic and put things in an unstable state. I replaced this `unwrap` with a log message.

I only addressed the panic caused in this situation, but note there are lots of `unwrap`s in this part of the code. May be prudent for us to review each of these and determine which are logically "`unreachable`" and which are stability liabilities.