### PR TITLE
Prevent confusion between ping and null messages in rattlegram

### DIFF
--- a/examples/rattlegram/src/decoder.rs
+++ b/examples/rattlegram/src/decoder.rs
@@ -1207,15 +1207,18 @@ impl Decoder {
         self.staged_mode = (md & 0xff).into();
         self.staged_call = md >> 8;
 
-        if self.staged_mode == OperationMode::Null {
-            return DecoderResult::Nope;
+        if self.staged_mode == OperationMode::Null
+            && self.staged_call != 0
+            && self.staged_call < 129961739795077
+        {
+            return DecoderResult::Ping;
         }
+
         if self.staged_call == 0 || self.staged_call >= 129961739795077 {
             self.staged_call = 0;
             return DecoderResult::Nope;
         }
 
-        // Todo status PING
         DecoderResult::Okay
     }
 


### PR DESCRIPTION
This PR fixes the issue where ping messages were incorrectly classified as null packets in the rattlegram example. This ensures that control messages are handled separately from empty data packets.