### PR TITLE
Increase TX buffer size for Zigbee example

### DIFF
--- a/examples/zigbee/src/bin/trx.rs
+++ b/examples/zigbee/src/bin/trx.rs
@@ -46,6 +46,7 @@ fn main() -> Result<()> {
             .frequency(args.tx_freq)
             .sample_rate(4e6)
             .gain(args.tx_gain)
+            .min_in_buffer_size(98304)
             .build_sink()?,
     );
 

--- a/examples/zigbee/src/bin/tx.rs
+++ b/examples/zigbee/src/bin/tx.rs
@@ -48,6 +48,7 @@ fn main() -> Result<()> {
         .sample_rate(args.sample_rate)
         .gain(args.gain)
         .antenna(args.antenna)
+        .min_in_buffer_size(98304)
         .build_sink()?;
     let snk = fg.add_block(snk);
 


### PR DESCRIPTION
This PR increases the TX buffer size for tx and trx modes of Zigbee examples considering the maximum possible sample size of a Zigbee packet.