### PR TITLE
lora: unify interfaces

### DIFF
--- a/examples/lora/Cargo.toml
+++ b/examples/lora/Cargo.toml
@@ -27,3 +27,5 @@ triggered = "0.1.3"
 strum_macros = "0.26.4"
 strum = "0.26.3"
 rand = "0.9.0"
+serde = { version = "1.0.228", features = ["derive"] }
+regex = "1.10.4"

--- a/examples/lora/src/bin/loopback.rs
+++ b/examples/lora/src/bin/loopback.rs
@@ -7,20 +7,18 @@ use futuresdr::async_io::Timer;
 use futuresdr::blocks::BlobToUdp;
 use futuresdr::prelude::*;
 
-use lora::Decoder;
-use lora::Deinterleaver;
-use lora::FftDemod;
-use lora::FrameSync;
-use lora::GrayMapping;
-use lora::HammingDecoder;
-use lora::HeaderDecoder;
-use lora::HeaderMode;
-use lora::Transmitter;
-use lora::default_values::ldro;
+use lora::build_lora_rx_soft_decoding;
+use lora::build_lora_tx;
+use lora::default_values::HAS_CRC;
+use lora::default_values::PREAMBLE_LEN;
 use lora::utils::Bandwidth;
 use lora::utils::Channel;
 use lora::utils::CodeRate;
+use lora::utils::HeaderMode;
+use lora::utils::LdroMode;
 use lora::utils::SpreadingFactor;
+use lora::utils::SynchWord;
+use lora::utils::SynchWordEnumParser;
 
 #[derive(Parser, Debug)]
 #[clap(version)]
@@ -32,81 +30,71 @@ struct Args {
     #[clap(long, value_enum, default_value_t = SpreadingFactor::SF7)]
     spreading_factor: SpreadingFactor,
     /// Bandwidth
-    #[clap(long, value_enum, default_value_t = Bandwidth::BW125)]
+    #[clap(long, value_enum, default_value_t)]
     bandwidth: Bandwidth,
     /// Oversampling Factor
     #[clap(long, default_value_t = 1)]
     oversampling: usize,
     /// Sync Word
-    #[clap(long, default_value_t = 0x0816)]
-    sync_word: usize,
+    #[clap(long, value_parser=SynchWordEnumParser, value_enum, default_value_t = SynchWord::Private)]
+    sync_word: SynchWord,
     /// Soft Decoding
     #[clap(long, default_value_t = false)]
     soft_decoding: bool,
     /// LoRa Code Rate
-    #[clap(long, value_enum, default_value_t = CodeRate::CR_4_5)]
+    #[clap(long, value_enum, default_value_t)]
     code_rate: CodeRate,
 }
 
-const HAS_CRC: bool = true;
-const IMPLICIT_HEADER: bool = false;
-const LOW_DATA_RATE: bool = false;
-const PREAMBLE_LEN: usize = 8;
 const PAD: usize = 10000;
 
 fn main() -> Result<()> {
     let args = Args::parse();
+    let ldro = LdroMode::AUTO;
 
     let mut fg = Flowgraph::new();
 
     // ==============================================================
     // TX
     // ==============================================================
-    let transmitter: Transmitter = Transmitter::new(
+    let transmitter = build_lora_tx(
+        &mut fg,
+        args.bandwidth,
+        args.spreading_factor,
         args.code_rate,
         HAS_CRC,
-        args.spreading_factor,
-        LOW_DATA_RATE,
-        IMPLICIT_HEADER,
+        ldro,
+        HeaderMode::Explicit,
         args.oversampling,
-        vec![args.sync_word],
-        PREAMBLE_LEN,
+        args.sync_word,
+        Some(PREAMBLE_LEN),
         PAD,
-    );
+    )?;
 
     // ==============================================================
     // RX
     // ==============================================================
-    let frame_sync: FrameSync = FrameSync::new(
+    let (frame_sync_ref, decoder_ref) = build_lora_rx_soft_decoding(
+        &mut fg,
         Channel::EU868_1,
         args.bandwidth,
         args.spreading_factor,
-        IMPLICIT_HEADER,
-        vec![vec![args.sync_word]],
+        HeaderMode::Explicit,
+        LdroMode::AUTO,
+        Some(&[args.sync_word]),
         args.oversampling,
         None,
         None,
         false,
         None,
-    );
-    let fft_demod: FftDemod = FftDemod::new(args.spreading_factor, ldro(args.spreading_factor));
-    let gray_mapping: GrayMapping = GrayMapping::new();
-    let deinterleaver: Deinterleaver =
-        Deinterleaver::new(ldro(args.spreading_factor), args.spreading_factor);
-    let hamming_dec: HammingDecoder = HammingDecoder::new();
-    let header_decoder: HeaderDecoder = HeaderDecoder::new(HeaderMode::Explicit, false);
-    let decoder: Decoder = Decoder::new();
+    )?;
     let udp_data: BlobToUdp = BlobToUdp::new("127.0.0.1:55555");
     let udp_rftap: BlobToUdp = BlobToUdp::new("127.0.0.1:55556");
     connect!(fg,
-        transmitter > frame_sync > fft_demod > gray_mapping > deinterleaver > hamming_dec > header_decoder;
-        header_decoder.frame_info | frame_info.frame_sync;
-        header_decoder | decoder;
-        decoder.crc_check | payload_crc_result.frame_sync;
-        decoder.out | udp_data;
-        decoder.rftap | udp_rftap;
+        transmitter > frame_sync_ref;
+        decoder_ref.out | udp_data;
+        decoder_ref.rftap | udp_rftap;
     );
-
     let transmitter = transmitter.into();
 
     // ==============================================================

--- a/examples/lora/src/bin/rx.rs
+++ b/examples/lora/src/bin/rx.rs
@@ -5,20 +5,16 @@ use clap::Parser;
 use futuresdr::blocks::BlobToUdp;
 use futuresdr::blocks::seify::Builder;
 use futuresdr::prelude::*;
-
-use lora::Decoder;
-use lora::Deinterleaver;
-use lora::FftDemod;
-use lora::FrameSync;
-use lora::GrayMapping;
-use lora::HammingDecoder;
-use lora::HeaderDecoder;
-use lora::HeaderMode;
-use lora::default_values::ldro;
+use lora::build_lora_rx_soft_decoding;
 use lora::utils::Bandwidth;
 use lora::utils::Channel;
 use lora::utils::ChannelEnumParser;
+use lora::utils::HeaderMode;
+use lora::utils::HeaderModeEnumParser;
+use lora::utils::LdroMode;
 use lora::utils::SpreadingFactor;
+use lora::utils::SynchWord;
+use lora::utils::SynchWordEnumParser;
 
 #[derive(Parser, Debug)]
 #[clap(version)]
@@ -39,22 +35,25 @@ struct Args {
     #[clap(short, long, value_enum, default_value_t = SpreadingFactor::SF7)]
     spreading_factor: SpreadingFactor,
     /// LoRa Bandwidth
-    #[clap(short, long, value_enum, default_value_t = Bandwidth::BW125)]
+    #[clap(short, long, value_enum, default_value_t)]
     bandwidth: Bandwidth,
     /// LoRa Sync Word
-    #[clap(long, default_value_t = 0x12)]
-    sync_word: u8,
+    #[clap(long, value_parser=SynchWordEnumParser, value_enum, default_value_t = SynchWord::Private)]
+    sync_word: SynchWord,
+    /// LoRa Explicit or Implicit Header
+    #[clap(long, value_parser=HeaderModeEnumParser, value_enum, default_value_t)]
+    header_mode: HeaderMode,
     /// Oversampling Factor
     #[clap(long, default_value_t = 4)]
     oversampling: usize,
 }
 
-const IMPLICIT_HEADER: bool = false;
-
 fn main() -> Result<()> {
     futuresdr::runtime::init();
     let args = Args::parse();
     info!("args {:?}", &args);
+
+    let mut fg = Flowgraph::new();
 
     let src = Builder::new(args.args)?
         .sample_rate((Into::<usize>::into(args.bandwidth) * args.oversampling) as f64)
@@ -63,46 +62,26 @@ fn main() -> Result<()> {
         .antenna(args.antenna)
         .build_source()?;
 
-    let frame_sync: FrameSync = FrameSync::new(
+    let (frame_sync_ref, decoder_ref) = build_lora_rx_soft_decoding(
+        &mut fg,
         args.channel,
         args.bandwidth,
         args.spreading_factor,
-        IMPLICIT_HEADER,
-        vec![vec![args.sync_word.into()]],
+        HeaderMode::Explicit,
+        LdroMode::AUTO,
+        Some(&[args.sync_word]),
         args.oversampling,
         None,
         Some("header_crc_ok"),
         false,
         None,
-    );
-    let fft_demod: FftDemod = FftDemod::new(args.spreading_factor, ldro(args.spreading_factor));
-    let gray_mapping: GrayMapping = GrayMapping::new();
-    let deinterleaver: Deinterleaver =
-        Deinterleaver::new(ldro(args.spreading_factor), args.spreading_factor);
-    let hamming_dec: HammingDecoder = HammingDecoder::new();
-    let header_decoder: HeaderDecoder = HeaderDecoder::new(
-        if IMPLICIT_HEADER {
-            HeaderMode::Implicit {
-                payload_len: 15,
-                has_crc: false,
-                code_rate: 1,
-            }
-        } else {
-            HeaderMode::Explicit
-        },
-        ldro(args.spreading_factor),
-    );
-    let decoder: Decoder = Decoder::new();
+    )?;
     let udp_data: BlobToUdp = BlobToUdp::new("127.0.0.1:55555");
     let udp_rftap: BlobToUdp = BlobToUdp::new("127.0.0.1:55556");
-
-    let mut fg = Flowgraph::new();
     connect!(fg,
-        src.outputs[0] > frame_sync > fft_demod > gray_mapping > deinterleaver > hamming_dec > header_decoder;
-        header_decoder.frame_info | frame_info.frame_sync;
-        header_decoder | decoder;
-        decoder | udp_data;
-        decoder.rftap | udp_rftap;
+        src.outputs[0] > frame_sync_ref;
+        decoder_ref | udp_data;
+        decoder_ref.rftap | udp_rftap;
     );
 
     if let Err(e) = Runtime::new().run(fg) {

--- a/examples/lora/src/bin/rx_all_channels_eu.rs
+++ b/examples/lora/src/bin/rx_all_channels_eu.rs
@@ -14,19 +14,14 @@ use futuresdr::blocks::PfbChannelizer;
 use futuresdr::blocks::seify::Builder;
 use futuresdr::prelude::*;
 
-use lora::Decoder;
-use lora::Deinterleaver;
-use lora::FftDemod;
-use lora::FrameSync;
-use lora::GrayMapping;
-use lora::HammingDecoder;
-use lora::HeaderDecoder;
-use lora::HeaderMode;
 use lora::PacketForwarderClient;
-use lora::default_values::ldro;
+use lora::build_lora_rx_soft_decoding;
 use lora::utils::Bandwidth;
 use lora::utils::Channel;
+use lora::utils::HeaderMode;
+use lora::utils::LdroMode;
 use lora::utils::SpreadingFactor;
+use lora::utils::SynchWord;
 
 #[derive(Parser, Debug)]
 #[clap(version)]
@@ -158,37 +153,29 @@ fn main() -> Result<()> {
                 "connecting {:.1}MHz FrameSync with spreading factor {sf}",
                 Into::<f32>::into(channel) / 1.0e6,
             );
-            let frame_sync: FrameSync = FrameSync::new(
+            let (frame_sync_ref, decoder_ref) = build_lora_rx_soft_decoding(
+                &mut fg,
                 channel,
                 BANDWIDTH,
                 sf,
-                false,
-                vec![vec![0x12], vec![0x34]],
+                HeaderMode::Explicit,
+                LdroMode::AUTO,
+                Some(&[SynchWord::Private, SynchWord::Public]),
                 OVERSAMPLING,
                 None,
                 None,
                 false,
                 Some(stream_start_time),
-            );
-            let frame_sync = fg.add_block(frame_sync);
-            fg.connect_dyn(&resampler, "out", &frame_sync, "in")?;
-            let fft_demod: FftDemod = FftDemod::new(sf, ldro(sf));
-            let gray_mapping: GrayMapping = GrayMapping::new();
-            let deinterleaver: Deinterleaver = Deinterleaver::new(ldro(sf), sf);
-            let hamming_dec: HammingDecoder = HammingDecoder::new();
-            let header_decoder = HeaderDecoder::new(HeaderMode::Explicit, ldro(sf));
-            let decoder = Decoder::new();
+            )?;
             let udp_data = BlobToUdp::new("127.0.0.1:55555");
             let udp_rftap = BlobToUdp::new("127.0.0.1:55556");
 
             let resampler_block_ref = resampler.clone();
 
             connect!(fg,
-                resampler_block_ref > frame_sync > fft_demod > gray_mapping > deinterleaver > hamming_dec > header_decoder;
-                header_decoder.frame_info | frame_info.frame_sync;
-                header_decoder | decoder;
-                decoder.out | udp_data;
-                decoder.rftap | udp_rftap;
+                resampler_block_ref > frame_sync_ref;
+                decoder_ref.out | udp_data;
+                decoder_ref.rftap | udp_rftap;
             );
             if let Some(ref pf) = packet_forwarder {
                 let packet_forwarder = pf.clone();
@@ -201,7 +188,7 @@ fn main() -> Result<()> {
                     (String::from("freq"), Pmt::F64(Into::<f64>::into(channel))),
                 ]);
                 let metadata_tagger = MessageAnnotator::new(tags, None);
-                connect!(fg, decoder.out_annotated | metadata_tagger);
+                connect!(fg, decoder_ref.out_annotated | metadata_tagger);
                 connect!(fg, metadata_tagger | packet_forwarder);
             }
         }

--- a/examples/lora/src/bin/rx_meshtastic.rs
+++ b/examples/lora/src/bin/rx_meshtastic.rs
@@ -7,20 +7,15 @@ use futuresdr::blocks::XlatingFir;
 use futuresdr::blocks::seify::Builder;
 use futuresdr::prelude::*;
 
-use lora::Decoder;
-use lora::Deinterleaver;
-use lora::FftDemod;
-use lora::FrameSync;
-use lora::GrayMapping;
-use lora::HammingDecoder;
-use lora::HeaderDecoder;
-use lora::HeaderMode;
+use lora::build_lora_rx_soft_decoding;
 use lora::meshtastic::MeshtasticChannel;
 use lora::meshtastic::MeshtasticChannels;
 use lora::meshtastic::MeshtasticConfig;
+use lora::meshtastic::MeshtasticConfigEnumParser;
 use lora::utils::Bandwidth;
+use lora::utils::HeaderMode;
+use lora::utils::SynchWord;
 
-const IMPLICIT_HEADER: bool = false;
 const OVERSAMPLING: usize = 4;
 
 #[derive(Parser, Debug)]
@@ -35,7 +30,7 @@ struct Args {
     #[clap(short, long, default_value_t = 50.0)]
     gain: f64,
     /// Meshtastic LoRa Config
-    #[clap(short, long, value_enum, default_value_t = MeshtasticConfig::LongFastEu)]
+    #[clap(short, long, value_parser=MeshtasticConfigEnumParser, value_enum, default_value_t = MeshtasticConfig::LongFastEu)]
     meshtastic_config: MeshtasticConfig,
     /// Meshtastic Channels (Format: <name>:<base64key>,<name>:<base64key>,..)
     #[clap(short, long)]
@@ -58,6 +53,8 @@ fn main() -> Result<()> {
 
     println!("channels: {channels:?}");
 
+    let mut fg = Flowgraph::new();
+
     let src = Builder::new(args.args)?
         .sample_rate(1e6)
         .frequency(Into::<f64>::into(chan) - 200e3)
@@ -76,36 +73,26 @@ fn main() -> Result<()> {
     let taps = firdes::kaiser::lowpass(cutoff, transition_bw, 0.05);
     let decimation: XlatingFir = XlatingFir::with_taps(taps, decimation, 200e3, 1e6);
 
-    let frame_sync: FrameSync = FrameSync::new(
+    let (frame_sync_ref, decoder_ref) = build_lora_rx_soft_decoding(
+        &mut fg,
         chan,
         bandwidth,
         spreading_factor,
-        IMPLICIT_HEADER,
-        vec![vec![16, 88]],
+        HeaderMode::Explicit,
+        ldro,
+        Some(&[SynchWord::Meshtastic]),
         OVERSAMPLING,
         None,
         Some("header_crc_ok"),
         false,
         None,
-    );
-    let fft_demod: FftDemod = FftDemod::new(spreading_factor, ldro);
-    let gray_mapping: GrayMapping = GrayMapping::new();
-    let deinterleaver: Deinterleaver = Deinterleaver::new(ldro, spreading_factor);
-    let hamming_dec: HammingDecoder = HammingDecoder::new();
-    let header_decoder: HeaderDecoder = HeaderDecoder::new(HeaderMode::Explicit, ldro);
-    let decoder: Decoder = Decoder::new();
+    )?;
 
     let (tx_frame, mut rx_frame) = mpsc::channel::<Pmt>(100);
     let message_pipe = MessagePipe::new(tx_frame);
-
-    let mut fg = Flowgraph::new();
     connect!(fg,
-        src.outputs[0] > decimation > frame_sync;
-        frame_sync > fft_demod;
-        fft_demod > gray_mapping > deinterleaver > hamming_dec > header_decoder;
-        header_decoder.frame_info | frame_info.frame_sync;
-        header_decoder | decoder;
-        decoder | message_pipe;
+        src.outputs[0] > decimation > frame_sync_ref;
+        decoder_ref.out_annotated | message_pipe;
     );
 
     let rt = Runtime::new();
@@ -116,12 +103,14 @@ fn main() -> Result<()> {
         for c in channels {
             chans.add_channel(MeshtasticChannel::new(&c.0, &c.1));
         }
-        while let Some(x) = rx_frame.next().await {
-            match x {
-                Pmt::Blob(data) => {
-                    chans.decode(&data[..data.len() - 2]);
+        loop {
+            while let Ok(x) = rx_frame.recv().await {
+                match x {
+                    Pmt::Blob(data) => {
+                        chans.decode(&data[..data.len() - 2]);
+                    }
+                    _ => break,
                 }
-                _ => break,
             }
         }
     });

--- a/examples/lora/src/bin/rx_meshtastic_all_channels.rs
+++ b/examples/lora/src/bin/rx_meshtastic_all_channels.rs
@@ -7,21 +7,16 @@ use futuresdr::blocks::XlatingFir;
 use futuresdr::blocks::seify::Builder;
 use futuresdr::prelude::*;
 
-use lora::Decoder;
-use lora::Deinterleaver;
-use lora::FftDemod;
-use lora::FrameSync;
-use lora::GrayMapping;
-use lora::HammingDecoder;
-use lora::HeaderDecoder;
-use lora::HeaderMode;
+use lora::build_lora_rx_soft_decoding;
 use lora::meshtastic::MeshtasticChannel;
 use lora::meshtastic::MeshtasticChannels;
 use lora::utils::Bandwidth;
 use lora::utils::Channel;
+use lora::utils::HeaderMode;
+use lora::utils::LdroMode;
 use lora::utils::SpreadingFactor;
+use lora::utils::SynchWord;
 
-const IMPLICIT_HEADER: bool = false;
 const OVERSAMPLING: usize = 4;
 
 #[derive(Debug, Clone, clap::ValueEnum, Copy, Default)]
@@ -73,22 +68,25 @@ fn main() -> Result<()> {
                     Bandwidth::BW250,
                     Channel::Custom(869_525_000),
                     vec![
-                        (SpreadingFactor::SF7, false),
-                        (SpreadingFactor::SF8, false),
-                        (SpreadingFactor::SF9, false),
-                        (SpreadingFactor::SF10, false),
-                        (SpreadingFactor::SF11, false),
+                        (SpreadingFactor::SF7, LdroMode::DISABLE),
+                        (SpreadingFactor::SF8, LdroMode::DISABLE),
+                        (SpreadingFactor::SF9, LdroMode::DISABLE),
+                        (SpreadingFactor::SF10, LdroMode::DISABLE),
+                        (SpreadingFactor::SF11, LdroMode::DISABLE),
                     ],
                 ),
                 (
                     Bandwidth::BW125,
                     Channel::Custom(869_587_500),
-                    vec![(SpreadingFactor::SF11, true), (SpreadingFactor::SF12, true)],
+                    vec![
+                        (SpreadingFactor::SF11, LdroMode::ENABLE),
+                        (SpreadingFactor::SF12, LdroMode::ENABLE),
+                    ],
                 ),
                 (
                     Bandwidth::BW62,
                     Channel::Custom(869_492_500),
-                    vec![(SpreadingFactor::SF12, true)],
+                    vec![(SpreadingFactor::SF12, LdroMode::ENABLE)],
                 ),
             ],
         ),
@@ -100,22 +98,25 @@ fn main() -> Result<()> {
                     Bandwidth::BW250,
                     Channel::Custom(906_875_000),
                     vec![
-                        (SpreadingFactor::SF7, false),
-                        (SpreadingFactor::SF8, false),
-                        (SpreadingFactor::SF9, false),
-                        (SpreadingFactor::SF10, false),
-                        (SpreadingFactor::SF11, false),
+                        (SpreadingFactor::SF7, LdroMode::DISABLE),
+                        (SpreadingFactor::SF8, LdroMode::DISABLE),
+                        (SpreadingFactor::SF9, LdroMode::DISABLE),
+                        (SpreadingFactor::SF10, LdroMode::DISABLE),
+                        (SpreadingFactor::SF11, LdroMode::DISABLE),
                     ],
                 ),
                 (
                     Bandwidth::BW125,
                     Channel::Custom(904_437_500),
-                    vec![(SpreadingFactor::SF11, true), (SpreadingFactor::SF12, true)],
+                    vec![
+                        (SpreadingFactor::SF11, LdroMode::ENABLE),
+                        (SpreadingFactor::SF12, LdroMode::ENABLE),
+                    ],
                 ),
                 (
                     Bandwidth::BW62,
                     Channel::Custom(916_218_750),
-                    vec![(SpreadingFactor::SF12, true)],
+                    vec![(SpreadingFactor::SF12, LdroMode::ENABLE)],
                 ),
             ],
         ),
@@ -151,31 +152,23 @@ fn main() -> Result<()> {
         for (spreading_factor, ldro) in chains.into_iter() {
             let decimation = decimation.clone();
             let message_pipe = message_pipe.clone();
-            let frame_sync: FrameSync = FrameSync::new(
+            let (frame_sync_ref, decoder_ref) = build_lora_rx_soft_decoding(
+                &mut fg,
                 chan,
                 bandwidth,
                 spreading_factor,
-                IMPLICIT_HEADER,
-                vec![vec![16, 88]],
+                HeaderMode::Explicit,
+                ldro,
+                Some(&[SynchWord::Meshtastic]),
                 OVERSAMPLING,
                 None,
                 Some("header_crc_ok"),
                 false,
                 None,
-            );
-            let fft_demod: FftDemod = FftDemod::new(spreading_factor, ldro);
-            let gray_mapping: GrayMapping = GrayMapping::new();
-            let deinterleaver: Deinterleaver = Deinterleaver::new(ldro, spreading_factor);
-            let hamming_dec: HammingDecoder = HammingDecoder::new();
-            let header_decoder: HeaderDecoder = HeaderDecoder::new(HeaderMode::Explicit, ldro);
-            let decoder: Decoder = Decoder::new();
+            )?;
             connect!(fg,
-                decimation > frame_sync;
-                frame_sync > fft_demod;
-                fft_demod > gray_mapping > deinterleaver > hamming_dec > header_decoder;
-                header_decoder.frame_info | frame_info.frame_sync;
-                header_decoder | decoder;
-                decoder | message_pipe;
+                decimation > frame_sync_ref;
+                decoder_ref | message_pipe;
             );
         }
     }
@@ -188,7 +181,7 @@ fn main() -> Result<()> {
         for c in channels {
             chans.add_channel(MeshtasticChannel::new(&c.0, &c.1));
         }
-        while let Some(x) = rx_frame.next().await {
+        while let Ok(x) = rx_frame.recv().await {
             match x {
                 Pmt::Blob(data) => {
                     chans.decode(&data[..data.len() - 2]);

--- a/examples/lora/src/bin/tx.rs
+++ b/examples/lora/src/bin/tx.rs
@@ -5,15 +5,18 @@ use clap::Parser;
 use futuresdr::async_io::Timer;
 use futuresdr::blocks::seify::Builder;
 use futuresdr::prelude::*;
-use lora::Transmitter;
+use lora::build_lora_tx;
 use lora::default_values::HAS_CRC;
-use lora::default_values::IMPLICIT_HEADER;
 use lora::default_values::PREAMBLE_LEN;
-use lora::default_values::ldro;
 use lora::utils::Bandwidth;
 use lora::utils::Channel;
 use lora::utils::CodeRate;
+use lora::utils::HeaderMode;
+use lora::utils::HeaderModeEnumParser;
+use lora::utils::LdroMode;
 use lora::utils::SpreadingFactor;
+use lora::utils::SynchWord;
+use lora::utils::SynchWordEnumParser;
 use lora::utils::sample_count;
 use rand::RngCore;
 
@@ -40,23 +43,30 @@ struct Args {
     /// Spreading Factor
     #[clap(short, long, value_enum, default_value_t = SpreadingFactor::SF7)]
     spreading_factor: SpreadingFactor,
-    /// Sync Word
-    #[clap(long, default_value_t = 0x0816)]
-    sync_word: usize,
+    /// LoRa Sync Word
+    #[clap(long, value_parser=SynchWordEnumParser, value_enum, default_value_t = SynchWord::Private)]
+    sync_word: SynchWord,
     /// Sync Word
     #[clap(long, default_value_t = 16)]
     payload_len: usize,
     /// LoRa Bandwidth
-    #[clap(short, long, value_enum, default_value_t = Bandwidth::BW125)]
+    #[clap(short, long, value_enum, default_value_t)]
     bandwidth: Bandwidth,
     /// LoRa Code Rate
-    #[clap(short, long, value_enum, default_value_t = CodeRate::CR_4_5)]
+    #[clap(short, long, value_enum, default_value_t)]
     code_rate: CodeRate,
+    /// LoRa Code Rate
+    #[clap(long, value_parser=HeaderModeEnumParser, value_enum, default_value_t)]
+    header_mode: HeaderMode,
 }
 const PAD: usize = 0;
 
 fn main() -> Result<()> {
     let args = Args::parse();
+    let ldro = LdroMode::AUTO;
+    let ldro_enabled = ldro
+        .resolve_if_auto(args.spreading_factor, args.bandwidth)
+        .enabled();
 
     let mut fg = Flowgraph::new();
 
@@ -69,31 +79,32 @@ fn main() -> Result<()> {
             // make sure the sink will not stall on large bursts
             args.spreading_factor,
             PREAMBLE_LEN,
-            IMPLICIT_HEADER,
+            args.header_mode,
             args.payload_len,
             HAS_CRC,
             args.code_rate,
             args.oversampling,
             PAD,
-            ldro(args.spreading_factor),
+            ldro_enabled,
         ))
         .build_sink()?;
 
-    let transmitter: Transmitter = Transmitter::new(
+    let transmitter = build_lora_tx(
+        &mut fg,
+        args.bandwidth,
+        args.spreading_factor,
         args.code_rate,
         HAS_CRC,
-        args.spreading_factor,
-        ldro(args.spreading_factor),
-        IMPLICIT_HEADER,
+        ldro,
+        args.header_mode,
         args.oversampling,
-        vec![args.sync_word],
-        PREAMBLE_LEN,
+        args.sync_word,
+        Some(PREAMBLE_LEN),
         PAD,
-    );
+    )?;
 
     connect!(fg, transmitter > inputs[0].sink);
     let transmitter = transmitter.into();
-
     let rt = Runtime::new();
 
     let (_fg, mut handle) = rt.start_sync(fg)?;

--- a/examples/lora/src/bin/tx_meshtastic.rs
+++ b/examples/lora/src/bin/tx_meshtastic.rs
@@ -2,13 +2,15 @@ use anyhow::Result;
 use clap::Parser;
 use futuresdr::blocks::seify::Builder;
 use futuresdr::prelude::*;
-use lora::Transmitter;
+use lora::build_lora_tx;
 use lora::default_values::HAS_CRC;
-use lora::default_values::IMPLICIT_HEADER;
 use lora::default_values::PREAMBLE_LEN;
 use lora::meshtastic::MeshtasticChannel;
 use lora::meshtastic::MeshtasticConfig;
+use lora::meshtastic::MeshtasticConfigEnumParser;
 use lora::utils::Bandwidth;
+use lora::utils::HeaderMode;
+use lora::utils::SynchWord;
 use std::io::BufRead;
 use std::io::Write;
 
@@ -24,7 +26,7 @@ struct Args {
     #[clap(short, long, default_value_t = 50.0)]
     gain: f64,
     /// Meshtastic LoRa Config
-    #[clap(short, long, value_enum)]
+    #[clap(short, long, value_parser=MeshtasticConfigEnumParser, value_enum)]
     meshtastic_config: MeshtasticConfig,
     /// meshtastic channel name
     #[clap(short, long)]
@@ -56,21 +58,22 @@ fn main() -> Result<()> {
         .antenna(args.antenna)
         .build_sink()?;
 
-    let transmitter: Transmitter = Transmitter::new(
+    let transmitter = build_lora_tx(
+        &mut fg,
+        bandwidth,
+        spreading_factor,
         code_rate,
         HAS_CRC,
-        spreading_factor,
         ldro,
-        IMPLICIT_HEADER,
+        HeaderMode::Explicit,
         interpolation,
-        vec![16, 88],
-        PREAMBLE_LEN,
+        SynchWord::Meshtastic,
+        Some(PREAMBLE_LEN),
         PAD,
-    );
+    )?;
 
     connect!(fg, transmitter > inputs[0].sink);
     let transmitter = transmitter.into();
-
     let rt = Runtime::new();
     let (_fg, handle) = rt.start_sync(fg)?;
 

--- a/examples/lora/src/decoder.rs
+++ b/examples/lora/src/decoder.rs
@@ -130,8 +130,10 @@ impl Decoder {
                                 Pmt::Blob(dewhitened.clone()),
                             )]);
                         annotated_payload.extend(frame.annotations.clone());
-                        annotated_payload
-                            .insert(String::from("code_rate"), Pmt::Usize(frame.code_rate));
+                        annotated_payload.insert(
+                            String::from("code_rate"),
+                            Pmt::Usize(frame.code_rate.into()),
+                        );
                         annotated_payload.insert(String::from("has_crc"), Pmt::Bool(frame.has_crc));
                         annotated_payload.insert(
                             String::from("implicit_header"),

--- a/examples/lora/src/default_values.rs
+++ b/examples/lora/src/default_values.rs
@@ -1,12 +1,9 @@
+use crate::utils::Bandwidth;
 use crate::utils::CodeRate;
 use crate::utils::SpreadingFactor;
 
-pub const SYNC_WORD_PUBLIC: usize = 0x34;
-pub const SYNC_WORD_PRIVATE: usize = 0x12;
-
-pub const BANDWIDTH: usize = 125_000;
+pub const BANDWIDTH: Bandwidth = Bandwidth::BW125;
 pub const HAS_CRC: bool = true;
-pub const IMPLICIT_HEADER: bool = false;
 pub const PREAMBLE_LEN: usize = 8;
 pub const PAD_SYMBOLS: usize = 0;
 pub const CODE_RATE_LORAWAN: CodeRate = CodeRate::CR_4_5;
@@ -15,6 +12,7 @@ pub const OVERSAMPLING_TX: usize = 8;
 pub const INTERLEAVED_HEADER_SYMBOL_COUNT: usize = 8;
 pub const SOFT_DECODING: bool = true;
 pub const PACKET_FORWARDER_PORT: u16 = 1730;
+pub const LDRO_MAX_DURATION_MS: f32 = 16.;
 
 pub fn preamble_len(sf: SpreadingFactor) -> usize {
     if sf == SpreadingFactor::SF5 {
@@ -29,7 +27,4 @@ pub fn code_rate(sf: SpreadingFactor) -> CodeRate {
     } else {
         CodeRate::CR_4_5
     }
-}
-pub fn ldro(sf: SpreadingFactor) -> bool {
-    sf >= SpreadingFactor::SF11
 }

--- a/examples/lora/src/deinterleaver.rs
+++ b/examples/lora/src/deinterleaver.rs
@@ -7,8 +7,8 @@ use crate::utils::*;
 pub struct Deinterleaver<
     S = DemodulatedSymbolSoftDecoding,
     D = DeinterleavedSymbolSoftDecoding,
-    I = DefaultCpuReader<DemodulatedSymbolSoftDecoding>,
-    O = DefaultCpuWriter<DeinterleavedSymbolSoftDecoding>,
+    I = DefaultCpuReader<S>,
+    O = DefaultCpuWriter<D>,
 > where
     S: DemodulatedSymbol,
     D: DeinterleavedSymbol,
@@ -19,10 +19,10 @@ pub struct Deinterleaver<
     input: I,
     #[output]
     output: O,
-    sf: usize,       // Spreading factor
-    cr: usize,       // Coding rate
+    sf: usize,          // Spreading factor
+    cr: usize,          // Coding rate
     is_header: bool, // Indicate that we need to deinterleave the first block with the default header parameters (cr=4/8, reduced rate)
-    ldro: bool,      // use low datarate optimization mode
+    ldro_enabled: bool, // use low datarate optimization mode
 }
 
 impl<S, D, I, O> Deinterleaver<S, D, I, O>
@@ -32,14 +32,14 @@ where
     I: CpuBufferReader<Item = S>,
     O: CpuBufferWriter<Item = D>,
 {
-    pub fn new(ldro: bool, sf: SpreadingFactor) -> Self {
+    pub fn new(ldro_enabled: bool, sf: SpreadingFactor) -> Self {
         Self {
             input: I::default(),
             output: O::default(),
             sf: Into::<usize>::into(sf),
             cr: 0,
             is_header: false,
-            ldro,
+            ldro_enabled,
         }
     }
 }
@@ -124,16 +124,6 @@ where
         let (output, mut out_tags) = self.output.slice_with_tags();
         let mut input_len = input.len();
         let output_len = output.len();
-        // let mut n_input = if self.soft_decoding {
-        //     sio.input(0).slice::<[LLR; MAX_SF]>().len()
-        // } else {
-        //     sio.input(0).slice::<u16>().len()
-        // };
-        // let n_output = if self.soft_decoding {
-        //     sio.output(0).slice::<[LLR; 8]>().len()
-        // } else {
-        //     sio.output(0).slice::<u8>().len()
-        // };
 
         let tags: Vec<(usize, &HashMap<String, Pmt>)> = in_tags
             .iter()
@@ -196,7 +186,7 @@ where
                     } else {
                         panic!()
                     };
-                    self.ldro = if let Pmt::Bool(tmp) = tag.get("ldro").unwrap() {
+                    self.ldro_enabled = if let Pmt::Bool(tmp) = tag.get("ldro_enabled").unwrap() {
                         *tmp
                     } else {
                         panic!()
@@ -209,8 +199,8 @@ where
         };
 
         #[allow(clippy::nonminimal_bool)]
-        let sf_app = if (self.sf >= 7 && (self.is_header || self.ldro))
-            || (self.sf < 7 && !self.is_header && self.ldro)
+        let sf_app = if (self.sf >= 7 && (self.is_header || self.ldro_enabled))
+            || (self.sf < 7 && !self.is_header && self.ldro_enabled)
         {
             self.sf - 2 // TODO this can be called w/o ever receiving a header tag, causing overflow if sf is not set explicitly in initializer
         } else {

--- a/examples/lora/src/encoder.rs
+++ b/examples/lora/src/encoder.rs
@@ -9,7 +9,7 @@ pub struct Encoder {
     code_rate: CodeRate,
     pub spreading_factor: SpreadingFactor,
     has_crc: bool,
-    low_data_rate: bool,
+    ldro_enabled: bool,
     implicit_header: bool,
 }
 
@@ -18,14 +18,14 @@ impl Encoder {
         code_rate: CodeRate,
         spreading_factor: SpreadingFactor,
         has_crc: bool,
-        low_data_rate: bool,
+        ldro_enabled: bool,
         implicit_header: bool,
     ) -> Encoder {
         Encoder {
             code_rate,
             spreading_factor,
             has_crc,
-            low_data_rate,
+            ldro_enabled,
             implicit_header,
         }
     }
@@ -47,7 +47,7 @@ impl Encoder {
             frame,
             self.code_rate,
             self.spreading_factor,
-            self.low_data_rate,
+            self.ldro_enabled,
         );
         Self::gray_demap(frame, self.spreading_factor)
     }
@@ -185,7 +185,7 @@ impl Encoder {
         mut frame: Vec<u8>,
         code_rate: CodeRate,
         spreading_factor: SpreadingFactor,
-        low_data_rate: bool,
+        ldro_enabled: bool,
     ) -> Vec<u16> {
         let mut cnt: usize = 0;
         let mut out = Vec::new();
@@ -199,7 +199,7 @@ impl Encoder {
                     } else {
                         code_rate.into()
                     },
-                    cnt < Into::<usize>::into(spreading_factor) - 2 || low_data_rate, // header or ldro activated for payload
+                    cnt < Into::<usize>::into(spreading_factor) - 2 || ldro_enabled, // header or ldro activated for payload
                 )
             } else
             //sf == 5 or sf ==6 don't use LDRO in header
@@ -210,7 +210,7 @@ impl Encoder {
                     } else {
                         code_rate.into()
                     },
-                    cnt >= spreading_factor.into() && low_data_rate, // not header and ldro activated for payload
+                    cnt >= spreading_factor.into() && ldro_enabled, // not header and ldro activated for payload
                 )
             };
             let sf_app: usize = if use_ldro {

--- a/examples/lora/src/fft_demod.rs
+++ b/examples/lora/src/fft_demod.rs
@@ -27,7 +27,7 @@ pub struct State<T: DemodulatedSymbol> {
     m_sf: SpreadingFactor,       //< Spreading factor
     m_cr: usize,                 //< Coding rate
     max_log_approx: bool,        //< use Max-log approximation in LLR formula
-    m_ldro: bool,                //< use low datarate optimisation
+    m_ldro_enabled: bool,        //< use low datarate optimisation
     m_symb_numb: usize,          //< number of symbols in the frame
     m_samples_per_symbol: usize, //< Number of samples received per lora symbols
     // variable used to perform the FFT demodulation
@@ -53,8 +53,8 @@ where
         self.m_samples_per_symbol = self.m_sf.samples_per_symbol();
         self.fft_plan = FftPlanner::new().plan_fft_forward(self.m_samples_per_symbol);
         self.base_downchirp = build_upchirp(0, sf, 1, false)
-            .iter()
-            .map(|&x| Complex64::new(x.re as f64, x.im as f64).conj())
+            .into_iter()
+            .map(|x| c64(x.re, x.im))
             .collect();
     }
 
@@ -71,7 +71,8 @@ where
 
     /// check if the reduced rate should be used
     fn reduced_rate(&self) -> bool {
-        (self.is_header && self.m_sf >= SpreadingFactor::SF7) || (!self.is_header && self.m_ldro)
+        (self.is_header && self.m_sf >= SpreadingFactor::SF7)
+            || (!self.is_header && self.m_ldro_enabled)
     }
 
     fn next_iteration_possible(
@@ -261,7 +262,7 @@ where
     O: CpuBufferWriter<Item = T>,
     State<T>: Demod<T>,
 {
-    pub fn new(sf_initial: SpreadingFactor, ldro: bool) -> Self {
+    pub fn new(sf_initial: SpreadingFactor, ldro_enabled: bool) -> Self {
         let m_samples_per_symbol = sf_initial.samples_per_symbol();
         let fft_plan = FftPlanner::new().plan_fft_forward(m_samples_per_symbol);
 
@@ -274,16 +275,16 @@ where
             s: State::<T> {
                 m_sf: sf_initial,
                 m_cr: 0, // initial value irrelevant, set from tag before read
+                m_ldro_enabled: ldro_enabled,
                 max_log_approx: true,
                 m_samples_per_symbol,
                 base_downchirp: build_upchirp(0, sf_initial, 1, false)
-                    .iter()
-                    .map(|&x| Complex64::new(x.re as f64, x.im as f64).conj())
+                    .into_iter()
+                    .map(|x| c64(x.re, x.im).conj())
                     .collect(),
                 m_downchirp: vec![],
                 out: Vec::with_capacity(8),
                 is_header: false,
-                m_ldro: ldro,
                 m_symb_numb: 0,
                 fft_plan,
                 lls: vec![0.; m_samples_per_symbol],
@@ -403,7 +404,8 @@ where
                     } else {
                         panic!()
                     };
-                    self.s.m_ldro = if let Pmt::Bool(tmp) = tag.get("ldro").unwrap() {
+                    self.s.m_ldro_enabled = if let Pmt::Bool(tmp) = tag.get("ldro_enabled").unwrap()
+                    {
                         *tmp
                     } else {
                         panic!()

--- a/examples/lora/src/frame_sync.rs
+++ b/examples/lora/src/frame_sync.rs
@@ -705,7 +705,7 @@ impl State {
         frame_info.insert(String::from("cfo_frac"), Pmt::F64(self.m_cfo_frac));
         frame_info.insert(String::from("sf"), Pmt::Usize(self.m_sf.into()));
         frame_info.insert(
-            String::from("timestamp"),
+            String::from("timestamp_unix_ns"),
             Pmt::U64(
                 self.startup_timestamp_nanos
                     + (self.processed_samples
@@ -717,6 +717,18 @@ impl State {
                         })
                         * 1_000_000_000
                         / ((Into::<usize>::into(self.m_bw) * self.m_os_factor) as u64),
+            ),
+        );
+        frame_info.insert(
+            String::from("timestamp_samples"),
+            Pmt::U64(
+                self.processed_samples
+                    + items_to_consume as u64
+                    + if one_symbol_off {
+                        self.m_samples_per_symbol as u64
+                    } else {
+                        0
+                    },
             ),
         );
         let frame_info_pmt = Pmt::MapStrPmt(frame_info);
@@ -1061,7 +1073,7 @@ where
         bandwidth: Bandwidth,
         sf: SpreadingFactor,
         impl_head: bool,
-        initial_sync_words: Vec<Vec<usize>>, // initially known NetIDs
+        initial_sync_words: &[SynchWord], // initially known NetIDs
         os_factor: usize,
         preamble_len: Option<usize>,
         net_id_caching_policy: Option<&str>,
@@ -1084,11 +1096,9 @@ where
         let mut known_valid_net_ids: [[bool; 256]; 256] = [[false; 256]; 256];
         let mut known_valid_net_ids_reverse: [[bool; 256]; 256] = [[false; 256]; 256];
         for sync_word in initial_sync_words {
-            let sync_word_tmp: Vec<usize> = expand_sync_word(sync_word);
-            if sync_word_tmp.len() == 2 {
-                known_valid_net_ids_reverse[sync_word_tmp[1]][sync_word_tmp[0]] = true;
-                known_valid_net_ids[sync_word_tmp[0]][sync_word_tmp[1]] = true;
-            }
+            let sync_word_tmp = sync_word.verify_and_expand(sf).unwrap();
+            known_valid_net_ids_reverse[sync_word_tmp[1]][sync_word_tmp[0]] = true;
+            known_valid_net_ids[sync_word_tmp[0]][sync_word_tmp[1]] = true;
         }
         let m_number_of_bins_tmp = sf.samples_per_symbol();
         let m_samples_per_symbol_tmp = m_number_of_bins_tmp * os_factor;
@@ -1267,17 +1277,11 @@ where
             } else {
                 panic!("invalid m_has_crc")
             };
-            // uint8_t
-            let ldro_mode_tmp: LdroMode =
-                if let Pmt::Bool(temp) = frame_info.get("ldro_mode").unwrap() {
-                    if *temp {
-                        LdroMode::ENABLE
-                    } else {
-                        LdroMode::DISABLE
-                    }
-                } else {
-                    panic!("invalid ldro_mode")
-                };
+            let ldro_enabled = if let Pmt::Bool(temp) = frame_info.get("ldro_enabled").unwrap() {
+                *temp
+            } else {
+                panic!("invalid ldro_enabled")
+            };
             let m_invalid_header = if let Pmt::Bool(temp) = frame_info.get("err").unwrap() {
                 *temp
             } else {
@@ -1302,20 +1306,6 @@ where
                     // TODO append NetID to FrameInfo, pass through to decoder, and include NetID in CRC result to avoid need to block
                     self.s.ready_to_detect = false;
                 }
-                // frame parameters
-                let m_ldro: LdroMode = if ldro_mode_tmp == LdroMode::AUTO {
-                    if (self.s.m_sf.samples_per_symbol()) as f32 * 1e3
-                        / Into::<f32>::into(self.s.m_bw)
-                        > LDRO_MAX_DURATION_MS
-                    {
-                        LdroMode::ENABLE
-                    } else {
-                        LdroMode::DISABLE
-                    }
-                } else {
-                    ldro_mode_tmp
-                };
-
                 let m_symb_numb_tmp = 8_isize
                     + ((2 * m_pay_len as isize - self.s.m_sf as isize
                         + if self.s.m_sf >= SpreadingFactor::SF7 {
@@ -1325,7 +1315,7 @@ where
                         }
                         + (!self.s.m_impl_head) as isize * 5
                         + if m_has_crc { 4 } else { 0 }) as f64
-                        / (Into::<usize>::into(self.s.m_sf) - 2 * m_ldro as usize) as f64)
+                        / (Into::<usize>::into(self.s.m_sf) - 2 * ldro_enabled as usize) as f64)
                         .ceil() as isize
                         * (4 + m_cr as isize);
                 assert!(
@@ -1336,8 +1326,6 @@ where
                 self.s.m_received_head = true;
                 frame_info.insert(String::from("is_header"), Pmt::Bool(false));
                 frame_info.insert(String::from("symb_numb"), Pmt::Usize(self.s.m_symb_numb));
-                frame_info.remove("ldro_mode");
-                frame_info.insert(String::from("ldro"), Pmt::Bool(m_ldro as usize != 0));
                 let frame_info_pmt = Pmt::MapStrPmt(frame_info);
                 self.s
                     .tag_from_msg_handler_to_work_channel

--- a/examples/lora/src/hamming_dec.rs
+++ b/examples/lora/src/hamming_dec.rs
@@ -36,7 +36,7 @@ struct State<T> {
 #[message_outputs(out)]
 pub struct HammingDecoder<
     T = DeinterleavedSymbolSoftDecoding,
-    I = DefaultCpuReader<DeinterleavedSymbolSoftDecoding>,
+    I = DefaultCpuReader<T>,
     O = DefaultCpuWriter<u8>,
 > where
     T: DeinterleavedSymbol,

--- a/examples/lora/src/header_decoder.rs
+++ b/examples/lora/src/header_decoder.rs
@@ -1,3 +1,5 @@
+use crate::utils::CodeRate;
+use crate::utils::HeaderMode;
 use futuresdr::prelude::*;
 use std::cmp::min;
 use std::collections::HashMap;
@@ -7,7 +9,7 @@ pub struct Frame {
     pub nibbles: Vec<u8>,
     pub implicit_header: bool,
     pub has_crc: bool,
-    pub code_rate: usize,
+    pub code_rate: CodeRate,
     pub annotations: HashMap<String, Pmt>,
 }
 
@@ -17,19 +19,10 @@ impl Default for Frame {
             nibbles: Vec::new(),
             implicit_header: false,
             has_crc: false,
-            code_rate: 1,
+            code_rate: CodeRate::CR_4_5,
             annotations: HashMap::new(),
         }
     }
-}
-
-pub enum HeaderMode {
-    Explicit,
-    Implicit {
-        payload_len: usize,
-        has_crc: bool,
-        code_rate: usize,
-    },
 }
 
 const HEADER_LEN: usize = 5; // size of the header in nibbles
@@ -45,20 +38,20 @@ where
     mode: HeaderMode,
     left: usize,
     frame: Frame,
-    ldro_mode: bool,
+    ldro_enabled: bool,
 }
 
 impl<I> HeaderDecoder<I>
 where
     I: CpuBufferReader<Item = u8>,
 {
-    pub fn new(mode: HeaderMode, ldro_mode: bool) -> Self {
+    pub fn new(mode: HeaderMode, ldro_enabled: bool) -> Self {
         Self {
             input: I::default(),
             mode,
             left: 0,
             frame: Frame::default(),
-            ldro_mode,
+            ldro_enabled,
         }
     }
 
@@ -67,7 +60,7 @@ where
         cr: usize,
         pay_len: usize,
         crc: bool,
-        ldro_mode: bool,
+        ldro_enabled: bool,
         err: bool,
     ) -> Result<()> {
         let mut header_content: HashMap<String, Pmt> = HashMap::new();
@@ -75,7 +68,7 @@ where
         header_content.insert("cr".to_string(), Pmt::Usize(cr));
         header_content.insert("pay_len".to_string(), Pmt::Usize(pay_len));
         header_content.insert("crc".to_string(), Pmt::Bool(crc));
-        header_content.insert("ldro_mode".to_string(), Pmt::Bool(ldro_mode));
+        header_content.insert("ldro_enabled".to_string(), Pmt::Bool(ldro_enabled));
         header_content.insert("err".to_string(), Pmt::Bool(err));
         mio.post("frame_info", Pmt::MapStrPmt(header_content.clone()))
             .await?;
@@ -177,10 +170,10 @@ where
 
                 Self::publish_frame_info(
                     mio,
-                    code_rate,
+                    code_rate.into(),
                     payload_len,
                     has_crc,
-                    self.ldro_mode,
+                    self.ldro_enabled,
                     false,
                 )
                 .await?;
@@ -190,7 +183,8 @@ where
                 // explicit header to decode
                 let payload_len = ((input[0] << 4) + input[1]) as usize;
                 let has_crc = input[2] & 1 != 0;
-                let code_rate = (input[2] >> 1) as usize;
+                let code_rate_raw = input[2] >> 1;
+                let code_rate = CodeRate::try_from(code_rate_raw);
 
                 // check header Checksum
                 let header_chk = ((input[3] & 1) << 4) + input[4];
@@ -224,7 +218,7 @@ where
                 info!("..:: Header");
                 info!("Payload length: {}", payload_len);
                 info!("CRC presence:   {}", has_crc);
-                info!("Coding rate:    {}", code_rate);
+                info!("Coding rate:    {}", code_rate_raw);
 
                 let mut head_err = header_chk as i16
                     - ((c4 << 4) + (c3 << 3) + (c2 << 2) + (c1 << 1) + c0) as i16
@@ -239,7 +233,7 @@ where
                         debug!("item to process= {}", nitem_to_consume);
                     }
                     head_err = true;
-                } else if code_rate > 3 {
+                } else if code_rate.is_err() {
                     info!("Header invalid!");
                     debug!("Code rate must be within [0, 3]!");
                     head_err = true;
@@ -249,10 +243,10 @@ where
 
                 Self::publish_frame_info(
                     mio,
-                    code_rate,
+                    code_rate_raw as usize,
                     payload_len,
                     has_crc,
-                    self.ldro_mode,
+                    self.ldro_enabled,
                     head_err,
                 )
                 .await?;
@@ -262,7 +256,7 @@ where
                         nibbles: Vec::new(),
                         implicit_header: false,
                         has_crc,
-                        code_rate,
+                        code_rate: code_rate.unwrap(),
                         annotations: annotations.unwrap_or(HashMap::<String, Pmt>::new()),
                     };
 

--- a/examples/lora/src/lib.rs
+++ b/examples/lora/src/lib.rs
@@ -1,17 +1,30 @@
 #![allow(clippy::precedence)]
 
+use crate::utils::Bandwidth;
+use crate::utils::Channel;
+use crate::utils::CodeRate;
+use crate::utils::DeinterleavedSymbolHardDecoding;
+use crate::utils::DemodulatedSymbolHardDecoding;
+use crate::utils::HeaderMode;
+use crate::utils::LdroMode;
+use crate::utils::SpreadingFactor;
+use crate::utils::SynchWord;
 pub use decoder::Decoder;
 pub use deinterleaver::Deinterleaver;
 pub use encoder::Encoder;
 pub use fft_demod::FftDemod;
 pub use frame_sync::FrameSync;
+use futuresdr::macros::connect;
+use futuresdr::prelude::BlockRef;
+use futuresdr::prelude::Flowgraph;
+use futuresdr::prelude::Result;
 pub use gray_mapping::GrayMapping;
 pub use hamming_dec::HammingDecoder;
 pub use header_decoder::Frame;
 pub use header_decoder::HeaderDecoder;
-pub use header_decoder::HeaderMode;
 pub use modulator::Modulator;
 pub use packet_forwarder_client::PacketForwarderClient;
+use std::time::SystemTime;
 pub use stream_adder::StreamAdder;
 pub use transmitter::Transmitter;
 
@@ -30,3 +43,174 @@ pub mod packet_forwarder_client;
 pub mod stream_adder;
 pub mod transmitter;
 pub mod utils;
+
+#[allow(clippy::too_many_arguments)]
+pub fn build_lora_tx(
+    fg: &mut Flowgraph,
+    bw: Bandwidth,
+    sf: SpreadingFactor,
+    code_rate: CodeRate,
+    has_crc: bool,
+    ldro: LdroMode,
+    header_mode: HeaderMode,
+    os_factor: usize,
+    sync_word: SynchWord,
+    preamble_len: Option<usize>,
+    pad: usize,
+) -> Result<BlockRef<Transmitter>> {
+    let ldro_enabled = ldro.resolve_if_auto(sf, bw).enabled();
+    let transmitter = fg.add_block(Transmitter::new(
+        code_rate,
+        has_crc,
+        sf,
+        ldro_enabled,
+        header_mode,
+        os_factor,
+        sync_word,
+        preamble_len.unwrap_or(default_values::preamble_len(sf)),
+        pad,
+    )?);
+    Ok(transmitter)
+}
+
+#[allow(clippy::too_many_arguments)]
+pub fn build_lora_rx_dyn(
+    fg: &mut Flowgraph,
+    chan: Channel,
+    bw: Bandwidth,
+    sf: SpreadingFactor,
+    header_mode: HeaderMode,
+    ldro: LdroMode,
+    initial_sync_words: Option<&[SynchWord]>,
+    os_factor: usize,
+    preamble_len: Option<usize>,
+    sync_word_caching_policy: Option<&str>,
+    collect_receive_statistics: bool,
+    startup_timestamp: Option<SystemTime>,
+    soft_decoding: bool,
+) -> Result<(BlockRef<FrameSync>, BlockRef<Decoder>)> {
+    if soft_decoding {
+        let (frame_sync_ref, decoder_ref) = build_lora_rx_soft_decoding(
+            fg,
+            chan,
+            bw,
+            sf,
+            header_mode,
+            ldro,
+            initial_sync_words,
+            os_factor,
+            preamble_len,
+            sync_word_caching_policy,
+            collect_receive_statistics,
+            startup_timestamp,
+        )?;
+        Ok((frame_sync_ref, decoder_ref))
+    } else {
+        let (frame_sync_ref, decoder_ref) = build_lora_rx_hard_decoding(
+            fg,
+            chan,
+            bw,
+            sf,
+            header_mode,
+            ldro,
+            initial_sync_words,
+            os_factor,
+            preamble_len,
+            sync_word_caching_policy,
+            collect_receive_statistics,
+            startup_timestamp,
+        )?;
+        Ok((frame_sync_ref, decoder_ref))
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+pub fn build_lora_rx_soft_decoding(
+    fg: &mut Flowgraph,
+    chan: Channel,
+    bw: Bandwidth,
+    sf: SpreadingFactor,
+    header_mode: HeaderMode,
+    ldro: LdroMode,
+    initial_sync_words: Option<&[SynchWord]>,
+    os_factor: usize,
+    preamble_len: Option<usize>,
+    sync_word_caching_policy: Option<&str>,
+    collect_receive_statistics: bool,
+    startup_timestamp: Option<SystemTime>,
+) -> Result<(BlockRef<FrameSync>, BlockRef<Decoder>)> {
+    let ldro_enabled = ldro.resolve_if_auto(sf, bw).enabled();
+    let frame_sync: FrameSync = FrameSync::new(
+        chan,
+        bw,
+        sf,
+        !matches!(header_mode, HeaderMode::Explicit),
+        initial_sync_words.unwrap_or_default(),
+        os_factor,
+        preamble_len,
+        sync_word_caching_policy,
+        collect_receive_statistics,
+        startup_timestamp,
+    );
+    let fft_demod: FftDemod = FftDemod::new(sf, ldro_enabled);
+    let gray_mapping: GrayMapping = GrayMapping::new();
+    let deinterleaver: Deinterleaver = Deinterleaver::new(ldro_enabled, sf);
+    let hamming_dec: HammingDecoder = HammingDecoder::new();
+    let header_decoder: HeaderDecoder = HeaderDecoder::new(header_mode, ldro_enabled);
+    let decoder: Decoder = Decoder::new();
+    connect!(fg,
+        frame_sync > fft_demod > gray_mapping > deinterleaver > hamming_dec > header_decoder;
+        header_decoder.frame_info | frame_info.frame_sync;
+        header_decoder | decoder;
+    );
+    Ok((frame_sync, decoder))
+}
+
+#[allow(clippy::too_many_arguments)]
+pub fn build_lora_rx_hard_decoding(
+    fg: &mut Flowgraph,
+    chan: Channel,
+    bw: Bandwidth,
+    sf: SpreadingFactor,
+    header_mode: HeaderMode,
+    ldro: LdroMode,
+    initial_sync_words: Option<&[SynchWord]>,
+    os_factor: usize,
+    preamble_len: Option<usize>,
+    sync_word_caching_policy: Option<&str>,
+    collect_receive_statistics: bool,
+    startup_timestamp: Option<SystemTime>,
+) -> Result<(BlockRef<FrameSync>, BlockRef<Decoder>)> {
+    let ldro_enabled = ldro.resolve_if_auto(sf, bw).enabled();
+    let frame_sync = FrameSync::new(
+        chan,
+        bw,
+        sf,
+        !matches!(header_mode, HeaderMode::Explicit),
+        initial_sync_words.unwrap_or_default(),
+        os_factor,
+        preamble_len,
+        sync_word_caching_policy,
+        collect_receive_statistics,
+        startup_timestamp,
+    );
+    let fft_demod: FftDemod<_, _, _, _> = FftDemod::<
+        DemodulatedSymbolHardDecoding,
+        fft_demod::State<DemodulatedSymbolHardDecoding>,
+    >::new(sf, ldro_enabled);
+    let gray_mapping: GrayMapping<_, _, _> = GrayMapping::<DemodulatedSymbolHardDecoding>::new();
+    let deinterleaver: Deinterleaver<_, _, _, _> = Deinterleaver::<
+        DemodulatedSymbolHardDecoding,
+        DeinterleavedSymbolHardDecoding,
+    >::new(ldro_enabled, sf);
+    let hamming_dec: HammingDecoder<_, _, _> =
+        HammingDecoder::<DeinterleavedSymbolHardDecoding>::new();
+    let header_decoder: HeaderDecoder = HeaderDecoder::new(header_mode, ldro_enabled);
+    let decoder: Decoder = Decoder::new();
+    connect!(fg,
+        frame_sync > fft_demod > gray_mapping > deinterleaver > hamming_dec > header_decoder;
+        header_decoder.frame_info | frame_info.frame_sync;
+        header_decoder | decoder;
+    );
+    Ok((frame_sync, decoder))
+}

--- a/examples/lora/src/meshtastic.rs
+++ b/examples/lora/src/meshtastic.rs
@@ -1,13 +1,23 @@
+use crate::utils::Bandwidth;
+use crate::utils::Channel;
+use crate::utils::CodeRate;
+use crate::utils::LdroMode;
+use crate::utils::SpreadingFactor;
 use base64::prelude::*;
+use clap::Arg;
+use clap::Command;
+use clap::Error;
+use clap::ValueEnum;
+use clap::builder::PossibleValue;
+use clap::builder::TypedValueParser;
+use clap::error::ErrorKind;
 use ctr::cipher::KeyIvInit;
 use ctr::cipher::StreamCipher;
 use futuresdr::tracing::info;
 use meshtastic::Message;
-
-use crate::utils::Bandwidth;
-use crate::utils::Channel;
-use crate::utils::CodeRate;
-use crate::utils::SpreadingFactor;
+use std::ffi::OsStr;
+use std::fmt::Display;
+use std::fmt::Formatter;
 
 type Aes128 = ctr::Ctr64BE<aes::Aes128>;
 type Aes256 = ctr::Ctr64BE<aes::Aes256>;
@@ -16,8 +26,7 @@ const DEFAULT_KEY: [u8; 16] = [
     0xd4, 0xf1, 0xbb, 0x3a, 0x20, 0x29, 0x07, 0x59, 0xf0, 0xbc, 0xff, 0xab, 0xcf, 0x4e, 0x69, 0x01,
 ];
 
-#[derive(Debug, Clone, clap::ValueEnum, Copy, Default)]
-#[clap(rename_all = "SCREAMING_SNAKE_CASE")]
+#[derive(Debug, Clone, Copy, Default)]
 #[allow(non_camel_case_types)]
 pub enum MeshtasticConfig {
     ShortFastEu,
@@ -29,131 +38,353 @@ pub enum MeshtasticConfig {
     LongModerateEu,
     LongSlowEu,
     VeryLongSlowEu,
+    ShortTurboUs,
     ShortFastUs,
     ShortSlowUs,
     MediumFastUs,
     MediumSlowUs,
+    LongTurboUs,
     LongFastUs,
     LongModerateUs,
     LongSlowUs,
     VeryLongSlowUs,
+    Custom(Bandwidth, SpreadingFactor, CodeRate, Channel, LdroMode),
 }
 
 impl MeshtasticConfig {
-    pub fn to_config(&self) -> (Bandwidth, SpreadingFactor, CodeRate, Channel, bool) {
+    fn parse_custom_components(input: &str, ignore_case: bool) -> Result<Self, String> {
+        let components: Vec<_> = input.split(',').map(str::trim).collect();
+        if components.len() != 5 {
+            return Err(format!(
+                "invalid custom Meshtastic config '{input}': expected 5 comma-separated values"
+            ));
+        }
+
+        let bandwidth = <Bandwidth as ValueEnum>::from_str(components[0], ignore_case)?;
+        let spreading_factor =
+            <SpreadingFactor as ValueEnum>::from_str(components[1], ignore_case)?;
+        let code_rate = <CodeRate as ValueEnum>::from_str(components[2], ignore_case)?;
+        let channel = <Channel as ValueEnum>::from_str(components[3], ignore_case)?;
+        let ldro = <LdroMode as ValueEnum>::from_str(components[4], ignore_case)?;
+        Ok(Self::Custom(
+            bandwidth,
+            spreading_factor,
+            code_rate,
+            channel,
+            ldro,
+        ))
+    }
+
+    fn strip_custom_wrapper(input: &str, ignore_case: bool) -> Option<&str> {
+        let trimmed = input.trim();
+        if let Some(inner) = trimmed.strip_prefix('(').and_then(|s| s.strip_suffix(')')) {
+            return Some(inner);
+        }
+
+        if ignore_case {
+            let prefix = "custom(";
+            if trimmed.len() > prefix.len()
+                && trimmed[..prefix.len()].eq_ignore_ascii_case(prefix)
+                && trimmed.ends_with(')')
+            {
+                return Some(&trimmed[prefix.len()..trimmed.len() - 1]);
+            }
+        } else if let Some(inner) = trimmed
+            .strip_prefix("Custom(")
+            .and_then(|s| s.strip_suffix(')'))
+        {
+            return Some(inner);
+        }
+
+        None
+    }
+
+    fn parse_custom(input: &str, ignore_case: bool) -> Option<Result<Self, String>> {
+        let trimmed = input.trim();
+        if let Some(inner) = Self::strip_custom_wrapper(trimmed, ignore_case) {
+            return Some(Self::parse_custom_components(inner, ignore_case));
+        }
+
+        if trimmed.contains(',') {
+            return Some(Self::parse_custom_components(trimmed, ignore_case));
+        }
+
+        None
+    }
+
+    pub fn to_config(&self) -> (Bandwidth, SpreadingFactor, CodeRate, Channel, LdroMode) {
         match self {
             Self::ShortFastEu => (
                 Bandwidth::BW250,
                 SpreadingFactor::SF7,
                 CodeRate::CR_4_5,
                 Channel::Custom(869525000),
-                false,
+                LdroMode::DISABLE,
             ),
             Self::ShortSlowEu => (
                 Bandwidth::BW250,
                 SpreadingFactor::SF8,
                 CodeRate::CR_4_5,
                 Channel::Custom(869525000),
-                false,
+                LdroMode::DISABLE,
             ),
             Self::MediumFastEu => (
                 Bandwidth::BW250,
                 SpreadingFactor::SF9,
                 CodeRate::CR_4_5,
                 Channel::Custom(869525000),
-                false,
+                LdroMode::DISABLE,
             ),
             Self::MediumSlowEu => (
                 Bandwidth::BW250,
                 SpreadingFactor::SF10,
                 CodeRate::CR_4_5,
                 Channel::Custom(869525000),
-                false,
+                LdroMode::DISABLE,
             ),
             Self::LongFastEu => (
                 Bandwidth::BW250,
                 SpreadingFactor::SF11,
                 CodeRate::CR_4_5,
                 Channel::Custom(869525000),
-                false,
+                LdroMode::DISABLE,
             ),
             Self::LongModerateEu => (
                 Bandwidth::BW125,
                 SpreadingFactor::SF11,
                 CodeRate::CR_4_8,
                 Channel::Custom(869587500),
-                true,
+                LdroMode::ENABLE,
             ),
             Self::LongSlowEu => (
                 Bandwidth::BW125,
                 SpreadingFactor::SF12,
                 CodeRate::CR_4_8,
                 Channel::Custom(869587500),
-                true,
+                LdroMode::ENABLE,
             ),
             Self::VeryLongSlowEu => (
                 Bandwidth::BW62,
                 SpreadingFactor::SF12,
                 CodeRate::CR_4_8,
                 Channel::Custom(869492500),
-                true,
+                LdroMode::ENABLE,
+            ),
+            Self::ShortTurboUs => (
+                Bandwidth::BW500,
+                SpreadingFactor::SF7,
+                CodeRate::CR_4_5,
+                Channel::Custom(906875000),
+                LdroMode::DISABLE,
             ),
             Self::ShortFastUs => (
                 Bandwidth::BW250,
                 SpreadingFactor::SF7,
                 CodeRate::CR_4_5,
                 Channel::Custom(906875000),
-                false,
+                LdroMode::DISABLE,
             ),
             Self::ShortSlowUs => (
                 Bandwidth::BW250,
                 SpreadingFactor::SF8,
                 CodeRate::CR_4_5,
                 Channel::Custom(906875000),
-                false,
+                LdroMode::DISABLE,
             ),
             Self::MediumFastUs => (
                 Bandwidth::BW250,
                 SpreadingFactor::SF9,
                 CodeRate::CR_4_5,
                 Channel::Custom(906875000),
-                false,
+                LdroMode::DISABLE,
             ),
             Self::MediumSlowUs => (
                 Bandwidth::BW250,
                 SpreadingFactor::SF10,
                 CodeRate::CR_4_5,
                 Channel::Custom(906875000),
-                false,
+                LdroMode::DISABLE,
+            ),
+            Self::LongTurboUs => (
+                Bandwidth::BW500,
+                SpreadingFactor::SF11,
+                CodeRate::CR_4_5,
+                Channel::Custom(906875000),
+                LdroMode::DISABLE,
             ),
             Self::LongFastUs => (
                 Bandwidth::BW250,
                 SpreadingFactor::SF11,
                 CodeRate::CR_4_5,
                 Channel::Custom(906875000),
-                false,
+                LdroMode::DISABLE,
             ),
             Self::LongModerateUs => (
                 Bandwidth::BW125,
                 SpreadingFactor::SF11,
                 CodeRate::CR_4_8,
                 Channel::Custom(904437500),
-                true,
+                LdroMode::ENABLE,
             ),
             Self::LongSlowUs => (
                 Bandwidth::BW125,
                 SpreadingFactor::SF12,
                 CodeRate::CR_4_8,
                 Channel::Custom(904437500),
-                true,
+                LdroMode::ENABLE,
             ),
             Self::VeryLongSlowUs => (
                 Bandwidth::BW62,
                 SpreadingFactor::SF12,
                 CodeRate::CR_4_8,
                 Channel::Custom(916218750),
-                true,
+                LdroMode::ENABLE,
             ),
+            Self::Custom(bw, sf, cr, freq, ldro) => (*bw, *sf, *cr, *freq, *ldro),
+        }
+    }
+}
+
+impl clap::ValueEnum for MeshtasticConfig {
+    fn value_variants<'a>() -> &'a [Self] {
+        &[
+            Self::ShortFastEu,
+            Self::ShortSlowEu,
+            Self::MediumFastEu,
+            Self::MediumSlowEu,
+            Self::LongFastEu,
+            Self::LongModerateEu,
+            Self::LongSlowEu,
+            Self::VeryLongSlowEu,
+            Self::ShortTurboUs,
+            Self::ShortFastUs,
+            Self::ShortSlowUs,
+            Self::MediumFastUs,
+            Self::MediumSlowUs,
+            Self::LongTurboUs,
+            Self::LongFastUs,
+            Self::LongModerateUs,
+            Self::LongSlowUs,
+            Self::VeryLongSlowUs,
+            Self::Custom(
+                Bandwidth::BW250,
+                SpreadingFactor::SF7,
+                CodeRate::CR_4_5,
+                Channel::Custom(868595000),
+                LdroMode::DISABLE,
+            ),
+        ]
+    }
+
+    fn from_str(input: &str, ignore_case: bool) -> Result<Self, String> {
+        if let Some(custom) = Self::parse_custom(input, ignore_case) {
+            return custom;
+        }
+
+        let input_uppercase = input.to_uppercase();
+        match if ignore_case {
+            input_uppercase.as_str()
+        } else {
+            input
+        } {
+            "SHORT_FAST_EU" => Ok(Self::ShortFastEu),
+            "SHORT_SLOW_EU" => Ok(Self::ShortSlowEu),
+            "MEDIUM_FAST_EU" => Ok(Self::MediumFastEu),
+            "MEDIUM_SLOW_EU" => Ok(Self::MediumSlowEu),
+            "LONG_FAST_EU" => Ok(Self::LongFastEu),
+            "LONG_MODERATE_EU" => Ok(Self::LongModerateEu),
+            "LONG_SLOW_EU" => Ok(Self::LongSlowEu),
+            "VERY_LONG_SLOW_EU" => Ok(Self::VeryLongSlowEu),
+            "SHORT_TURBO_US" => Ok(Self::ShortTurboUs),
+            "SHORT_FAST_US" => Ok(Self::ShortFastUs),
+            "SHORT_SLOW_US" => Ok(Self::ShortSlowUs),
+            "MEDIUM_FAST_US" => Ok(Self::MediumFastUs),
+            "MEDIUM_SLOW_US" => Ok(Self::MediumSlowUs),
+            "LONG_TURBO_US" => Ok(Self::LongTurboUs),
+            "LONG_FAST_US" => Ok(Self::LongFastUs),
+            "LONG_MODERATE_US" => Ok(Self::LongModerateUs),
+            "LONG_SLOW_US" => Ok(Self::LongSlowUs),
+            "VERY_LONG_SLOW_US" => Ok(Self::VeryLongSlowUs),
+            _ => Err(format!("invalid variant: {input}")),
+        }
+    }
+
+    fn to_possible_value(&self) -> Option<PossibleValue> {
+        match self {
+            Self::ShortFastEu => Some(PossibleValue::new("SHORT_FAST_EU")),
+            Self::ShortSlowEu => Some(PossibleValue::new("SHORT_SLOW_EU")),
+            Self::MediumFastEu => Some(PossibleValue::new("MEDIUM_FAST_EU")),
+            Self::MediumSlowEu => Some(PossibleValue::new("MEDIUM_SLOW_EU")),
+            Self::LongFastEu => Some(PossibleValue::new("LONG_FAST_EU")),
+            Self::LongModerateEu => Some(PossibleValue::new("LONG_MODERATE_EU")),
+            Self::LongSlowEu => Some(PossibleValue::new("LONG_SLOW_EU")),
+            Self::VeryLongSlowEu => Some(PossibleValue::new("VERY_LONG_SLOW_EU")),
+            Self::ShortTurboUs => Some(PossibleValue::new("SHORT_TURBO_US")),
+            Self::ShortFastUs => Some(PossibleValue::new("SHORT_FAST_US")),
+            Self::ShortSlowUs => Some(PossibleValue::new("SHORT_SLOW_US")),
+            Self::MediumFastUs => Some(PossibleValue::new("MEDIUM_FAST_US")),
+            Self::MediumSlowUs => Some(PossibleValue::new("MEDIUM_SLOW_US")),
+            Self::LongTurboUs => Some(PossibleValue::new("LONG_TURBO_US")),
+            Self::LongFastUs => Some(PossibleValue::new("LONG_FAST_US")),
+            Self::LongModerateUs => Some(PossibleValue::new("LONG_MODERATE_US")),
+            Self::LongSlowUs => Some(PossibleValue::new("LONG_SLOW_US")),
+            Self::VeryLongSlowUs => Some(PossibleValue::new("VERY_LONG_SLOW_US")),
+            Self::Custom(_, _, _, _, _) => Some(
+                PossibleValue::new(
+                    "Custom([bandwidth], [spreading_factor], [code_rate], [channel], [ldro])",
+                )
+                .help(
+                    "Also accepts '([..])' or bare '[..]' with the same 5 comma-separated values.",
+                ),
+            ),
+        }
+    }
+}
+
+impl Display for MeshtasticConfig {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::ShortFastEu => write!(f, "SHORT_FAST_EU"),
+            Self::ShortSlowEu => write!(f, "SHORT_SLOW_EU"),
+            Self::MediumFastEu => write!(f, "MEDIUM_FAST_EU"),
+            Self::MediumSlowEu => write!(f, "MEDIUM_SLOW_EU"),
+            Self::LongFastEu => write!(f, "LONG_FAST_EU"),
+            Self::LongModerateEu => write!(f, "LONG_MODERATE_EU"),
+            Self::LongSlowEu => write!(f, "LONG_SLOW_EU"),
+            Self::VeryLongSlowEu => write!(f, "VERY_LONG_SLOW_EU"),
+            Self::ShortTurboUs => write!(f, "SHORT_TURBO_US"),
+            Self::ShortFastUs => write!(f, "SHORT_FAST_US"),
+            Self::ShortSlowUs => write!(f, "SHORT_SLOW_US"),
+            Self::MediumFastUs => write!(f, "MEDIUM_FAST_US"),
+            Self::MediumSlowUs => write!(f, "MEDIUM_SLOW_US"),
+            Self::LongTurboUs => write!(f, "LONG_TURBO_US"),
+            Self::LongFastUs => write!(f, "LONG_FAST_US"),
+            Self::LongModerateUs => write!(f, "LONG_MODERATE_US"),
+            Self::LongSlowUs => write!(f, "LONG_SLOW_US"),
+            Self::VeryLongSlowUs => write!(f, "VERY_LONG_SLOW_US"),
+            Self::Custom(bandwidth, spreading_factor, code_rate, channel, ldro) => write!(
+                f,
+                "Custom({bandwidth}, {spreading_factor}, {code_rate}, {channel}, {ldro})"
+            ),
+        }
+    }
+}
+
+#[derive(Clone)]
+pub struct MeshtasticConfigEnumParser;
+
+impl TypedValueParser for MeshtasticConfigEnumParser {
+    type Value = MeshtasticConfig;
+    fn parse_ref(
+        &self,
+        _cmd: &Command,
+        arg: Option<&Arg>,
+        value: &OsStr,
+    ) -> Result<Self::Value, Error> {
+        let ignore_case = arg.map(|a| a.is_ignore_case_set()).unwrap_or(false);
+        match MeshtasticConfig::from_str(value.to_str().unwrap(), ignore_case) {
+            Err(msg) => Err(clap::error::Error::raw(ErrorKind::InvalidValue, msg)),
+            Ok(value) => Ok(value),
         }
     }
 }

--- a/examples/lora/src/modulator.rs
+++ b/examples/lora/src/modulator.rs
@@ -1,14 +1,16 @@
 use futuresdr::num_complex::Complex32;
+use futuresdr::prelude::Result;
 use futuresdr::tracing::warn;
 
 use crate::utils::SpreadingFactor;
+use crate::utils::SynchWord;
 use crate::utils::build_upchirp_phase_coherent;
-use crate::utils::expand_sync_word;
+use crate::utils::samples_from_phase_diff;
 
 pub struct Modulator {
     spreading_factor: SpreadingFactor,
     oversampling: usize,
-    sync_words: Vec<usize>,
+    sync_word: [usize; 2],
     preamble_len: usize,
     pad_front: usize,
     pad_tail: usize,
@@ -18,51 +20,27 @@ impl Modulator {
     pub fn new(
         spreading_factor: SpreadingFactor,
         oversampling: usize,
-        sync_words: Vec<usize>,
+        sync_word: SynchWord,
         preamble_len: usize,
         pad: usize,
-    ) -> Self {
+    ) -> Result<Self> {
         if preamble_len < 5 {
-            warn!("Preamble length should be at least 5!"); // TODO
+            warn!("Preamble length should be at least 5!"); // as specified in semtech datasheets
         }
-        let sync_words_expanded = expand_sync_word(sync_words.clone());
-        if sync_words[0] != 0x12 && spreading_factor < SpreadingFactor::SF7 {
-            warn!(
-                "LoRa Modulator: selecting sync word other than 0x12 for SF < 7 will likely not work with commercial receivers.\n\tSee e.g. https://github.com/Lora-net/sx1302_hal/issues/124#issuecomment-2173450337"
-            );
-        }
-        for sync_word_symbol in sync_words_expanded.iter() {
-            if *sync_word_symbol >= 1 << Into::<usize>::into(spreading_factor) {
-                panic!(
-                    "LoRa Modulator: can not encode chosen sync word with the given spreading factor: symbol space too small.\n\ttried to encode sync word '{}' (symbol values [{}, {}]), with {}, which only supports symbols within [0; {}].",
-                    sync_words[0],
-                    sync_words_expanded[0],
-                    sync_words_expanded[1],
-                    spreading_factor,
-                    1 << Into::<usize>::into(spreading_factor)
-                );
-            }
-        }
-        Modulator {
+        Ok(Modulator {
             spreading_factor,
             oversampling,
-            sync_words: sync_words_expanded,
+            sync_word: sync_word.verify_and_expand(spreading_factor)?,
             preamble_len,
             pad_front: pad,
             pad_tail: pad,
-        }
+        })
     }
 
-    fn samples_from_phase_diff(&self, phase_increments: &[f32]) -> Vec<Complex32> {
-        let mut last_phase = 0.0;
-        phase_increments
-            .iter()
-            .map(|p_i| {
-                let tmp = Complex32::new(1.0, 0.0) * Complex32::from_polar(1., last_phase + *p_i);
-                last_phase += *p_i;
-                tmp
-            })
-            .collect()
+    pub fn set_synch_word(&mut self, synch_word: SynchWord) -> Result<()> {
+        let sync_word_expanded = synch_word.verify_and_expand(self.spreading_factor)?;
+        self.sync_word = sync_word_expanded;
+        Ok(())
     }
 
     pub fn modulate(&self, frame: Vec<u16>) -> Vec<Complex32> {
@@ -95,7 +73,7 @@ impl Modulator {
                 // sync words
                 } else if preamb_samp_cnt == self.preamble_len {
                     let sync_upchirp = build_upchirp_phase_coherent(
-                        self.sync_words[0],
+                        self.sync_word[0],
                         self.spreading_factor.into(),
                         self.oversampling,
                         true,
@@ -105,7 +83,7 @@ impl Modulator {
                     phase_increments.extend_from_slice(&sync_upchirp);
                 } else if preamb_samp_cnt == self.preamble_len + 1 {
                     let sync_upchirp = build_upchirp_phase_coherent(
-                        self.sync_words[1],
+                        self.sync_word[1],
                         self.spreading_factor.into(),
                         self.oversampling,
                         true,
@@ -170,6 +148,6 @@ impl Modulator {
 
         phase_increments.extend_from_slice(&vec![0.0; self.pad_tail]);
 
-        self.samples_from_phase_diff(&phase_increments)
+        samples_from_phase_diff(&phase_increments)
     }
 }

--- a/examples/lora/src/transmitter.rs
+++ b/examples/lora/src/transmitter.rs
@@ -3,12 +3,14 @@ use futuresdr::prelude::*;
 use std::collections::VecDeque;
 
 use crate::Encoder;
+use crate::HeaderMode;
 use crate::Modulator;
 use crate::utils::CodeRate;
 use crate::utils::SpreadingFactor;
+use crate::utils::SynchWord;
 
 #[derive(Block)]
-#[message_inputs(msg)]
+#[message_inputs(msg, synch_word)]
 pub struct Transmitter<O = DefaultCpuWriter<Complex32>>
 where
     O: CpuBufferWriter<Item = Complex32>,
@@ -33,14 +35,14 @@ where
         code_rate: CodeRate,
         has_crc: bool,
         spreading_factor: SpreadingFactor,
-        low_data_rate: bool,
-        implicit_header: bool,
+        ldro_enabled: bool,
+        header_mode: HeaderMode,
         oversampling: usize,
-        sync_words: Vec<usize>,
+        sync_words: SynchWord,
         preamble_len: usize,
         pad: usize,
-    ) -> Self {
-        Self {
+    ) -> Result<Self> {
+        Ok(Self {
             output: O::default(),
             frames: VecDeque::new(),
             current_frame: Vec::new(),
@@ -50,8 +52,8 @@ where
                 code_rate,
                 spreading_factor,
                 has_crc,
-                low_data_rate,
-                implicit_header,
+                ldro_enabled,
+                !matches!(header_mode, HeaderMode::Explicit),
             ),
             modulator: Modulator::new(
                 spreading_factor,
@@ -59,9 +61,9 @@ where
                 sync_words,
                 preamble_len,
                 pad,
-            ),
+            )?,
             tag_pending: None,
-        }
+        })
     }
 
     async fn msg(
@@ -80,6 +82,30 @@ where
                 return Ok(Pmt::InvalidValue);
             }
         }
+        Ok(Pmt::Ok)
+    }
+
+    async fn synch_word(
+        &mut self,
+        _io: &mut WorkIo,
+        _mio: &mut MessageOutputs,
+        _meta: &mut BlockMeta,
+        p: Pmt,
+    ) -> Result<Pmt> {
+        let new_synch_word = match p {
+            Pmt::U32(synch_word_new) => SynchWord::from(TryInto::<u8>::try_into(synch_word_new)?),
+            Pmt::U64(synch_word_new) => SynchWord::from(TryInto::<u8>::try_into(synch_word_new)?),
+            Pmt::Blob(synch_word_new) => TryFrom::<&[u8]>::try_from(&synch_word_new)?,
+            Pmt::Finished => {
+                self.finished = true;
+                return Ok(Pmt::Ok);
+            }
+            _ => {
+                warn!("Transmitter: new synch_word was not a Blob");
+                return Ok(Pmt::InvalidValue);
+            }
+        };
+        self.modulator.set_synch_word(new_synch_word)?;
         Ok(Pmt::Ok)
     }
 }

--- a/examples/lora/src/utils.rs
+++ b/examples/lora/src/utils.rs
@@ -7,6 +7,7 @@ use std::fmt::Formatter;
 use std::hash::Hash;
 use std::ops::Mul;
 use std::ops::Rem;
+use std::str::FromStr;
 use std::sync::Arc;
 
 use clap::Arg;
@@ -25,15 +26,17 @@ use strum_macros::EnumIter;
 
 use futuredsp::firdes::remez;
 use futuresdr::num_complex::Complex32;
-
-use crate::utils::SpreadingFactor::SF7;
+use futuresdr::prelude::Result;
+use futuresdr::prelude::warn;
+use regex::Regex;
+use serde::Deserialize;
+use serde::Serialize;
 
 pub type LLR = f64; // Log-Likelihood Ratio type
 
 pub const PREAMB_COUNT_DEFAULT: usize = 8;
 
 pub const MAX_SF: usize = 12;
-pub const LDRO_MAX_DURATION_MS: f32 = 16.;
 pub const WHITENING_SEQ: [u8; 255] = [
     0xFF, 0xFE, 0xFC, 0xF8, 0xF0, 0xE1, 0xC2, 0x85, 0x0B, 0x17, 0x2F, 0x5E, 0xBC, 0x78, 0xF1, 0xE3,
     0xC6, 0x8D, 0x1A, 0x34, 0x68, 0xD0, 0xA0, 0x40, 0x80, 0x01, 0x02, 0x04, 0x08, 0x11, 0x23, 0x47,
@@ -136,7 +139,26 @@ impl clap::ValueEnum for Channel {
 
 impl Display for Channel {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", self.to_possible_value().unwrap().get_name())
+        match self {
+            Channel::Custom(center_freq) => {
+                if center_freq % 1_000 == 0 {
+                    let mhz = center_freq / 1_000_000;
+                    let khz_remainder = (center_freq % 1_000_000) / 1_000;
+                    if khz_remainder == 0 {
+                        write!(f, "[{mhz}.0MHz]")
+                    } else {
+                        let mut fractional = format!("{khz_remainder:03}");
+                        while fractional.ends_with('0') {
+                            fractional.pop();
+                        }
+                        write!(f, "[{mhz}.{fractional}MHz]")
+                    }
+                } else {
+                    write!(f, "[{center_freq}Hz]")
+                }
+            }
+            _ => write!(f, "{}", self.to_possible_value().unwrap().get_name()),
+        }
     }
 }
 
@@ -250,7 +272,7 @@ impl From<Channel> for f64 {
     }
 }
 
-#[derive(Debug, Clone, clap::ValueEnum, Copy, Default)]
+#[derive(Debug, Clone, clap::ValueEnum, Copy, Default, Display)]
 #[clap(rename_all = "SCREAMING_SNAKE_CASE")]
 #[allow(non_camel_case_types)]
 pub enum Bandwidth {
@@ -310,8 +332,183 @@ impl From<Bandwidth> for f64 {
     }
 }
 
+#[derive(Default, Debug, Clone, Copy, EnumIter, PartialEq, Eq, Display, Serialize, Deserialize)]
+pub enum SynchWord {
+    #[default]
+    Public,
+    Private,
+    Meshtastic,
+    Value(u8),
+    ExpandedSymbols(u8, u8),
+}
+
+impl clap::ValueEnum for SynchWord {
+    fn value_variants<'a>() -> &'a [Self] {
+        &[
+            SynchWord::Value(0x12),
+            SynchWord::ExpandedSymbols(0x08, 0x16),
+        ]
+    }
+
+    fn from_str(input: &str, ignore_case: bool) -> Result<Self, String> {
+        let input_uppercase = input.to_uppercase();
+        Ok(if let Ok(synch_word) = input.parse::<u8>() {
+            Self::from(synch_word)
+        } else if let Ok(expanded_symbols) = input.parse::<u16>() {
+            Self::ExpandedSymbols(
+                (expanded_symbols >> 8) as u8,
+                (expanded_symbols & 0x00FF) as u8,
+            )
+        } else {
+            match if ignore_case {
+                input_uppercase.as_str()
+            } else {
+                input
+            } {
+                "public" => SynchWord::Public,
+                "private" => SynchWord::Private,
+                "meshtastic" => SynchWord::Meshtastic,
+                _ => return Err(format!("invalid variant: {input}")),
+            }
+        })
+    }
+
+    fn to_possible_value(&self) -> Option<PossibleValue> {
+        match self {
+            SynchWord::Private => Some(PossibleValue::new("private")),
+            SynchWord::Public => Some(PossibleValue::new("public")),
+            SynchWord::Meshtastic => Some(PossibleValue::new("meshtastic")),
+            SynchWord::Value(_) => Some(PossibleValue::new("[u8]")),
+            SynchWord::ExpandedSymbols(_, _) => Some(
+                PossibleValue::new("[u16]")
+                    .help("expanded synch word, e.g. 0x0816 for LoRaWAN private."),
+            ),
+        }
+    }
+}
+
+impl From<u8> for SynchWord {
+    fn from(value: u8) -> Self {
+        match value {
+            0x12 => SynchWord::Private,
+            0x34 => SynchWord::Public,
+            0x2B => SynchWord::Meshtastic,
+            other => SynchWord::Value(other),
+        }
+    }
+}
+
+impl TryFrom<&[u8]> for SynchWord {
+    type Error = anyhow::Error;
+
+    fn try_from(values: &[u8]) -> Result<Self, Self::Error> {
+        match values.len() {
+            1 => Ok(Self::from(values[0])),
+            2 => Ok(SynchWord::ExpandedSymbols(values[0], values[1])),
+            _ => Err(anyhow::Error::new(
+                futuresdr::prelude::Error::ValidationError(format!(
+                    "invalid value for synch word: {values:?}"
+                )),
+            )),
+        }
+    }
+}
+
+impl From<SynchWord> for u8 {
+    fn from(value: SynchWord) -> Self {
+        match value {
+            SynchWord::Private => 0x12,
+            SynchWord::Public => 0x34,
+            SynchWord::Meshtastic => 0x2B,
+            SynchWord::Value(v) => v,
+            SynchWord::ExpandedSymbols(synch_0, synch_1) => SynchWord::compact(synch_0, synch_1),
+        }
+    }
+}
+
+#[derive(Clone)]
+pub struct SynchWordEnumParser;
+
+impl TypedValueParser for SynchWordEnumParser {
+    type Value = SynchWord;
+    fn parse_ref(
+        &self,
+        _cmd: &Command,
+        arg: Option<&Arg>,
+        value: &OsStr,
+    ) -> Result<Self::Value, Error> {
+        let ignore_case = arg.map(|a| a.is_ignore_case_set()).unwrap_or(false);
+        match SynchWord::from_str(value.to_str().unwrap(), ignore_case) {
+            Err(msg) => Err(clap::error::Error::raw(ErrorKind::InvalidValue, msg)),
+            Ok(value) => Ok(value),
+        }
+    }
+}
+
+impl SynchWord {
+    fn compact(synch_0: u8, synch_1: u8) -> u8 {
+        ((synch_0 << 1) & 0xF0) | ((synch_1 >> 3) & 0x0F)
+    }
+    fn expand(&self) -> [u8; 2] {
+        fn expand_u8(value: &u8) -> [u8; 2] {
+            [((value & 0xF0_u8) >> 4) << 3, (value & 0x0F_u8) << 3]
+        }
+        match self {
+            SynchWord::Private => expand_u8(&0x12),
+            SynchWord::Public => expand_u8(&0x34),
+            SynchWord::Meshtastic => expand_u8(&0x2B),
+            SynchWord::Value(v) => expand_u8(v),
+            SynchWord::ExpandedSymbols(v1, v2) => [*v1, *v2],
+        }
+    }
+
+    fn verify(sync_word_expanded: [u8; 2], spreading_factor: SpreadingFactor) -> Result<[u8; 2]> {
+        if !(sync_word_expanded[0] == 0x08 && sync_word_expanded[1] == 0x16)
+            && spreading_factor < SpreadingFactor::SF7
+        {
+            warn!(
+                "LoRa Modulator: selecting sync word other than 0x12 for SF < 7 will likely not work with commercial receivers.\n\tSee e.g. https://github.com/Lora-net/sx1302_hal/issues/124#issuecomment-2173450337"
+            );
+        }
+        for sync_word_symbol in sync_word_expanded.iter() {
+            if Into::<usize>::into(*sync_word_symbol) >= spreading_factor.samples_per_symbol() {
+                let msg = format!(
+                    "LoRa Modulator: can not encode chosen sync word with the given spreading factor: symbol space too small.\n\ttried to encode sync word '{}' (symbol values [{}, {}]), with {}, which only supports symbols within [0; {}].",
+                    Self::compact(sync_word_expanded[0], sync_word_expanded[1]),
+                    sync_word_expanded[0],
+                    sync_word_expanded[1],
+                    spreading_factor,
+                    1 << Into::<usize>::into(spreading_factor)
+                );
+                return Err(anyhow::Error::new(
+                    futuresdr::prelude::Error::ValidationError(msg),
+                ));
+            }
+        }
+        Ok(sync_word_expanded)
+    }
+
+    pub fn verify_and_expand(&self, spreading_factor: SpreadingFactor) -> Result<[usize; 2]> {
+        let sync_words_expanded = self.expand();
+        Self::verify(sync_words_expanded, spreading_factor)
+            .map(|synch_word_u8| synch_word_u8.map(|val| val as usize))
+    }
+}
+
 #[derive(
-    Debug, Clone, clap::ValueEnum, Copy, Default, EnumIter, PartialEq, Eq, PartialOrd, Ord, Display,
+    Debug,
+    Clone,
+    clap::ValueEnum,
+    Copy,
+    Default,
+    EnumIter,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    Display,
+    Serialize,
+    Deserialize,
 )]
 #[clap(rename_all = "SCREAMING_SNAKE_CASE")]
 #[allow(non_camel_case_types)]
@@ -325,6 +522,24 @@ pub enum SpreadingFactor {
     SF10,
     SF11,
     SF12,
+}
+
+impl FromStr for SpreadingFactor {
+    type Err = ();
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "SF5" => Ok(SpreadingFactor::SF5),
+            "SF6" => Ok(SpreadingFactor::SF6),
+            "SF7" => Ok(SpreadingFactor::SF7),
+            "SF8" => Ok(SpreadingFactor::SF8),
+            "SF9" => Ok(SpreadingFactor::SF9),
+            "SF10" => Ok(SpreadingFactor::SF10),
+            "SF11" => Ok(SpreadingFactor::SF11),
+            "SF12" => Ok(SpreadingFactor::SF12),
+            _ => Err(()),
+        }
+    }
 }
 
 impl TryFrom<u8> for SpreadingFactor {
@@ -410,7 +625,7 @@ impl SpreadingFactor {
     }
 }
 
-#[derive(Debug, Clone, clap::ValueEnum, Copy, Default, Display)]
+#[derive(Debug, Clone, clap::ValueEnum, Copy, Default, Display, PartialEq, Eq)]
 #[clap(rename_all = "SCREAMING_SNAKE_CASE")]
 #[allow(non_camel_case_types)]
 pub enum CodeRate {
@@ -464,12 +679,37 @@ impl From<CodeRate> for usize {
 }
 
 #[repr(usize)]
-#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+#[derive(Debug, Copy, Clone, Eq, PartialEq, clap::ValueEnum, Display)]
+#[clap(rename_all = "SCREAMING_SNAKE_CASE")]
+#[strum(serialize_all = "SCREAMING_SNAKE_CASE")]
+#[allow(non_camel_case_types)]
 pub enum LdroMode {
     DISABLE = 0,
     ENABLE = 1,
     AUTO = 2,
 }
+
+impl LdroMode {
+    pub fn resolve_if_auto(self, sf: SpreadingFactor, bw: Bandwidth) -> Self {
+        if self != LdroMode::AUTO {
+            return self;
+        }
+
+        if sf.samples_per_symbol() as f32 * 1e3 / Into::<f32>::into(bw)
+            > crate::default_values::LDRO_MAX_DURATION_MS
+        {
+            LdroMode::ENABLE
+        } else {
+            LdroMode::DISABLE
+        }
+    }
+
+    pub fn enabled(self) -> bool {
+        debug_assert_ne!(self, LdroMode::AUTO);
+        self == LdroMode::ENABLE
+    }
+}
+
 impl From<usize> for LdroMode {
     fn from(orig: usize) -> Self {
         match orig {
@@ -477,6 +717,106 @@ impl From<usize> for LdroMode {
             1_usize => LdroMode::ENABLE,
             2_usize => LdroMode::AUTO,
             _ => panic!("invalid value to ldro_mode"),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, Default, Eq, PartialEq)]
+pub enum HeaderMode {
+    #[default]
+    Explicit,
+    Implicit {
+        payload_len: usize,
+        has_crc: bool,
+        code_rate: CodeRate,
+    },
+}
+
+impl clap::ValueEnum for HeaderMode {
+    fn value_variants<'a>() -> &'a [Self] {
+        &[
+            HeaderMode::Explicit,
+            HeaderMode::Implicit {
+                payload_len: 0,
+                has_crc: true,
+                code_rate: CodeRate::CR_4_5,
+            },
+        ]
+    }
+
+    fn from_str(input: &str, ignore_case: bool) -> Result<Self, String> {
+        fn parse_implicit_header(passed: &str, ignore_case: bool) -> Result<HeaderMode, String> {
+            let re = Regex::new(
+                r#"^"??(?<uppercase>[Ii])mplicit\((?<payload_len>[0-9]{1,3}), ?(?<has_crc>[tT]rue|(?:[fF]alse)), ?(?<code_rate>CR_4_[5678])\)"?$"#,
+            )
+            .unwrap();
+            let regex_match = re.captures(passed);
+            match regex_match {
+                Some(regex_match) => {
+                    let is_uppercase = "I" == &regex_match["uppercase"];
+                    if !is_uppercase && !ignore_case {
+                        return Err(format!(
+                            "invalid variant (has to be uppercase 'Implicit[...]'): {passed}"
+                        ));
+                    }
+                    let payload_len: u8 = regex_match["payload_len"].parse().unwrap();
+                    let has_crc = "true" == regex_match["has_crc"].to_lowercase();
+                    let code_rate = CodeRate::from_str(&regex_match["code_rate"], ignore_case)?;
+                    Ok(HeaderMode::Implicit {
+                        payload_len: payload_len as usize,
+                        has_crc,
+                        code_rate,
+                    })
+                }
+                None => Err(format!("invalid variant: {passed}")),
+            }
+        }
+        let input_lowercase = input.to_lowercase();
+        if ignore_case {
+            match input_lowercase.as_str() {
+                "explicit" => Ok(HeaderMode::Explicit),
+                _ => parse_implicit_header(&input_lowercase, true),
+            }
+        } else {
+            match input {
+                "Explicit" => Ok(HeaderMode::Explicit),
+                _ => parse_implicit_header(input, false),
+            }
+        }
+    }
+
+    fn to_possible_value(&self) -> Option<PossibleValue> {
+        match self {
+            HeaderMode::Explicit => Some(PossibleValue::new("Explicit")),
+            HeaderMode::Implicit {
+                payload_len: _,
+                has_crc: _,
+                code_rate: _,
+            } => Some(
+                PossibleValue::new(
+                    "Implicit{[payload_len], [has_crc], [code_rate]}",
+                )
+                .help("fixed LoRa modulation parameters known to both sender and receiver. E.g., 'Implicit(16, false, CR_4_5)'"),
+            ),
+        }
+    }
+}
+
+#[derive(Clone)]
+pub struct HeaderModeEnumParser;
+
+impl TypedValueParser for HeaderModeEnumParser {
+    type Value = HeaderMode;
+    fn parse_ref(
+        &self,
+        _cmd: &Command,
+        arg: Option<&Arg>,
+        value: &OsStr,
+    ) -> Result<Self::Value, Error> {
+        let ignore_case = arg.map(|a| a.is_ignore_case_set()).unwrap_or(false);
+        match HeaderMode::from_str(value.to_str().unwrap(), ignore_case) {
+            Err(msg) => Err(clap::error::Error::raw(ErrorKind::InvalidValue, msg)),
+            Ok(value) => Ok(value),
         }
     }
 }
@@ -610,6 +950,18 @@ pub fn build_upchirp_phase_coherent(
     phase_increment
 }
 
+pub fn samples_from_phase_diff(phase_increments: &[f32]) -> Vec<Complex32> {
+    let mut last_phase = 0.0;
+    phase_increments
+        .iter()
+        .map(|p_i| {
+            let tmp = Complex32::new(1.0, 0.0) * Complex32::from_polar(1., last_phase + *p_i);
+            last_phase += *p_i;
+            tmp
+        })
+        .collect()
+}
+
 #[inline]
 pub fn my_modulo(val1: isize, val2: usize) -> usize {
     if val1 >= 0 {
@@ -637,23 +989,29 @@ pub fn my_roundf(number: f32) -> isize {
 pub fn sample_count(
     sf: SpreadingFactor,
     preamble_len: usize,
-    implicit_header: bool,
+    header_mode: HeaderMode,
     payload_len: usize,
     has_crc: bool,
     code_rate: CodeRate,
     os_factor: usize,
     pad: usize,
-    ldro: bool,
+    ldro_enabled: bool,
 ) -> usize {
-    let preamble_symbol_count: f32 = preamble_len as f32 + 4.25 + if sf < SF7 { 2.0 } else { 0.0 };
-    let header_symbol_count_before_interleaving: usize = if implicit_header { 0 } else { 5 };
+    let preamble_symbol_count: f32 =
+        preamble_len as f32 + 4.25 + if sf < SpreadingFactor::SF7 { 2.0 } else { 0.0 };
+    let header_symbol_count_before_interleaving: usize =
+        if matches!(header_mode, HeaderMode::Explicit) {
+            5
+        } else {
+            0
+        };
     let payload_symbol_count_before_interleaving: usize =
         2 * payload_len + if has_crc { 4 } else { 0 };
     ((preamble_symbol_count
         + 8.  // header symbol count after interleaving, including the first [(Into::<usize>::into(sf) - if LEGACY_SF_5_6 || sf >= SF7 {2} else {0}))] payload symbols
         + ((payload_symbol_count_before_interleaving + header_symbol_count_before_interleaving
-            - (Into::<usize>::into(sf) - if sf >= SF7 {2} else {0})) as f32
-            / (Into::<usize>::into(sf) - if ldro {2} else {0}) as f32)
+            - (Into::<usize>::into(sf) - if sf >= SpreadingFactor::SF7 {2} else {0})) as f32
+            / (Into::<usize>::into(sf) - if ldro_enabled {2} else {0}) as f32)
             .ceil()  // 22 -> 21.x
             * (4 + Into::<usize>::into(code_rate)) as f32)
         * ((1 << Into::<usize>::into(sf)) * os_factor) as f32) as usize
@@ -716,15 +1074,6 @@ pub fn get_symbol_val(
         Some(argmax_f32(&fft_mag))
     } else {
         None
-    }
-}
-
-pub fn expand_sync_word(sync_word: Vec<usize>) -> Vec<usize> {
-    if sync_word.len() == 1 {
-        let tmp = sync_word[0];
-        vec![((tmp & 0xF0_usize) >> 4) << 3, (tmp & 0x0F_usize) << 3]
-    } else {
-        sync_word
     }
 }
 


### PR DESCRIPTION
add convenience wrappers for RX and TX chain creation, introduce enums for arguments with non-trivial types (sync-word, ldro mode, header mode, meshtastic presets).

main additions in lib.rs, utils.rs and meshtastic.rs, plus necessary updates of interfaces throughout all files.