### PR TITLE
update LoRa example, update PFB, improve HackRF TX

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,11 +11,11 @@ readme = "README.md"
 description = "An Experimental Async SDR Runtime for Heterogeneous Architectures."
 keywords = ["sdr", "radio", "runtime", "async", "acceleration"]
 categories = [
-  "asynchronous",
-  "concurrency",
-  "hardware-support",
-  "science",
-  "wasm",
+    "asynchronous",
+    "concurrency",
+    "hardware-support",
+    "science",
+    "wasm",
 ]
 
 [workspace]
@@ -94,8 +94,8 @@ wgpu = { version = "26.0", optional = true }
 cpal = { version = "0.16", optional = true, features = ['wasm-bindgen'] }
 getrandom = { version = "0.3", features = ["wasm_js"] }
 gloo-net = { version = "0.6", default-features = false, features = [
-  "websocket",
-  "json",
+    "websocket",
+    "json",
 ] }
 gloo-timers = { version = "0.3", features = ["futures"] }
 js-sys = "0.3"
@@ -123,7 +123,7 @@ hound = { version = "3.5", optional = true }
 libc = "0.2"
 ouroboros = { version = "0.18", optional = true }
 rodio = { version = "0.21", default-features = false, features = [
-  "symphonia-all",
+    "symphonia-all",
 ], optional = true }
 tokio = { version = "1", features = ["rt"] }
 tower-http = { version = "0.6", features = ["add-extension", "cors", "fs"] }
@@ -141,24 +141,24 @@ tracing-android = "0.2"
 [target.'cfg(target_arch = "wasm32")'.dependencies.web-sys]
 version = "0.3"
 features = [
-  'Document',
-  'Element',
-  'HtmlElement',
-  'Navigator',
-  'Node',
-  'Usb',
-  'UsbConfiguration',
-  'UsbControlTransferParameters',
-  'UsbDevice',
-  'UsbDeviceFilter',
-  'UsbDeviceRequestOptions',
-  'UsbInTransferResult',
-  'UsbOutTransferResult',
-  'UsbRecipient',
-  'UsbRequestType',
-  'Window',
-  'WorkerGlobalScope',
-  'WorkerNavigator',
+    'Document',
+    'Element',
+    'HtmlElement',
+    'Navigator',
+    'Node',
+    'Usb',
+    'UsbConfiguration',
+    'UsbControlTransferParameters',
+    'UsbDevice',
+    'UsbDeviceFilter',
+    'UsbDeviceRequestOptions',
+    'UsbInTransferResult',
+    'UsbOutTransferResult',
+    'UsbRecipient',
+    'UsbRequestType',
+    'Window',
+    'WorkerGlobalScope',
+    'WorkerNavigator',
 ]
 
 [build-dependencies]

--- a/examples/adsb/src/tracker.rs
+++ b/examples/adsb/src/tracker.rs
@@ -186,10 +186,10 @@ impl Tracker {
         // and an even frame.
         // Make rec immutable
         let rec = self.aircraft_register.register.get(icao).unwrap();
-        if rec.last_cpr_even.is_some() && rec.last_cpr_odd.is_some() {
+        if let Some(even_cpr_rec) = &rec.last_cpr_even.as_ref()
+            && let Some(odd_cpr_rec) = &rec.last_cpr_odd.as_ref()
+        {
             // The frames must be recent
-            let even_cpr_rec = rec.last_cpr_even.as_ref().unwrap();
-            let odd_cpr_rec = rec.last_cpr_odd.as_ref().unwrap();
             if even_cpr_rec.time < now + ADSB_TIME_RECENT
                 && odd_cpr_rec.time < now + ADSB_TIME_RECENT
             {

--- a/examples/lora/Cargo.toml
+++ b/examples/lora/Cargo.toml
@@ -24,3 +24,6 @@ semtech-udp = { version = "0.12.0", features = ["client"] }
 structopt = "0.3.26"
 tokio = { version = "1", features = ["rt-multi-thread"] }
 triggered = "0.1.3"
+strum_macros = "0.26.4"
+strum = "0.26.3"
+rand = "0.9.0"

--- a/examples/lora/src/bin/rx.rs
+++ b/examples/lora/src/bin/rx.rs
@@ -1,6 +1,7 @@
 use anyhow::Result;
 use anyhow::anyhow;
 use clap::Parser;
+
 use futuresdr::blocks::BlobToUdp;
 use futuresdr::blocks::seify::Builder;
 use futuresdr::prelude::*;
@@ -10,10 +11,13 @@ use lora::Deinterleaver;
 use lora::FftDemod;
 use lora::FrameSync;
 use lora::GrayMapping;
-use lora::HammingDec;
+use lora::HammingDecoder;
 use lora::HeaderDecoder;
 use lora::HeaderMode;
+use lora::default_values::ldro;
 use lora::utils::Bandwidth;
+use lora::utils::Channel;
+use lora::utils::ChannelEnumParser;
 use lora::utils::SpreadingFactor;
 
 #[derive(Parser, Debug)]
@@ -28,19 +32,23 @@ struct Args {
     /// RX Gain
     #[clap(short, long, default_value_t = 50.0)]
     gain: f64,
-    /// Channel Frequency
-    #[clap(short, long)]
-    freq: f64,
+    /// RX Channel
+    #[clap(long, value_parser=ChannelEnumParser, default_value_t = Channel::EU868_1)]
+    channel: Channel,
     /// LoRa Spreading Factor
     #[clap(short, long, value_enum, default_value_t = SpreadingFactor::SF7)]
     spreading_factor: SpreadingFactor,
     /// LoRa Bandwidth
     #[clap(short, long, value_enum, default_value_t = Bandwidth::BW125)]
     bandwidth: Bandwidth,
+    /// LoRa Sync Word
+    #[clap(long, default_value_t = 0x12)]
+    sync_word: u8,
+    /// Oversampling Factor
+    #[clap(long, default_value_t = 4)]
+    oversampling: usize,
 }
 
-const OVERSAMPLING: usize = 4;
-const SOFT_DECODING: bool = false;
 const IMPLICIT_HEADER: bool = false;
 
 fn main() -> Result<()> {
@@ -49,32 +57,44 @@ fn main() -> Result<()> {
     info!("args {:?}", &args);
 
     let src = Builder::new(args.args)?
-        .sample_rate(Into::<f64>::into(args.bandwidth) * OVERSAMPLING as f64)
-        .frequency(args.freq)
+        .sample_rate((Into::<usize>::into(args.bandwidth) * args.oversampling) as f64)
+        .frequency(args.channel.into())
         .gain(args.gain)
         .antenna(args.antenna)
         .build_source()?;
 
     let frame_sync: FrameSync = FrameSync::new(
-        args.freq as u32,
-        args.bandwidth.into(),
-        args.spreading_factor.into(),
+        args.channel,
+        args.bandwidth,
+        args.spreading_factor,
         IMPLICIT_HEADER,
-        vec![],
-        OVERSAMPLING,
+        vec![vec![args.sync_word.into()]],
+        args.oversampling,
         None,
         Some("header_crc_ok"),
         false,
         None,
     );
-    let fft_demod: FftDemod = FftDemod::new(SOFT_DECODING, args.spreading_factor.into());
-    let gray_mapping: GrayMapping = GrayMapping::new(SOFT_DECODING);
-    let deinterleaver: Deinterleaver = Deinterleaver::new(SOFT_DECODING);
-    let hamming_dec: HammingDec = HammingDec::new(SOFT_DECODING);
-    let header_decoder = HeaderDecoder::new(HeaderMode::Explicit, false);
-    let decoder = Decoder::new();
-    let udp_data = BlobToUdp::new("127.0.0.1:55555");
-    let udp_rftap = BlobToUdp::new("127.0.0.1:55556");
+    let fft_demod: FftDemod = FftDemod::new(args.spreading_factor, ldro(args.spreading_factor));
+    let gray_mapping: GrayMapping = GrayMapping::new();
+    let deinterleaver: Deinterleaver =
+        Deinterleaver::new(ldro(args.spreading_factor), args.spreading_factor);
+    let hamming_dec: HammingDecoder = HammingDecoder::new();
+    let header_decoder: HeaderDecoder = HeaderDecoder::new(
+        if IMPLICIT_HEADER {
+            HeaderMode::Implicit {
+                payload_len: 15,
+                has_crc: false,
+                code_rate: 1,
+            }
+        } else {
+            HeaderMode::Explicit
+        },
+        ldro(args.spreading_factor),
+    );
+    let decoder: Decoder = Decoder::new();
+    let udp_data: BlobToUdp = BlobToUdp::new("127.0.0.1:55555");
+    let udp_rftap: BlobToUdp = BlobToUdp::new("127.0.0.1:55556");
 
     let mut fg = Flowgraph::new();
     connect!(fg,

--- a/examples/lora/src/decoder.rs
+++ b/examples/lora/src/decoder.rs
@@ -105,9 +105,10 @@ impl Decoder {
 
             // let data = String::from_utf8_lossy(&dewhitened[..dewhitened.len() - 2]);
             // info!("received frame: {}", data);
-            info!("received frame [bin]: {:02x?}", &dewhitened);
+            info!("DECODER received frame [bin]: {:02x?}", &dewhitened);
             Some(dewhitened)
         } else {
+            info!("DECODER FAILED frame [bin]: {:02x?}", &dewhitened);
             None
         }
     }

--- a/examples/lora/src/default_values.rs
+++ b/examples/lora/src/default_values.rs
@@ -1,0 +1,35 @@
+use crate::utils::CodeRate;
+use crate::utils::SpreadingFactor;
+
+pub const SYNC_WORD_PUBLIC: usize = 0x34;
+pub const SYNC_WORD_PRIVATE: usize = 0x12;
+
+pub const BANDWIDTH: usize = 125_000;
+pub const HAS_CRC: bool = true;
+pub const IMPLICIT_HEADER: bool = false;
+pub const PREAMBLE_LEN: usize = 8;
+pub const PAD_SYMBOLS: usize = 0;
+pub const CODE_RATE_LORAWAN: CodeRate = CodeRate::CR_4_5;
+pub const OVERSAMPLING_TX: usize = 8;
+/// fist block of interleaved PHY header and Payload, always uses CR4/8 -> therefore need all 8 symbols of the interleaved block. always contains the full header
+pub const INTERLEAVED_HEADER_SYMBOL_COUNT: usize = 8;
+pub const SOFT_DECODING: bool = true;
+pub const PACKET_FORWARDER_PORT: u16 = 1730;
+
+pub fn preamble_len(sf: SpreadingFactor) -> usize {
+    if sf == SpreadingFactor::SF5 {
+        12
+    } else {
+        PREAMBLE_LEN
+    }
+}
+pub fn code_rate(sf: SpreadingFactor) -> CodeRate {
+    if sf <= SpreadingFactor::SF6 {
+        CodeRate::CR_4_8
+    } else {
+        CodeRate::CR_4_5
+    }
+}
+pub fn ldro(sf: SpreadingFactor) -> bool {
+    sf >= SpreadingFactor::SF11
+}

--- a/examples/lora/src/fft_demod.rs
+++ b/examples/lora/src/fft_demod.rs
@@ -1,10 +1,10 @@
+use crate::utils::*;
 use futuresdr::num_complex::Complex64;
 use futuresdr::prelude::*;
+use futuresdr::tracing::log::debug;
 use rustfft::FftPlanner;
 use std::collections::HashMap;
 use std::sync::Arc;
-
-use crate::utils::*;
 
 #[allow(non_snake_case)]
 pub fn bessel_I0(x: f64) -> f64 {
@@ -23,43 +23,43 @@ pub fn bessel_I0(x: f64) -> f64 {
     sum
 }
 
-struct State {
-    m_sf: usize,            //< Spreading factor
-    m_cr: usize,            //< Coding rate
-    _m_soft_decoding: bool, //< Hard/Soft decoding
-    // max_log_approx: bool,        //< use Max-log approximation in LLR formula
+pub struct State<T: DemodulatedSymbol> {
+    m_sf: SpreadingFactor,       //< Spreading factor
+    m_cr: usize,                 //< Coding rate
+    max_log_approx: bool,        //< use Max-log approximation in LLR formula
     m_ldro: bool,                //< use low datarate optimisation
     m_symb_numb: usize,          //< number of symbols in the frame
     m_samples_per_symbol: usize, //< Number of samples received per lora symbols
-
     // variable used to perform the FFT demodulation
     base_downchirp: Vec<Complex64>, //< Reference upchirp
     m_downchirp: Vec<Complex32>,    //< Reference downchirp
-    out: Vec<u16>, //< Stores the value to be outputted once a full bloc has been received
-    // llrs_block: Vec<[LLR; MAX_SF]>, //< Stores the LLRs to be outputted once a full bloc has been received
+    out: Vec<T>, //< Stores the value to be outputted once a full bloc has been received
     is_header: bool, //< Indicate that the first block hasn't been fully received
     fft_plan: Arc<dyn rustfft::Fft<f32>>,
-    // soft deoding buffers:
-    // lls: Vec<f64>,       // 2**sf  Log-Likelihood
-    // llrs: [LLR; MAX_SF], //      Log-Likelihood Ratios
+    // soft decoding buffers:
+    lls: Vec<f64>,                       // 2**sf  Log-Likelihood
+    llrs: DemodulatedSymbolSoftDecoding, //      Log-Likelihood Ratios
 }
 
-impl State {
+impl<T> State<T>
+where
+    T: DemodulatedSymbol,
+{
     /// Set spreading factor and init vector sizes accordingly
-    fn set_sf(&mut self, sf: usize) {
-        //Set he new sf for the frame
+    fn set_sf(&mut self, sf: SpreadingFactor) {
+        // Set he new sf for the frame
         // info!("[fft_demod_impl.cc] new sf received {}", sf);
         self.m_sf = sf;
-        self.m_samples_per_symbol = 1_usize << self.m_sf;
+        self.m_samples_per_symbol = self.m_sf.samples_per_symbol();
         self.fft_plan = FftPlanner::new().plan_fft_forward(self.m_samples_per_symbol);
-        self.base_downchirp = build_upchirp(0, sf, 1)
+        self.base_downchirp = build_upchirp(0, sf, 1, false)
             .iter()
             .map(|&x| Complex64::new(x.re as f64, x.im as f64).conj())
             .collect();
     }
 
     ///Compute the FFT and fill the class attributes
-    fn compute_fft_mag(&self, samples: &[Complex32]) -> Vec<f64> {
+    fn compute_fft_mag(&mut self, samples: &[Complex32]) -> Vec<f64> {
         // Multiply with ideal downchirp
         let mut m_dechirped = volk_32fc_x2_multiply_32fc(samples, &self.m_downchirp);
         // do the FFT
@@ -68,149 +68,11 @@ impl State {
         let m_fft_mag_sq = volk_32fc_magnitude_squared_32f(&m_dechirped);
         m_fft_mag_sq.iter().map(|x| *x as f64).collect()
     }
-    //
-    /// Use in Hard-decoding
-    /// Recover the lora symbol value using argmax of the dechirped symbol FFT.
-    /// \param  samples
-    ///         The pointer to the symbol beginning.
-    fn get_symbol_val(&self, samples: &[Complex32]) -> u16 {
-        let m_fft_mag_sq = self.compute_fft_mag(samples);
-        // Return argmax
-        let idx = argmax_f64(&m_fft_mag_sq);
-        idx.try_into().unwrap()
-    }
 
     /// check if the reduced rate should be used
     fn reduced_rate(&self) -> bool {
-        if LEGACY_SF_5_6 {
-            self.is_header || self.m_ldro
-        } else {
-            (self.is_header && self.m_sf >= 7) || (!self.is_header && self.m_ldro)
-        }
+        (self.is_header && self.m_sf >= SpreadingFactor::SF7) || (!self.is_header && self.m_ldro)
     }
-
-    // ///  Use in Soft-decoding
-    // /// Compute the Log-Likelihood Ratios of the SF nbr of bits
-    // fn compute_llrs(&mut self, samples: &[Complex32]) {
-    //     let mut m_fft_mag_sq = self.compute_fft_mag(samples);
-    //     // compute SNR estimate at each received symbol as SNR remains constant during 1 simulation run
-    //     // Estimate signal power
-    //     let symbol_idx = argmax_f64(&m_fft_mag_sq);
-    //     // Estimate noise power
-    //     let mut signal_energy: f64 = 0.;
-    //     let mut noise_energy: f64 = 0.;
-    //
-    //     let n_adjacent_bins = 1; // Put '0' for best accurate SNR estimation but if symbols energy splitted in 2 bins, put '1' for safety
-    //     for (i, &frequency_bin_energy) in m_fft_mag_sq.iter().enumerate() {
-    //         if ((i as isize - symbol_idx as isize).unsigned_abs() % (self.m_samples_per_symbol - 1))
-    //             < 1 + n_adjacent_bins
-    //         {
-    //             signal_energy += frequency_bin_energy;
-    //         } else {
-    //             noise_energy += frequency_bin_energy;
-    //         }
-    //     }
-    //
-    //     // If you want to use a normalized constant identical to all symbols within a frame, but it leads to same performance
-    //     // Lowpass filter update
-    //     //double p = 0.99; // proportion to keep
-    //     //Ps_est = p*Ps_est + (1-p)*  signal_energy / m_samples_per_symbol;
-    //     //Pn_est = p*Pn_est + (1-p)* noise_energy / (m_samples_per_symbol-1-2*n_adjacent_bins); // remove used bins for better estimation
-    //     // Signal and noise power estimation for each received symbol
-    //     let m_ps_est = signal_energy / self.m_samples_per_symbol as f64;
-    //     let m_pn_est = noise_energy / (self.m_samples_per_symbol - 1 - 2 * n_adjacent_bins) as f64;
-    //
-    //     let _snr_db_estimate = 10. * (m_ps_est / m_pn_est).log10();
-    //     // info!("SNR {}", SNRdB_estimate);
-    //     //  Normalize fft_mag to 1 to avoid Bessel overflow
-    //     m_fft_mag_sq = m_fft_mag_sq
-    //         .iter()
-    //         .map(|x| x * self.m_samples_per_symbol as f64)
-    //         .collect();
-    //     // upgrade to avoid for loop
-    //     // Normalized |Y[n]| * sqrt(N) => |Y[n]|² * N (depends on kiss FFT library)
-    //     //m_fft_mag_sq[i] /= Ps_frame; // // Normalize to avoid Bessel overflow (does not change the performances)
-    //     //
-    //     let mut clipping = false;
-    //     #[allow(clippy::needless_range_loop)]
-    //     for n in 0..self.m_samples_per_symbol {
-    //         let bessel_arg = m_ps_est.sqrt() / m_pn_est * m_fft_mag_sq[n].sqrt();
-    //         // Manage overflow of Bessel function
-    //         // 713 ~ log(std::numeric_limits<LLR>::max())
-    //         // if bessel_arg < 713. {
-    //         // println!("{}", LLR::MAX.ln() as usize);
-    //         if bessel_arg < 709. {
-    //             // TODO original limit produces NaNs
-    //             // TODO extremely slow implementation
-    //             // let tmp = bessel::i_nu(0., Complex64::new(bessel_arg, 0.));
-    //             let tmp = bessel_I0(bessel_arg);
-    //             assert!(!tmp.is_nan());
-    //             self.lls[n] = tmp; // compute Bessel safely
-    //         } else {
-    //             //std::cerr << RED << "Log-Likelihood clipping :-( SNR: " << SNRdB_estimate << " |Y|: " << std::sqrt(m_fft_mag_sq[n]) << RESET << std::endl;
-    //             //LLs[n] = std::numeric_limits<LLR>::max();  // clipping
-    //             clipping = true;
-    //             break;
-    //         }
-    //         if self.max_log_approx {
-    //             self.lls[n] = self.lls[n].ln(); // Log-Likelihood
-    //                                             //LLs[n] = m_fft_mag_sq[n]; // same performance with just |Y[n]| or |Y[n]|²
-    //         }
-    //     }
-    //     // change to max-log formula with only |Y[n]|² to avoid overflows, solve LLR computation incapacity in high SNR
-    //     if clipping {
-    //         self.lls.copy_from_slice(&m_fft_mag_sq);
-    //     }
-    //
-    //     // Log-Likelihood Ratio estimations
-    //     if self.max_log_approx {
-    //         for i in 0..self.m_sf {
-    //             // sf bits => sf LLRs
-    //             let mut max_x1: f64 = 0.;
-    //             let mut max_x0: f64 = 0.; // X1 = set of symbols where i-th bit is '1'
-    //             for (n, &ll) in self.lls.iter().enumerate() {
-    //                 // for all symbols n : 0 --> 2^sf
-    //                 // LoRa: shift by -1 and use reduce rate if first block (header)
-    //                 let mut s: usize = my_modulo(n as isize - 1, 1 << self.m_sf)
-    //                     / if self.reduced_rate() { 4 } else { 1 };
-    //                 s = s ^ (s >> 1); // Gray encoding formula               // Gray demap before (in this block)
-    //                 if (s & (1 << i)) != 0 {
-    //                     // if i-th bit of symbol n is '1'
-    //                     if ll > max_x1 {
-    //                         max_x1 = ll
-    //                     }
-    //                 } else {
-    //                     // if i-th bit of symbol n is '0'
-    //                     if ll > max_x0 {
-    //                         max_x0 = ll
-    //                     }
-    //                 }
-    //             }
-    //             self.llrs[self.m_sf - 1 - i] = max_x1 - max_x0; // [MSB ... ... LSB]
-    //         }
-    //     } else {
-    //         // Without max-log approximation of the LLR estimation
-    //         for i in 0..self.m_sf {
-    //             let mut sum_x1: f64 = 0.;
-    //             let mut sum_x0: f64 = 0.; // X1 = set of symbols where i-th bit is '1'
-    //             for (n, &ll) in self.lls.iter().enumerate() {
-    //                 // for all symbols n : 0 --> 2^sf
-    //                 let mut s: usize =
-    //                     ((n - 1) % (1 << self.m_sf)) / if self.reduced_rate() { 4 } else { 1 };
-    //                 s = s ^ (s >> 1); // Gray demap
-    //                 if (s & (1 << i)) != 0 {
-    //                     sum_x1 += ll;
-    //                 }
-    //                 // Likelihood
-    //                 else {
-    //                     sum_x0 += ll;
-    //                 }
-    //             }
-    //             self.llrs[self.m_sf - 1 - i] = sum_x1.ln() - sum_x0.ln();
-    //             // [MSB ... ... LSB]
-    //         }
-    //     }
-    // }
 
     fn next_iteration_possible(
         &self,
@@ -221,35 +83,186 @@ impl State {
             return false;
         }
         let block_size = 4 + if self.is_header { 4 } else { self.m_cr };
-        // if self.m_soft_decoding {
-        //     self.llrs_block.len() < block_size || space_left_in_output >= block_size
-        // } else {
         self.out.len() < block_size || space_left_in_output >= block_size
-        // }
     }
 }
 
 #[derive(Block)]
-pub struct FftDemod<I = DefaultCpuReader<Complex32>, O = DefaultCpuWriter<u16>>
-where
+pub struct FftDemod<
+    T = DemodulatedSymbolSoftDecoding,
+    S = State<DemodulatedSymbolSoftDecoding>,
+    I = DefaultCpuReader<Complex32>,
+    O = DefaultCpuWriter<T>,
+> where
+    T: DemodulatedSymbol,
     I: CpuBufferReader<Item = Complex32>,
-    O: CpuBufferWriter<Item = u16>,
+    O: CpuBufferWriter<Item = T>,
+    S: Demod<T>,
 {
     #[input]
     input: I,
     #[output]
     output: O,
-    s: State,
+    s: S,
     frame_info: Option<HashMap<String, Pmt>>,
 }
 
-impl<I, O> FftDemod<I, O>
+impl State<u16> {
+    /// Use in Hard-decoding
+    /// Recover the lora symbol value using argmax of the dechirped symbol FFT.
+    /// \param  samples
+    ///         The pointer to the symbol beginning.
+    fn get_symbol_val(&mut self, samples: &[Complex32]) -> u16 {
+        let m_fft_mag_sq = self.compute_fft_mag(samples);
+        // Return argmax
+        let idx = argmax_f64(&m_fft_mag_sq);
+        idx.try_into().unwrap()
+    }
+}
+
+impl State<[LLR; MAX_SF]> {
+    ///  Use in Soft-decoding
+    /// Compute the Log-Likelihood Ratios of the SF nbr of bits
+    fn compute_llrs(&mut self, samples: &[Complex32]) {
+        let mut m_fft_mag_sq = self.compute_fft_mag(samples);
+        // compute SNR estimate at each received symbol as SNR remains constant during 1 simulation run
+        // Estimate signal power
+        let symbol_idx = argmax_f64(&m_fft_mag_sq);
+        // Estimate noise power
+        let mut signal_energy: f64 = 0.;
+        let mut noise_energy: f64 = 0.;
+
+        let n_adjacent_bins = 1; // Put '0' for best accurate SNR estimation but if symbols energy splitted in 2 bins, put '1' for safety
+        for (i, &frequency_bin_energy) in m_fft_mag_sq.iter().enumerate() {
+            if ((i as isize - symbol_idx as isize).unsigned_abs() % (self.m_samples_per_symbol - 1))
+                < 1 + n_adjacent_bins
+            {
+                signal_energy += frequency_bin_energy;
+            } else {
+                noise_energy += frequency_bin_energy;
+            }
+        }
+
+        // Signal and noise power estimation for each received symbol
+        let m_ps_est = signal_energy / self.m_samples_per_symbol as f64;
+        let m_pn_est = noise_energy / (self.m_samples_per_symbol - 1 - 2 * n_adjacent_bins) as f64;
+
+        let _snr_db_estimate = 10. * (m_ps_est / m_pn_est).log10();
+        // info!("SNR {}", SNRdB_estimate);
+        // Normalize fft_mag to 1 to avoid Bessel overflow
+        m_fft_mag_sq = m_fft_mag_sq
+            .iter()
+            .map(|x| x * self.m_samples_per_symbol as f64)
+            .collect();
+        let mut clipping = false;
+        #[allow(clippy::needless_range_loop)]
+        for n in 0..self.m_samples_per_symbol {
+            let bessel_arg = m_ps_est.sqrt() / m_pn_est * m_fft_mag_sq[n].sqrt();
+            // Manage overflow of Bessel function
+            // 713 ~ log(std::numeric_limits<LLR>::max())
+            // original limit of 713 produces NaNs -> use slightly lower limit
+            if bessel_arg < 709. {
+                let tmp = bessel_I0(bessel_arg);
+                assert!(!tmp.is_nan());
+                self.lls[n] = tmp; // compute Bessel safely
+            } else {
+                debug!("Log-Likelihood clipping");
+                clipping = true;
+                break;
+            }
+            if self.max_log_approx {
+                self.lls[n] = self.lls[n].ln(); // Log-Likelihood
+                // LLs[n] = m_fft_mag_sq[n]; // same performance with just |Y[n]| or |Y[n]|²
+            }
+        }
+        // change to max-log formula with only |Y[n]|² to avoid overflows, solve LLR computation incapacity in high SNR
+        if clipping {
+            self.lls.copy_from_slice(&m_fft_mag_sq);
+        }
+
+        // Log-Likelihood Ratio estimations
+        if self.max_log_approx {
+            for i in 0..Into::<usize>::into(self.m_sf) {
+                // sf bits => sf LLRs
+                let mut max_x1: f64 = 0.;
+                let mut max_x0: f64 = 0.; // X1 = set of symbols where i-th bit is '1'
+                for (n, &ll) in self.lls.iter().enumerate() {
+                    // for all symbols n : 0 --> 2^sf
+                    // LoRa: shift by -1 and use reduce rate if first block (header)
+                    let mut s: usize = my_modulo(n as isize - 1, self.m_sf.samples_per_symbol())
+                        / if self.reduced_rate() { 4 } else { 1 };
+                    s = s ^ (s >> 1); // Gray encoding formula               // Gray demap before (in this block)
+                    if (s & (1 << i)) != 0 {
+                        // if i-th bit of symbol n is '1'
+                        if ll > max_x1 {
+                            max_x1 = ll
+                        }
+                    } else {
+                        // if i-th bit of symbol n is '0'
+                        if ll > max_x0 {
+                            max_x0 = ll
+                        }
+                    }
+                }
+                self.llrs[Into::<usize>::into(self.m_sf) - 1 - i] = max_x1 - max_x0; // [MSB ... ... LSB]
+            }
+        } else {
+            // Without max-log approximation of the LLR estimation
+            for i in 0..Into::<usize>::into(self.m_sf) {
+                let mut sum_x1: f64 = 0.;
+                let mut sum_x0: f64 = 0.; // X1 = set of symbols where i-th bit is '1'
+                for (n, &ll) in self.lls.iter().enumerate() {
+                    // for all symbols n : 0 --> 2^sf
+                    let mut s: usize = my_modulo(n as isize - 1, self.m_sf.samples_per_symbol())
+                        / if self.reduced_rate() { 4 } else { 1 };
+                    s = s ^ (s >> 1); // Gray demap
+                    if (s & (1 << i)) != 0 {
+                        sum_x1 += ll;
+                    }
+                    // Likelihood
+                    else {
+                        sum_x0 += ll;
+                    }
+                }
+                self.llrs[Into::<usize>::into(self.m_sf) - 1 - i] = sum_x1.ln() - sum_x0.ln();
+                // [MSB ... ... LSB]
+            }
+        }
+    }
+}
+
+pub trait Demod<T: DemodulatedSymbol>: Send {
+    fn decode_one_symbol(&mut self, samples: &[Complex32]) -> T;
+}
+
+impl Demod<u16> for State<DemodulatedSymbolHardDecoding> {
+    fn decode_one_symbol(&mut self, samples: &[Complex32]) -> DemodulatedSymbolHardDecoding {
+        // Hard decoding
+        // shift by -1 and use reduce rate if first block (header)
+        my_modulo(
+            self.get_symbol_val(samples) as isize - 1,
+            self.m_sf.samples_per_symbol(),
+        ) as u16
+            / if self.reduced_rate() { 4 } else { 1 }
+    }
+}
+
+impl Demod<[LLR; MAX_SF]> for State<DemodulatedSymbolSoftDecoding> {
+    fn decode_one_symbol(&mut self, samples: &[Complex32]) -> DemodulatedSymbolSoftDecoding {
+        self.compute_llrs(samples);
+        self.llrs // Store 'sf' LLRs
+    }
+}
+
+impl<T, I, O> FftDemod<T, State<T>, I, O>
 where
+    T: DemodulatedSymbol,
     I: CpuBufferReader<Item = Complex32>,
-    O: CpuBufferWriter<Item = u16>,
+    O: CpuBufferWriter<Item = T>,
+    State<T>: Demod<T>,
 {
-    pub fn new(soft_decoding: bool, sf_initial: usize) -> Self {
-        let m_samples_per_symbol = 1_usize << sf_initial;
+    pub fn new(sf_initial: SpreadingFactor, ldro: bool) -> Self {
+        let m_samples_per_symbol = sf_initial.samples_per_symbol();
         let fft_plan = FftPlanner::new().plan_fft_forward(m_samples_per_symbol);
 
         let mut input = I::default();
@@ -258,34 +271,34 @@ where
             input,
             output: O::default(),
             frame_info: None,
-            s: State {
+            s: State::<T> {
                 m_sf: sf_initial,
                 m_cr: 0, // initial value irrelevant, set from tag before read
-                _m_soft_decoding: soft_decoding,
-                // max_log_approx: true,
+                max_log_approx: true,
                 m_samples_per_symbol,
-                base_downchirp: build_upchirp(0, sf_initial, 1)
+                base_downchirp: build_upchirp(0, sf_initial, 1, false)
                     .iter()
                     .map(|&x| Complex64::new(x.re as f64, x.im as f64).conj())
                     .collect(),
                 m_downchirp: vec![],
                 out: Vec::with_capacity(8),
-                // llrs_block: Vec::with_capacity(8),
                 is_header: false,
-                m_ldro: false,
+                m_ldro: ldro,
                 m_symb_numb: 0,
                 fft_plan,
-                // lls: vec![0.; m_samples_per_symbol],
-                // llrs: [0.; MAX_SF],
+                lls: vec![0.; m_samples_per_symbol],
+                llrs: [0.; MAX_SF],
             },
         }
     }
 }
 
-impl<I, O> Kernel for FftDemod<I, O>
+impl<T, I, O> Kernel for FftDemod<T, State<T>, I, O>
 where
+    T: DemodulatedSymbol,
     I: CpuBufferReader<Item = Complex32>,
-    O: CpuBufferWriter<Item = u16>,
+    O: CpuBufferWriter<Item = T>,
+    State<T>: Demod<T>,
 {
     async fn work(
         &mut self,
@@ -358,8 +371,9 @@ where
                     } else {
                         panic!()
                     };
-                    let sf = if let Pmt::Usize(tmp) = tag.get("sf").unwrap() {
-                        *tmp
+                    let sf: SpreadingFactor = if let Pmt::Usize(tmp) = tag.get("sf").unwrap() {
+                        SpreadingFactor::try_from(*tmp as u8)
+                            .expect("received invalid spreading factor: {*tmp}")
                     } else {
                         panic!()
                     };
@@ -382,18 +396,13 @@ where
                         })
                         .map(|x| Complex32::new(x.re as f32, x.im as f32))
                         .collect();
-                    // if self.m_soft_decoding {
-                    //     self.llrs_block.clear();
-                    // } else {
                     self.s.out.clear();
-                    // }
                 } else {
                     self.s.m_cr = if let Pmt::Usize(tmp) = tag.get("cr").unwrap() {
                         *tmp
                     } else {
                         panic!()
                     };
-                    // warn!("FftDemod: received new cr {}", self.m_cr);
                     self.s.m_ldro = if let Pmt::Bool(tmp) = tag.get("ldro").unwrap() {
                         *tmp
                     } else {
@@ -415,20 +424,10 @@ where
             .s
             .next_iteration_possible(nitems_to_process, output_len)
         {
-            // if self.m_soft_decoding {
-            //     self.compute_llrs(&input[..self.m_samples_per_symbol]);
-            //     self.llrs_block.push(self.llrs); // Store 'sf' LLRs
-            // } else {
-            // Hard decoding
-            // shift by -1 and use reduce rate if first block (header)
-            self.s.out.push(
-                my_modulo(
-                    self.s.get_symbol_val(&input[..self.s.m_samples_per_symbol]) as isize - 1,
-                    1 << self.s.m_sf,
-                ) as u16
-                    / if self.s.reduced_rate() { 4 } else { 1 },
-            );
-            // }
+            let demodulated_symbol: T = self
+                .s
+                .decode_one_symbol(&input[..self.s.m_samples_per_symbol]);
+            self.s.out.push(demodulated_symbol);
 
             let produced = if self.s.out.len() == block_size {
                 output[0..block_size].clone_from_slice(&self.s.out);
@@ -441,17 +440,10 @@ where
                     );
                 }
                 block_size
-
-            // } else if self.m_soft_decoding && self.llrs_block.len() == block_size {
-            //     let out_buf = sio.output(0).slice::<[LLR; MAX_SF]>();
-            //     out_buf[0..block_size].copy_from_slice(&self.llrs_block);
-            //     self.llrs_block.clear();
-            //     block_size
             } else {
                 0
             };
 
-            // warn!("FftDemod: consumed {self.m_samples_per_symbol}");
             self.input.consume(self.s.m_samples_per_symbol);
             self.output.produce(produced);
 

--- a/examples/lora/src/header_decoder.rs
+++ b/examples/lora/src/header_decoder.rs
@@ -230,7 +230,7 @@ where
                     - ((c4 << 4) + (c3 << 3) + (c2 << 2) + (c1 << 1) + c0) as i16
                     != 0;
                 if head_err || payload_len == 0 {
-                    debug!("Header checksum invalid!");
+                    info!("Header checksum invalid!");
                     if head_err {
                         debug!("Header checksum invalid!");
                     }
@@ -238,6 +238,10 @@ where
                         debug!("Frame can not be empty!");
                         debug!("item to process= {}", nitem_to_consume);
                     }
+                    head_err = true;
+                } else if code_rate > 3 {
+                    info!("Header invalid!");
+                    debug!("Code rate must be within [0, 3]!");
                     head_err = true;
                 } else {
                     debug!("Header checksum valid!");

--- a/examples/lora/src/lib.rs
+++ b/examples/lora/src/lib.rs
@@ -1,30 +1,32 @@
 #![allow(clippy::precedence)]
 
-pub mod decoder;
 pub use decoder::Decoder;
-pub mod deinterleaver;
 pub use deinterleaver::Deinterleaver;
-pub mod encoder;
 pub use encoder::Encoder;
-pub mod fft_demod;
 pub use fft_demod::FftDemod;
-pub mod frame_sync;
 pub use frame_sync::FrameSync;
-pub mod gray_mapping;
 pub use gray_mapping::GrayMapping;
-pub mod hamming_dec;
-pub use hamming_dec::HammingDec;
-pub mod header_decoder;
+pub use hamming_dec::HammingDecoder;
 pub use header_decoder::Frame;
 pub use header_decoder::HeaderDecoder;
 pub use header_decoder::HeaderMode;
+pub use modulator::Modulator;
+pub use packet_forwarder_client::PacketForwarderClient;
+pub use stream_adder::StreamAdder;
+pub use transmitter::Transmitter;
+
+pub mod decoder;
+pub mod default_values;
+pub mod deinterleaver;
+pub mod encoder;
+pub mod fft_demod;
+pub mod frame_sync;
+pub mod gray_mapping;
+pub mod hamming_dec;
+pub mod header_decoder;
 pub mod meshtastic;
 pub mod modulator;
-pub use modulator::Modulator;
 pub mod packet_forwarder_client;
-pub use packet_forwarder_client::PacketForwarderClient;
 pub mod stream_adder;
-pub use stream_adder::StreamAdder;
 pub mod transmitter;
-pub use transmitter::Transmitter;
 pub mod utils;

--- a/examples/lora/src/meshtastic.rs
+++ b/examples/lora/src/meshtastic.rs
@@ -5,6 +5,7 @@ use futuresdr::tracing::info;
 use meshtastic::Message;
 
 use crate::utils::Bandwidth;
+use crate::utils::Channel;
 use crate::utils::CodeRate;
 use crate::utils::SpreadingFactor;
 
@@ -39,118 +40,118 @@ pub enum MeshtasticConfig {
 }
 
 impl MeshtasticConfig {
-    pub fn to_config(&self) -> (Bandwidth, SpreadingFactor, CodeRate, u32, bool) {
+    pub fn to_config(&self) -> (Bandwidth, SpreadingFactor, CodeRate, Channel, bool) {
         match self {
             Self::ShortFastEu => (
                 Bandwidth::BW250,
                 SpreadingFactor::SF7,
                 CodeRate::CR_4_5,
-                869525000,
+                Channel::Custom(869525000),
                 false,
             ),
             Self::ShortSlowEu => (
                 Bandwidth::BW250,
                 SpreadingFactor::SF8,
                 CodeRate::CR_4_5,
-                869525000,
+                Channel::Custom(869525000),
                 false,
             ),
             Self::MediumFastEu => (
                 Bandwidth::BW250,
                 SpreadingFactor::SF9,
                 CodeRate::CR_4_5,
-                869525000,
+                Channel::Custom(869525000),
                 false,
             ),
             Self::MediumSlowEu => (
                 Bandwidth::BW250,
                 SpreadingFactor::SF10,
                 CodeRate::CR_4_5,
-                869525000,
+                Channel::Custom(869525000),
                 false,
             ),
             Self::LongFastEu => (
                 Bandwidth::BW250,
                 SpreadingFactor::SF11,
                 CodeRate::CR_4_5,
-                869525000,
+                Channel::Custom(869525000),
                 false,
             ),
             Self::LongModerateEu => (
                 Bandwidth::BW125,
                 SpreadingFactor::SF11,
                 CodeRate::CR_4_8,
-                869587500,
+                Channel::Custom(869587500),
                 true,
             ),
             Self::LongSlowEu => (
                 Bandwidth::BW125,
                 SpreadingFactor::SF12,
                 CodeRate::CR_4_8,
-                869587500,
+                Channel::Custom(869587500),
                 true,
             ),
             Self::VeryLongSlowEu => (
                 Bandwidth::BW62,
                 SpreadingFactor::SF12,
                 CodeRate::CR_4_8,
-                869492500,
+                Channel::Custom(869492500),
                 true,
             ),
             Self::ShortFastUs => (
                 Bandwidth::BW250,
                 SpreadingFactor::SF7,
                 CodeRate::CR_4_5,
-                906875000,
+                Channel::Custom(906875000),
                 false,
             ),
             Self::ShortSlowUs => (
                 Bandwidth::BW250,
                 SpreadingFactor::SF8,
                 CodeRate::CR_4_5,
-                906875000,
+                Channel::Custom(906875000),
                 false,
             ),
             Self::MediumFastUs => (
                 Bandwidth::BW250,
                 SpreadingFactor::SF9,
                 CodeRate::CR_4_5,
-                906875000,
+                Channel::Custom(906875000),
                 false,
             ),
             Self::MediumSlowUs => (
                 Bandwidth::BW250,
                 SpreadingFactor::SF10,
                 CodeRate::CR_4_5,
-                906875000,
+                Channel::Custom(906875000),
                 false,
             ),
             Self::LongFastUs => (
                 Bandwidth::BW250,
                 SpreadingFactor::SF11,
                 CodeRate::CR_4_5,
-                906875000,
+                Channel::Custom(906875000),
                 false,
             ),
             Self::LongModerateUs => (
                 Bandwidth::BW125,
                 SpreadingFactor::SF11,
                 CodeRate::CR_4_8,
-                904437500,
+                Channel::Custom(904437500),
                 true,
             ),
             Self::LongSlowUs => (
                 Bandwidth::BW125,
                 SpreadingFactor::SF12,
                 CodeRate::CR_4_8,
-                904437500,
+                Channel::Custom(904437500),
                 true,
             ),
             Self::VeryLongSlowUs => (
                 Bandwidth::BW62,
                 SpreadingFactor::SF12,
                 CodeRate::CR_4_8,
-                916218750,
+                Channel::Custom(916218750),
                 true,
             ),
         }

--- a/examples/lora/src/modulator.rs
+++ b/examples/lora/src/modulator.rs
@@ -1,13 +1,12 @@
 use futuresdr::num_complex::Complex32;
 use futuresdr::tracing::warn;
 
-use crate::utils::LEGACY_SF_5_6;
-use crate::utils::build_ref_chirps;
-use crate::utils::build_upchirp;
+use crate::utils::SpreadingFactor;
+use crate::utils::build_upchirp_phase_coherent;
 use crate::utils::expand_sync_word;
 
 pub struct Modulator {
-    spreading_factor: usize,
+    spreading_factor: SpreadingFactor,
     oversampling: usize,
     sync_words: Vec<usize>,
     preamble_len: usize,
@@ -17,39 +16,66 @@ pub struct Modulator {
 
 impl Modulator {
     pub fn new(
-        spreading_factor: usize,
+        spreading_factor: SpreadingFactor,
         oversampling: usize,
         sync_words: Vec<usize>,
-        mut preamble_len: usize,
+        preamble_len: usize,
         pad: usize,
     ) -> Self {
         if preamble_len < 5 {
-            warn!("Preamble length should be at least 5!");
-            preamble_len = 5;
+            warn!("Preamble length should be at least 5!"); // TODO
         }
-        let sync_words = expand_sync_word(sync_words);
+        let sync_words_expanded = expand_sync_word(sync_words.clone());
+        if sync_words[0] != 0x12 && spreading_factor < SpreadingFactor::SF7 {
+            warn!(
+                "LoRa Modulator: selecting sync word other than 0x12 for SF < 7 will likely not work with commercial receivers.\n\tSee e.g. https://github.com/Lora-net/sx1302_hal/issues/124#issuecomment-2173450337"
+            );
+        }
+        for sync_word_symbol in sync_words_expanded.iter() {
+            if *sync_word_symbol >= 1 << Into::<usize>::into(spreading_factor) {
+                panic!(
+                    "LoRa Modulator: can not encode chosen sync word with the given spreading factor: symbol space too small.\n\ttried to encode sync word '{}' (symbol values [{}, {}]), with {}, which only supports symbols within [0; {}].",
+                    sync_words[0],
+                    sync_words_expanded[0],
+                    sync_words_expanded[1],
+                    spreading_factor,
+                    1 << Into::<usize>::into(spreading_factor)
+                );
+            }
+        }
         Modulator {
             spreading_factor,
             oversampling,
-            sync_words,
+            sync_words: sync_words_expanded,
             preamble_len,
             pad_front: pad,
             pad_tail: pad,
         }
     }
 
+    fn samples_from_phase_diff(&self, phase_increments: &[f32]) -> Vec<Complex32> {
+        let mut last_phase = 0.0;
+        phase_increments
+            .iter()
+            .map(|p_i| {
+                let tmp = Complex32::new(1.0, 0.0) * Complex32::from_polar(1., last_phase + *p_i);
+                last_phase += *p_i;
+                tmp
+            })
+            .collect()
+    }
+
     pub fn modulate(&self, frame: Vec<u16>) -> Vec<Complex32> {
-        let (upchirp, downchirp) = build_ref_chirps(self.spreading_factor, self.oversampling);
         let mut preamb_samp_cnt = 0;
 
-        let mut out = vec![Complex32::new(0.0, 0.0); self.pad_front];
+        let mut phase_increments = vec![0.0; self.pad_front];
 
         loop {
             // output preamble part
             if preamb_samp_cnt
                 < self.preamble_len
                     + 5
-                    + if self.spreading_factor < 7 && !LEGACY_SF_5_6 {
+                    + if self.spreading_factor < SpreadingFactor::SF7 {
                         2
                     } else {
                         0
@@ -57,26 +83,72 @@ impl Modulator {
             {
                 // upchirps
                 if preamb_samp_cnt < self.preamble_len {
-                    out.extend_from_slice(&upchirp);
+                    let upchirp = build_upchirp_phase_coherent(
+                        0,
+                        self.spreading_factor.into(),
+                        self.oversampling,
+                        true,
+                        None,
+                        false,
+                    );
+                    phase_increments.extend_from_slice(&upchirp);
                 // sync words
                 } else if preamb_samp_cnt == self.preamble_len {
-                    let sync_upchirp =
-                        build_upchirp(self.sync_words[0], self.spreading_factor, self.oversampling);
-                    out.extend_from_slice(&sync_upchirp);
+                    let sync_upchirp = build_upchirp_phase_coherent(
+                        self.sync_words[0],
+                        self.spreading_factor.into(),
+                        self.oversampling,
+                        true,
+                        None,
+                        false,
+                    );
+                    phase_increments.extend_from_slice(&sync_upchirp);
                 } else if preamb_samp_cnt == self.preamble_len + 1 {
-                    let sync_upchirp =
-                        build_upchirp(self.sync_words[1], self.spreading_factor, self.oversampling);
-                    out.extend_from_slice(&sync_upchirp);
+                    let sync_upchirp = build_upchirp_phase_coherent(
+                        self.sync_words[1],
+                        self.spreading_factor.into(),
+                        self.oversampling,
+                        true,
+                        None,
+                        false,
+                    );
+                    phase_increments.extend_from_slice(&sync_upchirp);
                 // 2.25 downchirps
                 } else if preamb_samp_cnt < self.preamble_len + 4 {
-                    out.extend_from_slice(&downchirp);
+                    let downchirp = build_upchirp_phase_coherent(
+                        0,
+                        self.spreading_factor.into(),
+                        self.oversampling,
+                        false,
+                        None,
+                        false,
+                    );
+                    phase_increments.extend_from_slice(&downchirp);
                 } else if preamb_samp_cnt == self.preamble_len + 4 {
-                    out.extend_from_slice(&downchirp[..downchirp.len() / 4]);
-                } else if self.spreading_factor < 7
-                    && !LEGACY_SF_5_6
+                    let downchirp = build_upchirp_phase_coherent(
+                        0,
+                        self.spreading_factor.into(),
+                        self.oversampling,
+                        false,
+                        Some(
+                            (self.spreading_factor.samples_per_symbol() * self.oversampling) / 4
+                                - self.oversampling, // quarter down is one baseband sample shorter than a quarter symbol
+                        ),
+                        false,
+                    );
+                    phase_increments.extend_from_slice(&downchirp);
+                } else if self.spreading_factor < SpreadingFactor::SF7
                     && preamb_samp_cnt < self.preamble_len + 7
                 {
-                    out.extend_from_slice(&upchirp);
+                    let upchirp = build_upchirp_phase_coherent(
+                        0,
+                        self.spreading_factor.into(),
+                        self.oversampling,
+                        true,
+                        None,
+                        false,
+                    );
+                    phase_increments.extend_from_slice(&upchirp);
                 }
                 preamb_samp_cnt += 1;
             } else {
@@ -85,12 +157,19 @@ impl Modulator {
         }
 
         for sample in frame {
-            let data_upchirp =
-                build_upchirp(sample as usize, self.spreading_factor, self.oversampling);
-            out.extend_from_slice(&data_upchirp);
+            let data_upchirp = build_upchirp_phase_coherent(
+                sample as usize,
+                self.spreading_factor.into(),
+                self.oversampling,
+                true,
+                None,
+                true,
+            );
+            phase_increments.extend_from_slice(&data_upchirp);
         }
 
-        out.extend_from_slice(&vec![Complex32::new(0.0, 0.0); self.pad_tail]);
-        out
+        phase_increments.extend_from_slice(&vec![0.0; self.pad_tail]);
+
+        self.samples_from_phase_diff(&phase_increments)
     }
 }

--- a/src/blocks/burst_pad.rs
+++ b/src/blocks/burst_pad.rs
@@ -1,0 +1,295 @@
+use crate::prelude::*;
+
+enum BurstPadState {
+    Copy(usize, bool),
+    PadHead(usize, usize, bool),
+    PadTail(usize),
+    HaveUntaggedSamples(usize),
+    ClaimPending,
+}
+
+/// Pad head and/or tail of bursts by a fixed amount of samples, extending the burst tag.
+///
+/// # Stream Inputs
+///
+/// `in`: Input, expected to contain "burst_start" named_usize tags
+///
+/// # Stream Outputs
+///
+/// `out`: Output, potentially padded copy of the input samples
+///
+/// # Usage
+/// ```rust
+/// use futuresdr::blocks::{BurstPad, BurstSplit, BurstSizeRewriter};
+/// // use futuresdr::blocks::seify::Builder;
+/// use futuresdr::prelude::*;
+/// /// produces a single tagged burst of 8 zeroes
+/// #[derive(Block)]
+/// struct DummyBurstSource<
+///     O = DefaultCpuWriter<Complex32>,
+/// >
+/// where
+///     O: CpuBufferWriter<Item = Complex32>,
+/// {
+///     #[output]
+///     output: O,
+/// }
+/// impl<O> DummyBurstSource<O>
+/// where
+///     O: CpuBufferWriter<Item = Complex32>,
+/// {
+///     pub fn new() -> Self {
+///         let mut out = O::default();
+///         out.set_min_items(8);
+///         Self{
+///             output: out,
+///         }
+///     }
+/// }
+/// impl<O> Kernel for DummyBurstSource<O>
+/// where
+///     O: CpuBufferWriter<Item = Complex32>,
+/// {
+///     async fn work(
+///         &mut self,
+///         io: &mut WorkIo,
+///         _m: &mut MessageOutputs,
+///         _b: &mut BlockMeta,
+///     ) -> Result<()> {
+///         let (out, mut out_tags) = self.output.slice_with_tags();
+///         if out.len() >= 8 {
+///             out[..8].fill(Complex32::new(0.0, 0.0));
+///             out_tags.add_tag(0, Tag::NamedUsize("burst_start".to_string(), 8));
+///             self.output.produce(8);
+///             io.finished = true;
+///         }
+///         Ok(())
+///     }
+/// }
+/// // example pipeline to enable burst transmissions with the HackRF One in Half-Duplex mode:
+/// // first, extend each burst for individual lossless transmission, as the hackrf might discard queued samples when switching back to receive mode
+/// // then, pad the bursts to multiples of the hackrf transmit buffer size to ensure immediate transmission without the sink waiting to fill the buffer first
+/// // finally, break long bursts up into sub-bursts no longer than the hackrf transmit buffer size, as longer burst transmissions are currently not supported by the driver.
+/// // Overall, this ensures immediate and lossless transmission of bursts. While there is a chance for buffer underflow corrupting frames due to the chunking in the last step, this is very small, as the previous padding and a sufficiently sized buffer at the sink ensure that the required amount of samples to finish the original burst shoud be pretty much immediately available.
+/// fn main() -> Result<()> {
+///     // get a sample stream that contains "burst_start" tags
+///     let source: DummyBurstSource = DummyBurstSource::new();
+///     // keep track of the maximum expected burst size
+///     let mut max_burst_size: usize = 8;
+///     // pad each individual burst (there is only one in this example) to ensure lossless transmission with the HackRF One in Half-Duplex mode
+///     let pad_head: BurstPad = BurstPad::new_for_hackrf();
+///     // keep track of the maximum expected burst size
+///     max_burst_size = pad_head.propagate_max_burst_size(max_burst_size);
+///     // create sink with sufficiently sized input buffer to not stall on large bursts
+///     // let sink = Builder::new("driver=soapy,soapy_driver=hackrf")?
+///     //        .min_in_buffer_size(max_burst_size) // make sure the sink won't deadlock on large bursts due to insufficient buffer size
+///     //        .build_sink()?;
+///     // [connect and run Flowgraph]
+///     Ok(())
+/// }
+/// ```
+#[derive(Block)]
+pub struct BurstPad<
+    T: Copy + Send + 'static = Complex32,
+    I = DefaultCpuReader<T>,
+    O = DefaultCpuWriter<T>,
+> where
+    I: CpuBufferReader<Item = T>,
+    O: CpuBufferWriter<Item = T>,
+{
+    #[input]
+    input: I,
+    #[output]
+    output: O,
+    state: BurstPadState,
+    num_samples_pad_head: usize,
+    num_samples_pad_tail: usize,
+    pad_value: T,
+}
+
+impl<T: Copy + Send + 'static, I, O> BurstPad<T, I, O>
+where
+    I: CpuBufferReader<Item = T>,
+    O: CpuBufferWriter<Item = T>,
+{
+    /// Create [`struct@futuresdr::blocks::CopyAndTag`] block
+    pub fn new(num_samples_head: usize, num_samples_tail: usize, value: T) -> Self {
+        BurstPad::<T, I, O> {
+            input: I::default(),
+            output: O::default(),
+            state: BurstPadState::ClaimPending,
+            num_samples_pad_head: num_samples_head,
+            num_samples_pad_tail: num_samples_tail,
+            pad_value: value,
+        }
+    }
+
+    /// compute the maximum produced burst length based on the maximum expected input sample burst.
+    /// useful for correctly sizing the input buffer of a burst-aware downstream sink to avoid deadlocks, as it needs to wait for the whole burst to be available before starting to precess it.
+    pub fn propagate_max_burst_size(&self, max_input_burst_size: usize) -> usize {
+        self.num_samples_pad_head + max_input_burst_size + self.num_samples_pad_tail
+    }
+}
+
+impl<T: Copy + Send + 'static, I, O> Kernel for BurstPad<T, I, O>
+where
+    I: CpuBufferReader<Item = T>,
+    O: CpuBufferWriter<Item = T>,
+{
+    async fn work(
+        &mut self,
+        io: &mut WorkIo,
+        _m: &mut MessageOutputs,
+        _b: &mut BlockMeta,
+    ) -> Result<()> {
+        let mut consumed = 0;
+        let mut produced = 0;
+
+        let (i, i_tags) = self.input.slice_with_tags();
+        let (o, mut o_tags) = self.output.slice_with_tags();
+        let num_samples_in_input = i.len();
+        let num_slots_in_output = o.len();
+
+        'outer: loop {
+            match self.state {
+                BurstPadState::Copy(num_samples_left, tag_pending) => {
+                    let n_consume = (num_samples_in_input - consumed).min(num_samples_left);
+                    let n_produce = (num_slots_in_output - produced).min(num_samples_left);
+                    let n_copy = n_consume.min(n_produce);
+                    if n_copy > 0 {
+                        if tag_pending {
+                            o_tags.add_tag(
+                                produced,
+                                Tag::NamedUsize(
+                                    "burst_start".to_string(),
+                                    num_samples_left + self.num_samples_pad_tail,
+                                ),
+                            );
+                        }
+                        o[produced..produced + n_copy]
+                            .copy_from_slice(&i[consumed..consumed + n_copy]);
+                        consumed += n_copy;
+                        produced += n_copy;
+                        if n_copy == num_samples_left {
+                            if self.num_samples_pad_tail > 0 {
+                                self.state = BurstPadState::PadTail(self.num_samples_pad_tail);
+                            } else {
+                                self.state = BurstPadState::ClaimPending;
+                            }
+                        } else {
+                            self.state = BurstPadState::Copy(num_samples_left - n_copy, false);
+                        }
+                    } else {
+                        break 'outer;
+                    }
+                }
+                BurstPadState::PadHead(num_samples_left, original_burst_len, tag_pending) => {
+                    let n_produce = (num_slots_in_output - produced).min(num_samples_left);
+                    if n_produce > 0 {
+                        if tag_pending {
+                            o_tags.add_tag(
+                                produced,
+                                Tag::NamedUsize(
+                                    "burst_start".to_string(),
+                                    num_samples_left
+                                        + original_burst_len
+                                        + self.num_samples_pad_tail,
+                                ),
+                            );
+                        }
+                        for slot in o.iter_mut().skip(produced).take(n_produce) {
+                            *slot = self.pad_value;
+                        }
+                        produced += n_produce;
+                        if n_produce == num_samples_left {
+                            self.state = BurstPadState::Copy(original_burst_len, false);
+                        } else {
+                            self.state = BurstPadState::PadHead(
+                                num_samples_left - n_produce,
+                                original_burst_len,
+                                false,
+                            );
+                        }
+                    } else {
+                        break 'outer;
+                    }
+                }
+                BurstPadState::PadTail(num_samples_left) => {
+                    let n_produce = (num_slots_in_output - produced).min(num_samples_left);
+                    if n_produce > 0 {
+                        for slot in o.iter_mut().skip(produced).take(n_produce) {
+                            *slot = self.pad_value;
+                        }
+                        produced += n_produce;
+                        if n_produce == num_samples_left {
+                            self.state = BurstPadState::ClaimPending;
+                        } else {
+                            self.state = BurstPadState::PadTail(num_samples_left - n_produce);
+                        }
+                    } else {
+                        break 'outer;
+                    }
+                }
+                BurstPadState::HaveUntaggedSamples(num_samples_left) => {
+                    self.state = BurstPadState::Copy(num_samples_left, false);
+                    // TODO this just copies
+                }
+                BurstPadState::ClaimPending => {
+                    // get new state depending on available input
+                    if num_samples_in_input - consumed == 0 {
+                        break 'outer;
+                    } else {
+                        self.state = i_tags
+                            .iter()
+                            .find_map(|x| match x {
+                                ItemTag {
+                                    index,
+                                    tag: Tag::NamedUsize(n, len),
+                                } => {
+                                    if n == "burst_start" {
+                                        if *index < consumed {
+                                            warn!("dropping missed Tag: Tag::NamedUsize({n}, {len}) @ index {index}.");
+                                            None
+                                        } else if *index == consumed {
+                                            if self.num_samples_pad_head > 0 {
+                                                Some(BurstPadState::PadHead(
+                                                    self.num_samples_pad_head,
+                                                    *len,
+                                                    true,
+                                                ))
+                                            } else {
+                                                Some(BurstPadState::Copy(*len, true))
+                                            }
+                                        } else {
+                                            Some(BurstPadState::HaveUntaggedSamples(*index - consumed))
+                                        }
+                                    } else {
+                                        None
+                                    }
+                                }
+                                _ => None,
+                            })
+                            .unwrap_or(BurstPadState::HaveUntaggedSamples(
+                                num_samples_in_input - consumed,
+                            ));
+                    }
+                }
+            }
+        }
+
+        if consumed > 0 {
+            // debug!("consumed {consumed} samples");
+            self.input.consume(consumed);
+        }
+        if produced > 0 {
+            // debug!("produced {produced} samples");
+            self.output.produce(produced);
+        }
+
+        if self.input.finished() && consumed == num_samples_in_input {
+            io.finished = true;
+        };
+
+        Ok(())
+    }
+}

--- a/src/blocks/delay.rs
+++ b/src/blocks/delay.rs
@@ -145,8 +145,7 @@ where
                 } else {
                     self.state = State::Skip(n - m);
                 }
-
-                if self.input.finished() {
+                if self.input.finished() && m == i_len {
                     io.finished = true;
                 }
             }

--- a/src/blocks/mod.rs
+++ b/src/blocks/mod.rs
@@ -256,6 +256,8 @@ pub mod zeromq;
 mod zynq;
 #[cfg(all(feature = "zynq", target_os = "linux"))]
 pub use zynq::Zynq;
+mod burst_pad;
+pub use burst_pad::BurstPad;
 #[cfg(all(feature = "zynq", target_os = "linux"))]
 mod zynq_sync;
 #[cfg(all(feature = "zynq", target_os = "linux"))]

--- a/src/blocks/pfb/mod.rs
+++ b/src/blocks/pfb/mod.rs
@@ -1,3 +1,5 @@
 pub(super) mod arb_resampler;
 pub(super) mod channelizer;
 pub(super) mod synthesizer;
+mod utilities;
+mod window_buffer;

--- a/src/blocks/pfb/synthesizer.rs
+++ b/src/blocks/pfb/synthesizer.rs
@@ -1,12 +1,16 @@
-use futuredsp::FirFilter;
-use futuredsp::prelude::*;
+use std::sync::Arc;
+
 use rustfft::Fft;
 use rustfft::FftDirection;
 use rustfft::FftPlanner;
-use std::cmp::min;
-use std::sync::Arc;
+
+use futuredsp::Filter;
+use futuredsp::FirFilter;
 
 use crate::prelude::*;
+
+use super::utilities::partition_filter_taps;
+use super::window_buffer::WindowBuffer;
 
 /// Polyphase Synthesizer.
 #[derive(Block)]
@@ -19,11 +23,12 @@ where
     input: Vec<I>,
     #[output]
     output: O,
+    num_channels: usize,
+    ifft: Arc<dyn Fft<f32>>,
+    fft_buf: Vec<Complex32>,
     fir_filters: Vec<FirFilter<Complex32, Complex32, Vec<f32>>>,
-    taps_per_filter: usize,
-    n_channels: usize,
-    fir_filter_history: Vec<Vec<Complex32>>,
-    fft: Arc<dyn Fft<f32>>,
+    window_buf: Vec<WindowBuffer>,
+    all_windows_filled: bool,
 }
 
 impl<I, O> PfbSynthesizer<I, O>
@@ -32,37 +37,17 @@ where
     O: CpuBufferWriter<Item = Complex32>,
 {
     /// Create Polyphase Synthesizer.
-    pub fn new(n_channels: usize, taps: &[f32]) -> Self {
-        let mut ret = Self {
-            input: (0..n_channels).map(|_| I::default()).collect(),
+    pub fn new(num_channels: usize, taps: &[f32]) -> Self {
+        let (partitioned_filters, filter_length) = partition_filter_taps(taps, num_channels);
+        Self {
+            input: (0..num_channels).map(|_| I::default()).collect(),
             output: O::default(),
-            fir_filters: vec![],
-            taps_per_filter: 0,
-            n_channels,
-            fir_filter_history: vec![
-                vec![
-                    Complex32::new(0.0, 0.0);
-                    (taps.len() as f32 / n_channels as f32).ceil() as usize
-                ];
-                n_channels
-            ],
-            fft: FftPlanner::new().plan_fft(n_channels, FftDirection::Inverse),
-        };
-        ret.set_taps(taps);
-        ret
-    }
-
-    fn set_taps(&mut self, taps: &[f32]) {
-        self.fir_filters = vec![];
-        self.taps_per_filter = (taps.len() as f32 / self.n_channels as f32).ceil() as usize;
-        for i in 0..self.n_channels {
-            let mut taps_tmp: Vec<f32> =
-                taps[i..].iter().step_by(self.n_channels).copied().collect();
-            if taps_tmp.len() < self.taps_per_filter {
-                taps_tmp.push(0.);
-            }
-            self.fir_filters
-                .push(FirFilter::<Complex32, Complex32, _>::new(taps_tmp));
+            num_channels,
+            ifft: FftPlanner::new().plan_fft(num_channels, FftDirection::Inverse),
+            fft_buf: vec![Complex32::default(); num_channels],
+            fir_filters: partitioned_filters,
+            window_buf: vec![WindowBuffer::new(filter_length, false); num_channels],
+            all_windows_filled: false,
         }
     }
 }
@@ -79,67 +64,59 @@ where
         _m: &mut MessageOutputs,
         _b: &mut BlockMeta,
     ) -> Result<()> {
-        let n_items_available = self
-            .input
-            .iter_mut()
-            .map(|x| x.slice().len())
-            .min()
-            .unwrap();
-        let n_items_to_consume = n_items_available; // ensure we leave enough samples for "overlapping" FIR filter iterations (ref. "history" property of GNU Radio blocks)
         let out = self.output.slice();
+        let inputs: Vec<&[Complex32]> = self.input.iter_mut().map(|x| x.slice()).collect();
+        let n_items_to_consume = inputs.iter().map(|x| x.len()).min().unwrap();
         let n_items_to_produce = out.len();
-        let n_items_to_process = min(n_items_to_produce / self.n_channels, n_items_to_consume);
 
-        if n_items_to_process > 0 {
-            let mut fft_buf: Vec<Complex32> = vec![Complex32::new(0., 0.); self.n_channels];
-            let mut fir_inputs: Vec<Vec<Complex32>> =
-                vec![
-                    vec![Complex32::new(0.0, 0.0); n_items_to_process + self.taps_per_filter];
-                    self.n_channels
-                ];
-
-            for n in 0..n_items_to_process {
-                #[allow(clippy::needless_range_loop)]
-                for i in 0..self.n_channels {
-                    let input = &self.input[i].slice()[0..n_items_to_process];
-                    fft_buf[i] = input[n];
-                }
-                self.fft.process(&mut fft_buf);
-                for i in 0..self.n_channels {
-                    fir_inputs[i][self.taps_per_filter + n] = fft_buf[i];
+        let mut consumed_per_channel: usize = 0;
+        let mut produced: usize = 0;
+        while n_items_to_consume - consumed_per_channel > 0
+            && (n_items_to_produce - produced > self.num_channels || !self.all_windows_filled)
+        {
+            // interleave input streams, taking self.num_channels samples
+            for (input, fft_input_slot) in inputs.iter().zip(self.fft_buf.iter_mut()) {
+                *fft_input_slot = input[consumed_per_channel];
+            }
+            consumed_per_channel += 1;
+            // spin through IFFT
+            self.ifft.process(&mut self.fft_buf);
+            for ((window, fir_filter), spun_sample) in self
+                .window_buf
+                .iter_mut()
+                .zip(self.fir_filters.iter())
+                .zip(self.fft_buf.iter())
+            {
+                window.push(*spun_sample);
+                if window.filled() {
+                    fir_filter.filter(window.get_as_slice(), &mut out[produced..produced + 1]);
+                    produced += 1;
                 }
             }
-
-            #[allow(clippy::needless_range_loop)]
-            for i in 0..self.n_channels {
-                // use history
-                fir_inputs[i][0..self.taps_per_filter].copy_from_slice(&self.fir_filter_history[i]);
-                // update history
-                self.fir_filter_history[i].copy_from_slice(&fir_inputs[i][n_items_to_process..]);
-                let mut fir_output = vec![Complex32::new(0., 0.); n_items_to_process];
-                let _ = self.fir_filters[i].filter(&fir_inputs[i], &mut fir_output);
-                for (out_slot, &fir_out_val) in out
-                    .iter_mut()
-                    .skip(i)
-                    .step_by(self.n_channels)
-                    .zip(fir_output.iter())
-                {
-                    *out_slot = fir_out_val;
-                }
-                // for j in n_items_to_process {
-                //     out[i + n_items_to_process * self.n_channels] = fir_output[j];
-                // }
+            if !self.all_windows_filled {
+                self.all_windows_filled = self.window_buf.iter().all(|w| w.filled());
             }
-
-            for i in 0..self.n_channels {
-                self.input[i].consume(n_items_to_process);
+        }
+        if consumed_per_channel > 0 {
+            for i in 0..self.num_channels {
+                self.input[i].consume(consumed_per_channel);
             }
-            self.output.produce(n_items_to_process * self.n_channels);
+            if produced > 0 {
+                self.output.produce(produced);
+            }
         }
         // each iteration either depletes the available input items or the available space in the out buffer, therefore no manual call_again necessary
         // appropriately propagate flowgraph termination
-        if n_items_to_consume - n_items_to_process == 0
-            && self.input.iter_mut().all(|x| x.finished())
+        let samples_remaining_per_input: Vec<bool> = self
+            .input
+            .iter_mut()
+            .map(|x| x.slice())
+            .map(|x| x.len() - consumed_per_channel == 0)
+            .collect();
+        if samples_remaining_per_input
+            .iter()
+            .zip(self.input.iter().map(|x| x.finished()))
+            .any(|(&out_of_samples, finished)| out_of_samples && finished)
         {
             io.finished = true;
         }

--- a/src/blocks/pfb/utilities.rs
+++ b/src/blocks/pfb/utilities.rs
@@ -1,0 +1,25 @@
+use num_complex::Complex32;
+
+use futuredsp::FirFilter;
+
+pub fn partition_filter_taps(
+    taps: &[f32],
+    n_filters: usize,
+) -> (Vec<FirFilter<Complex32, Complex32, Vec<f32>>>, usize) {
+    let mut fir_filters = vec![];
+    let taps_per_filter = (taps.len() as f32 / n_filters as f32).ceil() as usize;
+    for i in 0..n_filters {
+        let pad = taps_per_filter - ((taps.len() - i) as f32 / n_filters as f32).ceil() as usize;
+        let taps_tmp: Vec<f32> = taps
+            .iter()
+            .skip(i)
+            .step_by(n_filters)
+            .copied()
+            // .rev()
+            .chain(std::iter::repeat_n(0.0, pad))
+            .collect();
+        debug_assert_eq!(taps_tmp.len(), taps_per_filter);
+        fir_filters.push(FirFilter::<Complex32, Complex32, _>::new(taps_tmp));
+    }
+    (fir_filters, taps_per_filter)
+}

--- a/src/blocks/pfb/window_buffer.rs
+++ b/src/blocks/pfb/window_buffer.rs
@@ -1,0 +1,44 @@
+use num_complex::Complex32;
+
+#[derive(Clone, Debug)]
+pub struct WindowBuffer {
+    buffer_len: usize,
+    circular_buffer: Vec<Complex32>,
+    start_idx: usize,
+    num_samples_missing: usize,
+}
+
+impl WindowBuffer {
+    /// Create Circular Window Buffer
+    pub fn new(buffer_len: usize, pad_start: bool) -> WindowBuffer {
+        WindowBuffer {
+            buffer_len,
+            circular_buffer: vec![Complex32::default(); buffer_len * 2],
+            start_idx: 0,
+            num_samples_missing: if pad_start { 0 } else { buffer_len },
+        }
+    }
+
+    /// add a new sample at the end of the window, dropping the oldest one if the window is already filled
+    pub fn push(&mut self, sample: Complex32) {
+        self.circular_buffer[(self.start_idx as isize - self.num_samples_missing as isize)
+            .rem_euclid(self.buffer_len as isize) as usize] = sample;
+        self.circular_buffer[(self.start_idx as isize - self.num_samples_missing as isize)
+            .rem_euclid(self.buffer_len as isize) as usize
+            + self.buffer_len] = sample;
+        self.num_samples_missing = self.num_samples_missing.saturating_sub(1);
+        self.start_idx += 1;
+        self.start_idx %= self.buffer_len;
+    }
+
+    /// access the window as a contiguous slice
+    pub fn get_as_slice(&self) -> &[Complex32] {
+        debug_assert_eq!(self.num_samples_missing, 0);
+        &self.circular_buffer
+            [self.start_idx..self.start_idx + self.buffer_len - self.num_samples_missing]
+    }
+
+    pub fn filled(&self) -> bool {
+        self.num_samples_missing == 0
+    }
+}


### PR DESCRIPTION
specifically improve SF5 and SF6 performance and enable soft-decoding;
exchange PFB implementations with ones derived from liquid-dsp;
add tagged burst processing blocks to enable corruption-free TX of large frames and immediate TX of small ones, including LoRa example;
add min buffer size setter for seify sink builder; 
also clippy