### PR TITLE
Add Bluetooth Low Energy Sniffer Example

### DIFF
--- a/examples/bluetooth/.gitignore
+++ b/examples/bluetooth/.gitignore
@@ -1,0 +1,2 @@
+*.iq
+metadata.json

--- a/examples/bluetooth/Cargo.toml
+++ b/examples/bluetooth/Cargo.toml
@@ -1,0 +1,24 @@
+[package]
+name = "bluetooth"
+version = "0.1.0"
+edition = "2024"
+default-run = "sniffer"
+
+[workspace]
+
+[[bin]]
+name = "sniffer"
+path = "src/main.rs"
+
+[features]
+default = ["soapy"]
+rtlsdr = ["futuresdr/rtlsdr"]
+soapy = ["futuresdr/soapy"]
+
+[dependencies]
+anyhow = "1.0"
+clap = { version = "4", features = ["derive"] }
+ctrlc = "3"
+futuresdr = { path = "../..", features = ["seify"] }
+yagi = "0.1.5"
+num-complex = "0.4"

--- a/examples/bluetooth/Cargo.toml
+++ b/examples/bluetooth/Cargo.toml
@@ -22,4 +22,3 @@ ctrlc = "3"
 futuresdr = { path = "../..", features = ["seify"] }
 futuredsp = { path = "../../crates/futuredsp" }
 yagi = "0.1.5"
-num-complex = "0.4"

--- a/examples/bluetooth/Cargo.toml
+++ b/examples/bluetooth/Cargo.toml
@@ -20,5 +20,6 @@ anyhow = "1.0"
 clap = { version = "4", features = ["derive"] }
 ctrlc = "3"
 futuresdr = { path = "../..", features = ["seify"] }
+futuredsp = { path = "../../crates/futuredsp" }
 yagi = "0.1.5"
 num-complex = "0.4"

--- a/examples/bluetooth/README.md
+++ b/examples/bluetooth/README.md
@@ -2,27 +2,41 @@
 
 ## Introduction
 
-This example is a single-channel BLE advertising sniffer. It receives a BLE
-advertising channel with an SDR, demodulates the GFSK signal, detects the BLE
-advertising access address, dewhitens the advertising PDU, validates the BLE
-CRC, and prints a compact packet summary.
+This example is an experimental BLE sniffer for FutureSDR. It currently focuses
+on BLE advertising reception and provides a working baseline for later
+connection following and wider multi-channel reception.
 
-The current implementation is intended as a baseline for further work. It is
-not yet a full Bluetooth sniffer and does not follow connections or decode all
-Bluetooth PHY modes.
+The receiver can tune one BLE channel directly, or use a FutureSDR PFB
+channelizer to split a wider capture into multiple 2 MHz BLE channel bins. The
+preferred decoder path is the IQ burst decoder. A continuous decoder is still
+available as a reference/debug path.
+
+The example can currently:
+
+- receive BLE advertising channels with SDR hardware,
+- demodulate BLE 1M GFSK packets,
+- detect the advertising access address,
+- dewhiten and CRC-check advertising PDUs,
+- parse common legacy advertising packet types,
+- summarize advertising data fields,
+- parse common `ADV_EXT_IND` extended advertising header fields,
+- parse `CONNECT_IND` and store connection parameters in a small connection
+  table,
+- run a PFB multi-channel mode for selected BLE channels,
+- validate the PFB channel mapping with a synthetic unit test.
+
+This is not yet a full Bluetooth sniffer. It does not yet decode BLE data
+channel packets or follow connection hopping.
 
 ## Running
 
-The default channel is BLE advertising channel 37. The default gain is 30,
-which provided the best balance between packet count and CRC reject rate in
-local tests.
-
-From the repository root:
+Run commands from this directory:
 
 ```sh
 cargo run --release
 ```
 
+The default channel is BLE advertising channel 37 and the default gain is 30.
 Stop the sniffer with Ctrl+C. The flowgraph shuts down gracefully and prints
 final packet statistics.
 
@@ -32,11 +46,29 @@ For a fixed-duration run:
 cargo run --release -- --duration 30
 ```
 
+The burst decoder is the recommended path:
+
+```sh
+cargo run --release -- --channel 37 --burst --gain 30 --duration 30
+```
+
+Packet printing can be disabled while keeping final statistics:
+
+```sh
+cargo run --release -- --channel 37 --burst --quiet --gain 30 --duration 30
+```
+
 To tune another advertising channel:
 
 ```sh
-cargo run --release -- --channel 38
-cargo run --release -- --channel 39
+cargo run --release -- --channel 38 --burst --quiet --gain 30 --duration 30
+cargo run --release -- --channel 39 --burst --quiet --gain 30 --duration 30
+```
+
+For a USRP B210, the following arguments were useful in local tests:
+
+```sh
+cargo run --release -- --channel 37 --burst --quiet --gain 30 --duration 30 --args "type=b200,num_recv_frames=512"
 ```
 
 ## Simulation
@@ -45,71 +77,169 @@ Simulation mode generates synthetic BLE advertising packets and sends them
 through the GMSK receive chain:
 
 ```sh
-cargo run --release -- --simulate --simulate-packets 3
+cargo run --release -- --simulate --burst --simulate-packets 3
 ```
 
-This is useful for checking the parser, whitening, CRC, GMSK filter,
-discriminator, slicer, and packet detector without SDR hardware.
+This is useful for checking the parser, whitening, CRC, GMSK filter, burst
+detector, demodulator, and packet detector without SDR hardware.
+
+## Multi-Channel Mode
+
+Multi-channel mode uses FutureSDR's `PfbChannelizer` to split a wider capture
+into 2 MHz channel bins. The channel list selects which BLE channels are decoded.
+Passive channels are included in the PFB capture span but are connected to a
+sink instead of a BLE decoder. This is useful for measuring whether a wider span
+is practical without implementing data-channel decoding yet.
+
+Advertising channel 37 plus adjacent data channel 0:
+
+```sh
+cargo run --release -- --multi-channel --channels 37 --passive-channels 0 --burst --quiet --gain 30 --duration 30 --args "type=b200,num_recv_frames=512"
+```
+
+Advertising channel 38 plus nearby data channels:
+
+```sh
+cargo run --release -- --multi-channel --channels 38 --passive-channels 10,11 --burst --quiet --gain 30 --duration 30 --args "type=b200,num_recv_frames=512"
+cargo run --release -- --multi-channel --channels 38 --passive-channels 9,10,11,12 --burst --quiet --gain 30 --duration 30 --args "type=b200,num_recv_frames=512"
+```
+
+Advertising channels 37 and 38 together:
+
+```sh
+cargo run --release -- --multi-channel --channels 37,38 --burst --quiet --gain 30 --duration 30 --args "type=b200,num_recv_frames=512"
+```
+
+In local B210 tests, low-rate PFB captures around one advertising channel were
+stable. Capturing advertising channels 37 and 38 together required a much wider
+span and produced many overflows on the test laptop, although packets from both
+channels were still decoded.
 
 ## Output
 
-Example output:
+Example packet summaries:
 
 ```text
 BLE packet: ch=37 type=ADV_IND len=24 adv_a=57:41:78:10:B4:06 ad=[flags=0x1A, tx_power=12dBm, mfg=Apple(0x004C)/8B]
 BLE packet: ch=37 type=ADV_EXT_IND len=7 ext=[mode=connectable adi=0x3F02 aux_ch=31 aux_offset=1170us aux_phy=2M]
 ```
 
-At shutdown the example prints final statistics:
+At shutdown the example prints final statistics and any tracked connections:
 
 ```text
-BLE stats: packets=1695 aa_candidates=3630 aa_per_packet=2.14 header_rejects=5 pdu_attempts=2210 crc_rejects=515 duplicate_crc_rejects=300 raw_crc_rejects=815 crc_reject_rate=23.3%
+BLE burst stats: ch=37 bursts=15757 decoded_bursts=11345 short_bursts=0 fsk_rejects=1881 packets=11345 connect_ind=1 connections=1 aa_candidates=13647 aa_per_packet=1.20 header_rejects=2 pdu_attempts=12833 crc_rejects=1488 crc_reject_rate=11.6%
+BLE connection: ch=37 aa=0xC6176D8D crc_init=0xA9DABD init_a=6D:3B:2F:E7:19:8A(random) adv_a=78:4B:F4:DF:75:14(random) interval=30.00ms latency=0 timeout=5000ms hop=14 sca=5 channels=37 first_ch=37 last_ch=37 seen=1
 ```
 
 Statistics:
 
 - `packets`: CRC-valid BLE advertising packets.
+- `connect_ind`: CRC-valid `CONNECT_IND` packets.
+- `connections`: unique connection requests stored in the connection table.
 - `aa_candidates`: detected advertising access address candidates.
 - `aa_per_packet`: access-address candidates per valid packet.
-- `header_rejects`: candidates rejected before CRC because no plausible PDU length was found.
+- `header_rejects`: candidates rejected before CRC because no plausible PDU
+  length was found.
 - `pdu_attempts`: valid packets plus non-duplicate CRC rejects.
 - `crc_rejects`: candidate windows that reached CRC and failed.
-- `duplicate_crc_rejects`: nearby CRC rejects grouped into the same candidate window.
-- `raw_crc_rejects`: `crc_rejects + duplicate_crc_rejects`.
 - `crc_reject_rate`: `crc_rejects / pdu_attempts`.
+
+The continuous decoder additionally reports:
+
+- `duplicate_crc_rejects`: nearby CRC rejects grouped into the same candidate
+  window.
+- `raw_crc_rejects`: `crc_rejects + duplicate_crc_rejects`.
+
+## Current Measurements
+
+These measurements were taken with a USRP B210, gain 30, packet printing
+disabled, and `num_recv_frames=512`. They are intended as rough development
+guidance, not final benchmark numbers.
+
+Single-channel burst decoder:
+
+| Channel | Packets | CONNECT_IND | CRC Reject Rate |
+| ------- | ------- | ----------- | --------------- |
+| 37 | 5427 | 1 | 11.7% |
+| 38 | 4811 | 1 | 11.5% |
+| 39 | 4000 | 1 | 13.1% |
+
+Low-rate PFB captures:
+
+| Configuration | Packets | CONNECT_IND | CRC Reject Rate |
+| ------------- | ------- | ----------- | --------------- |
+| ch37 + passive data0 | 5776 | 0 | 11.8% |
+| ch38 + passive data10,11 | 5398 | 1 | 13.0% |
+| ch38 + passive data9,10,11,12 | 6152 | 0 | 14.8% |
+
+Two advertising channels through PFB:
+
+| Channel | Packets | CONNECT_IND | CRC Reject Rate |
+| ------- | ------- | ----------- | --------------- |
+| 37 | 1088 | 0 | 14.8% |
+| 38 | 992 | 0 | 12.9% |
+
+The two-advertising-channel run produced many USRP overflows on the test
+machine. This suggests that the current PFB path is functionally correct but
+wide captures are limited by host/USB/PFB throughput in this setup.
+
+Continuous decoder versus burst decoder on channel 37:
+
+| Decoder | Packets | CRC Reject Rate | AA/Packet | Header Rejects | Avg CPU | Max CPU |
+| ------- | ------- | --------------- | --------- | -------------- | ------- | ------- |
+| Continuous | 16154 | 26.5% | 2.26 | 146 | 7.6% | 10.2% |
+| Burst | 12632 | 13.1% | 1.21 | 4 | 3.8% | 5.7% |
+
+The burst decoder used roughly half the CPU and produced fewer rejects in this
+measurement. The continuous decoder is currently kept as a reference/debug path.
 
 ## Decoder Notes
 
-The receiver currently uses a continuous detector:
+The burst decoder:
 
-1. Filter complex baseband samples with a GMSK receive filter.
-2. Run a phase discriminator.
-3. Slice discriminator output into bits with DC tracking.
-4. Search for the BLE advertising access address on each sample phase.
-5. After an access address candidate, capture a short PDU bit window.
-6. Try nearby bit offsets and accept the first CRC-valid PDU.
-7. Group nearby CRC failures into candidate-window rejects.
+1. Applies the GMSK receive filter.
+2. Detects IQ bursts with a simple squelch.
+3. Estimates and removes burst-level frequency offset.
+4. Demodulates and slices the burst.
+5. Searches for the BLE advertising access address.
+6. Tries nearby bit offsets and accepts the first CRC-valid advertising PDU.
+7. Records `CONNECT_IND` packets in a connection table.
 
-The `--normalize-levels` flag enables an experimental slicer mode that tracks
-positive and negative discriminator levels. It is disabled by default because it
-did not provide a consistent improvement in local measurements.
+The continuous decoder:
+
+1. Applies the GMSK receive filter.
+2. Runs a phase discriminator.
+3. Slices discriminator output into bits with DC tracking.
+4. Searches for the BLE advertising access address on each sample phase.
+5. Captures a short PDU bit window after an access address candidate.
+6. Tries nearby bit offsets and accepts the first CRC-valid advertising PDU.
+7. Groups nearby CRC failures into candidate-window rejects.
+
+The `--normalize-levels` flag enables an experimental slicer mode for the
+continuous decoder. It is disabled by default because it did not provide a
+consistent improvement in local measurements.
 
 ## Current Scope and Limitations
 
-- Single tuned BLE channel only.
-- Default channel is advertising channel 37.
-- Legacy advertising PDUs are parsed and summarized.
-- `ADV_EXT_IND` common extended header fields are summarized when present.
-- Secondary advertising channels from `AuxPtr` are not followed yet.
-- BLE data channels and connection following are not implemented.
+- BLE 1M advertising reception is the current focus.
+- Burst decoding is the preferred path.
+- `CONNECT_IND` is parsed and stored, but BLE data channel decoding is not
+  implemented yet.
+- Channel hopping is not followed yet.
+- `ADV_EXT_IND` common header fields are parsed, but secondary advertising
+  channels from `AuxPtr` are not followed yet.
+- Multi-channel PFB mode works for selected spans, but wide captures can be
+  limited by host throughput.
 - No PCAP, RFTap, Wireshark, or UDP output yet.
-- No PFB channelizer yet.
 
 ## Next Steps
 
-- Add README-level examples and measurement guidance for gain selection.
+- Use the connection table to try data-channel access-address detection.
+- CRC-check data-channel packets with the captured `crc_init`.
+- Add channel-map and hop prediction for one tracked connection.
+- Decide whether the continuous decoder should remain as a debug/reference path
+  or be removed.
+- Investigate whether the current FutureSDR PFB configuration is appropriate
+  for wider BLE captures, or whether a lighter/optimized channelizer path is
+  needed.
 - Add PCAP/RFTap output for Wireshark inspection.
-- Improve burst-based demodulation and timing/CFO handling.
-- Add channel hopping or a multi-channel PFB receiver.
-- Use `ADV_EXT_IND` `AuxPtr` information to follow secondary advertising once
-  multi-channel reception is available.

--- a/examples/bluetooth/README.md
+++ b/examples/bluetooth/README.md
@@ -1,245 +1,160 @@
-# Bluetooth Sniffer
+# Bluetooth Low Energy Sniffer
 
 ## Introduction
 
-This example is an experimental BLE sniffer for FutureSDR. It currently focuses
-on BLE advertising reception and provides a working baseline for later
-connection following and wider multi-channel reception.
+This example implements a Bluetooth Low Energy sniffer for FutureSDR. It
+receives BLE 1M signals from an SDR, demodulates GFSK packets, performs
+dewhitening and CRC validation, and prints decoded link-layer packet summaries.
 
-The receiver can tune one BLE channel directly, or use a FutureSDR PFB
-channelizer to split a wider capture into multiple 2 MHz BLE channel bins. The
-preferred decoder path is the IQ burst decoder. A continuous decoder is still
-available as a reference/debug path.
+The sniffer supports direct reception of a single BLE channel and PFB-based
+reception of multiple selected channels. It parses legacy and extended
+advertising headers, advertising data, and `CONNECT_IND` parameters. Connection
+following uses the captured access address, CRC initialization, channel map,
+and channel-selection parameters to inspect BLE data packets on monitored data
+channels.
 
-The example can currently:
+Two decoder modes are available:
 
-- receive BLE advertising channels with SDR hardware,
-- demodulate BLE 1M GFSK packets,
-- detect the advertising access address,
-- dewhiten and CRC-check advertising PDUs,
-- parse common legacy advertising packet types,
-- summarize advertising data fields,
-- parse common `ADV_EXT_IND` extended advertising header fields,
-- parse `CONNECT_IND` and store connection parameters in a small connection
-  table,
-- run a PFB multi-channel mode for selected BLE channels,
-- validate the PFB channel mapping with a synthetic unit test.
+- `continuous` processes the complete sample stream and is the default for a
+  single channel.
+- `burst` detects signal bursts before decoding and is the default for
+  multi-channel reception.
 
-This is not yet a full Bluetooth sniffer. It does not yet decode BLE data
-channel packets or follow connection hopping.
+## Single-Channel Reception
 
-## Running
-
-Run commands from this directory:
+Run the receiver from this directory:
 
 ```sh
 cargo run --release
 ```
 
-The default channel is BLE advertising channel 37 and the default gain is 30.
-Stop the sniffer with Ctrl+C. The flowgraph shuts down gracefully and prints
-final packet statistics.
-
-For a fixed-duration run:
+The default configuration receives BLE advertising channel 37 with gain 30 and
+the continuous decoder. Stop the receiver with Ctrl+C. A fixed duration can be
+specified when using SDR hardware:
 
 ```sh
-cargo run --release -- --duration 30
+cargo run --release -- --channels 37 --gain 30 --duration 30
 ```
 
-The burst decoder is the recommended path:
+Use the burst decoder explicitly with:
 
 ```sh
-cargo run --release -- --channel 37 --burst --gain 30 --duration 30
+cargo run --release -- --channels 37 --decoder burst --gain 30
 ```
 
-Packet printing can be disabled while keeping final statistics:
+Advertising channels 37, 38, and 39 can be selected by channel number:
 
 ```sh
-cargo run --release -- --channel 37 --burst --quiet --gain 30 --duration 30
+cargo run --release -- --channels 38 --decoder burst --gain 30
 ```
 
-To tune another advertising channel:
+Use `--quiet` to suppress individual packet lines while retaining the final
+statistics:
 
 ```sh
-cargo run --release -- --channel 38 --burst --quiet --gain 30 --duration 30
-cargo run --release -- --channel 39 --burst --quiet --gain 30 --duration 30
+cargo run --release -- --channels 37 --decoder burst --quiet
 ```
 
-For a USRP B210, the following arguments were useful in local tests:
+## Multi-Channel Reception
+
+A comma-separated channel list selects PFB-based multi-channel reception.
 
 ```sh
-cargo run --release -- --channel 37 --burst --quiet --gain 30 --duration 30 --args "type=b200,num_recv_frames=512"
+cargo run --release -- --channels 37,0 --gain 30
+cargo run --release -- --channels 38,10,11 --gain 30
+```
+
+Connection following can be enabled when the channel list contains an
+advertising channel and one or more data channels:
+
+```sh
+cargo run --release -- --channels 38,10,11 --follow-connections --gain 30
+```
+
+The follower records CRC-valid `CONNECT_IND` packets, predicts CSA #1 and
+CSA #2 connection events, validates data-channel packets with the
+connection-specific access address and CRC initialization, and processes
+link-layer connection and channel-map updates.
+
+The continuous decoder can also be selected explicitly for a multi-channel
+flowgraph:
+
+```sh
+cargo run --release -- --channels 38,10,11 --decoder continuous --gain 30
 ```
 
 ## Simulation
 
-Simulation mode generates synthetic BLE advertising packets and sends them
-through the GMSK receive chain:
+Simulation mode generates BLE advertising packets and passes them through the
+GMSK receive chain without SDR hardware:
 
 ```sh
-cargo run --release -- --simulate --burst --simulate-packets 3
+cargo run --release -- --simulate --decoder burst --simulate-packets 10
 ```
 
-This is useful for checking the parser, whitening, CRC, GMSK filter, burst
-detector, demodulator, and packet detector without SDR hardware.
+The flowgraph runs until all generated samples have been processed.
 
-## Multi-Channel Mode
+## Offline IQ Input
 
-Multi-channel mode uses FutureSDR's `PfbChannelizer` to split a wider capture
-into 2 MHz channel bins. The channel list selects which BLE channels are decoded.
-Passive channels are included in the PFB capture span but are connected to a
-sink instead of a BLE decoder. This is useful for measuring whether a wider span
-is practical without implementing data-channel decoding yet.
+Complex `f32` IQ recordings can be decoded with `--iq-file`. Samples use the
+native `Complex32` layout expected by FutureSDR's `FileSource`, with interleaved
+little-endian values:
 
-Advertising channel 37 plus adjacent data channel 0:
+```text
+I0 Q0 I1 Q1 I2 Q2 ...
+```
+
+The selected channel must match the recording center frequency, and the sample
+rate must match the recorded waveform:
 
 ```sh
-cargo run --release -- --multi-channel --channels 37 --passive-channels 0 --burst --quiet --gain 30 --duration 30 --args "type=b200,num_recv_frames=512"
+cargo run --release -- --iq-file ble_capture.iq --sample-rate 2e6 --channels 37 --decoder burst --quiet
 ```
 
-Advertising channel 38 plus nearby data channels:
+File input runs to EOF and then shuts down automatically.
+
+## Wireshark
+
+Decoded advertising and data packets can be streamed live to Wireshark over
+UDP using RFTap encapsulation:
 
 ```sh
-cargo run --release -- --multi-channel --channels 38 --passive-channels 10,11 --burst --quiet --gain 30 --duration 30 --args "type=b200,num_recv_frames=512"
-cargo run --release -- --multi-channel --channels 38 --passive-channels 9,10,11,12 --burst --quiet --gain 30 --duration 30 --args "type=b200,num_recv_frames=512"
+cargo run --release -- --channels 37 --decoder burst --wireshark
 ```
 
-Advertising channels 37 and 38 together:
+The default destination is `127.0.0.1:55556`. Capture the loopback interface in
+Wireshark and configure UDP port 55556 with **Decode As...** `RFTap`. The `btle`
+display filter then shows decoded BLE link-layer packets.
+
+Useful display filters include:
+
+```text
+btle
+btle.access_address == 0x8e89bed6
+btle && btle.access_address != 0x8e89bed6
+```
+
+The destination can be changed when required:
 
 ```sh
-cargo run --release -- --multi-channel --channels 37,38 --burst --quiet --gain 30 --duration 30 --args "type=b200,num_recv_frames=512"
+cargo run --release -- --channels 37 --decoder burst --wireshark --wireshark-addr 127.0.0.1:55556
 ```
-
-In local B210 tests, low-rate PFB captures around one advertising channel were
-stable. Capturing advertising channels 37 and 38 together required a much wider
-span and produced many overflows on the test laptop, although packets from both
-channels were still decoded.
 
 ## Output
 
-Example packet summaries:
+Decoded packets are printed in a compact form:
 
 ```text
-BLE packet: ch=37 type=ADV_IND len=24 adv_a=57:41:78:10:B4:06 ad=[flags=0x1A, tx_power=12dBm, mfg=Apple(0x004C)/8B]
-BLE packet: ch=37 type=ADV_EXT_IND len=7 ext=[mode=connectable adi=0x3F02 aux_ch=31 aux_offset=1170us aux_phy=2M]
+BLE packet: ch=37 phy=1M pdu=ADV_IND payload_len=24 adv_a=57:41:78:10:B4:06(random) ad=[flags=0x1A, tx_power=12dBm, mfg=Apple(0x004C)/8B]
+BLE packet: ch=38 phy=1M pdu=ADV_EXT_IND payload_len=7 ext=[mode=connectable adi=0x3F02 aux_ch=31 aux_offset=1170us aux_phy=2M]
 ```
 
-At shutdown the example prints final statistics and any tracked connections:
+On shutdown, each decoder prints CRC and packet statistics:
 
 ```text
-BLE burst stats: ch=37 bursts=15757 decoded_bursts=11345 short_bursts=0 fsk_rejects=1881 packets=11345 connect_ind=1 connections=1 aa_candidates=13647 aa_per_packet=1.20 header_rejects=2 pdu_attempts=12833 crc_rejects=1488 crc_reject_rate=11.6%
-BLE connection: ch=37 aa=0xC6176D8D crc_init=0xA9DABD init_a=6D:3B:2F:E7:19:8A(random) adv_a=78:4B:F4:DF:75:14(random) interval=30.00ms latency=0 timeout=5000ms hop=14 sca=5 channels=37 first_ch=37 last_ch=37 seen=1
+BLE summary: ch=37 mode=continuous packets=8738 connect_ind=0 crc_passes=8738 crc_checks=12613 crc_pass_rate=69.3%
+BLE summary: ch=37 mode=burst packets=9397 connect_ind=0 crc_passes=8908 crc_checks=10378 crc_pass_rate=85.8%
 ```
 
-Statistics:
-
-- `packets`: CRC-valid BLE advertising packets.
-- `connect_ind`: CRC-valid `CONNECT_IND` packets.
-- `connections`: unique connection requests stored in the connection table.
-- `aa_candidates`: detected advertising access address candidates.
-- `aa_per_packet`: access-address candidates per valid packet.
-- `header_rejects`: candidates rejected before CRC because no plausible PDU
-  length was found.
-- `pdu_attempts`: valid packets plus non-duplicate CRC rejects.
-- `crc_rejects`: candidate windows that reached CRC and failed.
-- `crc_reject_rate`: `crc_rejects / pdu_attempts`.
-
-The continuous decoder additionally reports:
-
-- `duplicate_crc_rejects`: nearby CRC rejects grouped into the same candidate
-  window.
-- `raw_crc_rejects`: `crc_rejects + duplicate_crc_rejects`.
-
-## Current Measurements
-
-These measurements were taken with a USRP B210, gain 30, packet printing
-disabled, and `num_recv_frames=512`. They are intended as rough development
-guidance, not final benchmark numbers.
-
-Single-channel burst decoder:
-
-| Channel | Packets | CONNECT_IND | CRC Reject Rate |
-| ------- | ------- | ----------- | --------------- |
-| 37 | 5427 | 1 | 11.7% |
-| 38 | 4811 | 1 | 11.5% |
-| 39 | 4000 | 1 | 13.1% |
-
-Low-rate PFB captures:
-
-| Configuration | Packets | CONNECT_IND | CRC Reject Rate |
-| ------------- | ------- | ----------- | --------------- |
-| ch37 + passive data0 | 5776 | 0 | 11.8% |
-| ch38 + passive data10,11 | 5398 | 1 | 13.0% |
-| ch38 + passive data9,10,11,12 | 6152 | 0 | 14.8% |
-
-Two advertising channels through PFB:
-
-| Channel | Packets | CONNECT_IND | CRC Reject Rate |
-| ------- | ------- | ----------- | --------------- |
-| 37 | 1088 | 0 | 14.8% |
-| 38 | 992 | 0 | 12.9% |
-
-The two-advertising-channel run produced many USRP overflows on the test
-machine. This suggests that the current PFB path is functionally correct but
-wide captures are limited by host/USB/PFB throughput in this setup.
-
-Continuous decoder versus burst decoder on channel 37:
-
-| Decoder | Packets | CRC Reject Rate | AA/Packet | Header Rejects | Avg CPU | Max CPU |
-| ------- | ------- | --------------- | --------- | -------------- | ------- | ------- |
-| Continuous | 16154 | 26.5% | 2.26 | 146 | 7.6% | 10.2% |
-| Burst | 12632 | 13.1% | 1.21 | 4 | 3.8% | 5.7% |
-
-The burst decoder used roughly half the CPU and produced fewer rejects in this
-measurement. The continuous decoder is currently kept as a reference/debug path.
-
-## Decoder Notes
-
-The burst decoder:
-
-1. Applies the GMSK receive filter.
-2. Detects IQ bursts with a simple squelch.
-3. Estimates and removes burst-level frequency offset.
-4. Demodulates and slices the burst.
-5. Searches for the BLE advertising access address.
-6. Tries nearby bit offsets and accepts the first CRC-valid advertising PDU.
-7. Records `CONNECT_IND` packets in a connection table.
-
-The continuous decoder:
-
-1. Applies the GMSK receive filter.
-2. Runs a phase discriminator.
-3. Slices discriminator output into bits with DC tracking.
-4. Searches for the BLE advertising access address on each sample phase.
-5. Captures a short PDU bit window after an access address candidate.
-6. Tries nearby bit offsets and accepts the first CRC-valid advertising PDU.
-7. Groups nearby CRC failures into candidate-window rejects.
-
-The `--normalize-levels` flag enables an experimental slicer mode for the
-continuous decoder. It is disabled by default because it did not provide a
-consistent improvement in local measurements.
-
-## Current Scope and Limitations
-
-- BLE 1M advertising reception is the current focus.
-- Burst decoding is the preferred path.
-- `CONNECT_IND` is parsed and stored, but BLE data channel decoding is not
-  implemented yet.
-- Channel hopping is not followed yet.
-- `ADV_EXT_IND` common header fields are parsed, but secondary advertising
-  channels from `AuxPtr` are not followed yet.
-- Multi-channel PFB mode works for selected spans, but wide captures can be
-  limited by host throughput.
-- No PCAP, RFTap, Wireshark, or UDP output yet.
-
-## Next Steps
-
-- Use the connection table to try data-channel access-address detection.
-- CRC-check data-channel packets with the captured `crc_init`.
-- Add channel-map and hop prediction for one tracked connection.
-- Decide whether the continuous decoder should remain as a debug/reference path
-  or be removed.
-- Investigate whether the current FutureSDR PFB configuration is appropriate
-  for wider BLE captures, or whether a lighter/optimized channelizer path is
-  needed.
-- Add PCAP/RFTap output for Wireshark inspection.
+When connection following is enabled, the receiver also reports tracked data
+packets, connection state, timing recovery, and SDR overflow events.

--- a/examples/bluetooth/README.md
+++ b/examples/bluetooth/README.md
@@ -1,0 +1,115 @@
+# Bluetooth Sniffer
+
+## Introduction
+
+This example is a single-channel BLE advertising sniffer. It receives a BLE
+advertising channel with an SDR, demodulates the GFSK signal, detects the BLE
+advertising access address, dewhitens the advertising PDU, validates the BLE
+CRC, and prints a compact packet summary.
+
+The current implementation is intended as a baseline for further work. It is
+not yet a full Bluetooth sniffer and does not follow connections or decode all
+Bluetooth PHY modes.
+
+## Running
+
+The default channel is BLE advertising channel 37. The default gain is 30,
+which provided the best balance between packet count and CRC reject rate in
+local tests.
+
+From the repository root:
+
+```sh
+cargo run --release
+```
+
+Stop the sniffer with Ctrl+C. The flowgraph shuts down gracefully and prints
+final packet statistics.
+
+For a fixed-duration run:
+
+```sh
+cargo run --release -- --duration 30
+```
+
+To tune another advertising channel:
+
+```sh
+cargo run --release -- --channel 38
+cargo run --release -- --channel 39
+```
+
+## Simulation
+
+Simulation mode generates synthetic BLE advertising packets and sends them
+through the GMSK receive chain:
+
+```sh
+cargo run --release -- --simulate --simulate-packets 3
+```
+
+This is useful for checking the parser, whitening, CRC, GMSK filter,
+discriminator, slicer, and packet detector without SDR hardware.
+
+## Output
+
+Example output:
+
+```text
+BLE packet: ch=37 type=ADV_IND len=24 adv_a=57:41:78:10:B4:06 ad=[flags=0x1A, tx_power=12dBm, mfg=Apple(0x004C)/8B]
+BLE packet: ch=37 type=ADV_EXT_IND len=7 ext=[mode=connectable adi=0x3F02 aux_ch=31 aux_offset=1170us aux_phy=2M]
+```
+
+At shutdown the example prints final statistics:
+
+```text
+BLE stats: packets=1695 aa_candidates=3630 aa_per_packet=2.14 header_rejects=5 pdu_attempts=2210 crc_rejects=515 duplicate_crc_rejects=300 raw_crc_rejects=815 crc_reject_rate=23.3%
+```
+
+Statistics:
+
+- `packets`: CRC-valid BLE advertising packets.
+- `aa_candidates`: detected advertising access address candidates.
+- `aa_per_packet`: access-address candidates per valid packet.
+- `header_rejects`: candidates rejected before CRC because no plausible PDU length was found.
+- `pdu_attempts`: valid packets plus non-duplicate CRC rejects.
+- `crc_rejects`: candidate windows that reached CRC and failed.
+- `duplicate_crc_rejects`: nearby CRC rejects grouped into the same candidate window.
+- `raw_crc_rejects`: `crc_rejects + duplicate_crc_rejects`.
+- `crc_reject_rate`: `crc_rejects / pdu_attempts`.
+
+## Decoder Notes
+
+The receiver currently uses a continuous detector:
+
+1. Filter complex baseband samples with a GMSK receive filter.
+2. Run a phase discriminator.
+3. Slice discriminator output into bits with DC tracking.
+4. Search for the BLE advertising access address on each sample phase.
+5. After an access address candidate, capture a short PDU bit window.
+6. Try nearby bit offsets and accept the first CRC-valid PDU.
+7. Group nearby CRC failures into candidate-window rejects.
+
+The `--normalize-levels` flag enables an experimental slicer mode that tracks
+positive and negative discriminator levels. It is disabled by default because it
+did not provide a consistent improvement in local measurements.
+
+## Current Scope and Limitations
+
+- Single tuned BLE channel only.
+- Default channel is advertising channel 37.
+- Legacy advertising PDUs are parsed and summarized.
+- `ADV_EXT_IND` common extended header fields are summarized when present.
+- Secondary advertising channels from `AuxPtr` are not followed yet.
+- BLE data channels and connection following are not implemented.
+- No PCAP, RFTap, Wireshark, or UDP output yet.
+- No PFB channelizer yet.
+
+## Next Steps
+
+- Add README-level examples and measurement guidance for gain selection.
+- Add PCAP/RFTap output for Wireshark inspection.
+- Improve burst-based demodulation and timing/CFO handling.
+- Add channel hopping or a multi-channel PFB receiver.
+- Use `ADV_EXT_IND` `AuxPtr` information to follow secondary advertising once
+  multi-channel reception is available.

--- a/examples/bluetooth/src/ble_ad.rs
+++ b/examples/bluetooth/src/ble_ad.rs
@@ -1,0 +1,153 @@
+use std::error::Error;
+use std::fmt;
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct BleAdStructure {
+    pub ad_type: u8,
+    pub data: Vec<u8>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum BleAdParseError {
+    Truncated {
+        offset: usize,
+        len: usize,
+        actual: usize,
+    },
+}
+
+impl fmt::Display for BleAdParseError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Truncated {
+                offset,
+                len,
+                actual,
+            } => write!(
+                f,
+                "truncated AD structure at offset {offset}: need {len} bytes, got {actual}"
+            ),
+        }
+    }
+}
+
+impl Error for BleAdParseError {}
+
+pub fn parse_ad_structures(data: &[u8]) -> Result<Vec<BleAdStructure>, BleAdParseError> {
+    let mut out = Vec::new();
+    let mut offset = 0usize;
+
+    while offset < data.len() {
+        let len = data[offset] as usize;
+        offset += 1;
+
+        if len == 0 {
+            break;
+        }
+
+        if offset + len > data.len() {
+            return Err(BleAdParseError::Truncated {
+                offset: offset - 1,
+                len,
+                actual: data.len() - offset,
+            });
+        }
+
+        out.push(BleAdStructure {
+            ad_type: data[offset],
+            data: data[offset + 1..offset + len].to_vec(),
+        });
+        offset += len;
+    }
+
+    Ok(out)
+}
+
+pub fn format_ad_structures(ad_structures: &[BleAdStructure]) -> String {
+    ad_structures
+        .iter()
+        .map(format_ad_structure)
+        .collect::<Vec<_>>()
+        .join(", ")
+}
+
+fn format_ad_structure(ad: &BleAdStructure) -> String {
+    match ad.ad_type {
+        0x01 if !ad.data.is_empty() => format!("flags=0x{:02X}", ad.data[0]),
+        0x02 | 0x03 => format_uuid16_list("uuid16", &ad.data),
+        0x08 => format!("short_name=\"{}\"", String::from_utf8_lossy(&ad.data)),
+        0x09 => format!("name=\"{}\"", String::from_utf8_lossy(&ad.data)),
+        0x0a if !ad.data.is_empty() => format!("tx_power={}dBm", ad.data[0] as i8),
+        0x16 if ad.data.len() >= 2 => {
+            let uuid = u16::from_le_bytes([ad.data[0], ad.data[1]]);
+            format!(
+                "service_data=0x{uuid:04X}/{}B",
+                ad.data.len().saturating_sub(2)
+            )
+        }
+        0xff if ad.data.len() >= 2 => {
+            let company = u16::from_le_bytes([ad.data[0], ad.data[1]]);
+            format!(
+                "mfg={}({company:#06X})/{}B",
+                company_name(company),
+                ad.data.len().saturating_sub(2)
+            )
+        }
+        _ => format!("type=0x{:02X}/{}B", ad.ad_type, ad.data.len()),
+    }
+}
+
+fn format_uuid16_list(label: &str, data: &[u8]) -> String {
+    let values = data
+        .chunks_exact(2)
+        .map(|bytes| u16::from_le_bytes([bytes[0], bytes[1]]))
+        .map(|uuid| format!("0x{uuid:04X}"))
+        .collect::<Vec<_>>()
+        .join("|");
+    format!("{label}=[{values}]")
+}
+
+fn company_name(company: u16) -> &'static str {
+    match company {
+        0x0006 => "Microsoft",
+        0x004c => "Apple",
+        0x0075 => "Samsung",
+        0x00e0 => "Google",
+        _ => "Unknown",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_ad_structures() {
+        let data = [
+            0x02, 0x01, 0x06, 0x05, 0x09, b'F', b'S', b'D', b'R', 0x04, 0xff, 0x4c, 0x00, 0x01,
+        ];
+        let ad = parse_ad_structures(&data).unwrap();
+
+        assert_eq!(
+            ad,
+            vec![
+                BleAdStructure {
+                    ad_type: 0x01,
+                    data: vec![0x06],
+                },
+                BleAdStructure {
+                    ad_type: 0x09,
+                    data: b"FSDR".to_vec(),
+                },
+                BleAdStructure {
+                    ad_type: 0xff,
+                    data: vec![0x4c, 0x00, 0x01],
+                },
+            ]
+        );
+        assert_eq!(
+            format_ad_structures(&ad),
+            "flags=0x06, name=\"FSDR\", mfg=Apple(0x004C)/1B"
+        );
+    }
+}

--- a/examples/bluetooth/src/ble_burst_catcher.rs
+++ b/examples/bluetooth/src/ble_burst_catcher.rs
@@ -1,0 +1,372 @@
+use std::collections::VecDeque;
+
+use futuresdr::num_complex::Complex32;
+
+const AGC_ALPHA: f32 = 0.25;
+const ADAPTIVE_SQUELCH_WARMUP_SAMPLES: usize = 512;
+const NOISE_FLOOR_WARMUP_ALPHA: f32 = 0.01;
+const NOISE_FLOOR_RISE_ALPHA: f32 = 0.00005;
+const NOISE_FLOOR_FALL_ALPHA: f32 = 0.01;
+const SQUELCH_HYSTERESIS_DB: f32 = 3.0;
+const SQUELCH_TIMEOUT_SAMPLES: usize = 100;
+const BURST_START_CAPACITY: usize = 2048;
+const MAX_BURST_SAMPLES: usize = 8192;
+
+pub(crate) const PRE_TRIGGER_SYMBOLS: usize = 4;
+
+#[derive(Clone, Copy, Debug)]
+pub enum SquelchConfig {
+    Adaptive { margin_db: f32 },
+    Fixed { threshold_db: f32 },
+}
+
+impl SquelchConfig {
+    pub fn adaptive(margin_db: f32) -> Self {
+        Self::Adaptive { margin_db }
+    }
+
+    pub fn fixed(threshold_db: f32) -> Self {
+        Self::Fixed { threshold_db }
+    }
+}
+
+pub(crate) struct CapturedBurst {
+    pub(crate) samples: Vec<Complex32>,
+    pub(crate) forced_close: bool,
+    pub(crate) start_sample_index: u64,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum SquelchState {
+    SignalLo,
+    Rise,
+    SignalHi,
+    Timeout,
+}
+
+pub(crate) struct BurstCatcher {
+    gain: f32,
+    signal_level: f32,
+    squelch: Squelch,
+    state: SquelchState,
+    timer: usize,
+    burst_buf: Vec<Complex32>,
+    pre_trigger: VecDeque<Complex32>,
+    pre_trigger_samples: usize,
+    capturing: bool,
+    next_sample_index: u64,
+    burst_start_sample_index: u64,
+}
+
+impl BurstCatcher {
+    pub(crate) fn new(config: SquelchConfig, pre_trigger_samples: usize) -> Self {
+        Self {
+            gain: 1000.0,
+            signal_level: 1e-3,
+            squelch: Squelch::new(config),
+            state: SquelchState::SignalLo,
+            timer: 0,
+            burst_buf: Vec::new(),
+            pre_trigger: VecDeque::with_capacity(pre_trigger_samples),
+            pre_trigger_samples,
+            capturing: false,
+            next_sample_index: 0,
+            burst_start_sample_index: 0,
+        }
+    }
+
+    pub(crate) fn execute(&mut self, sample: Complex32) -> Option<CapturedBurst> {
+        let sample_index = self.next_sample_index;
+        self.next_sample_index += 1;
+        let state = self.update_squelch(sample);
+
+        match state {
+            SquelchState::Rise => {
+                self.burst_buf = Vec::with_capacity(BURST_START_CAPACITY);
+                self.burst_buf.extend(self.pre_trigger.iter().copied());
+                self.burst_buf.push(sample);
+                self.burst_start_sample_index =
+                    sample_index.saturating_sub(self.pre_trigger.len() as u64);
+                self.capturing = true;
+                None
+            }
+            SquelchState::SignalHi => {
+                if self.capturing && self.burst_buf.len() < MAX_BURST_SAMPLES {
+                    self.burst_buf.push(sample);
+                }
+                if self.capturing && self.burst_buf.len() >= MAX_BURST_SAMPLES {
+                    self.finish(true)
+                } else {
+                    None
+                }
+            }
+            SquelchState::Timeout => {
+                let burst = self.finish(false);
+                self.remember_pre_trigger(sample);
+                burst
+            }
+            SquelchState::SignalLo => {
+                if self.capturing {
+                    self.capturing = false;
+                    self.burst_buf.clear();
+                }
+                self.remember_pre_trigger(sample);
+                None
+            }
+        }
+    }
+
+    pub(crate) fn finish(&mut self, forced_close: bool) -> Option<CapturedBurst> {
+        if self.capturing && !self.burst_buf.is_empty() {
+            self.capturing = false;
+            Some(CapturedBurst {
+                samples: std::mem::take(&mut self.burst_buf),
+                forced_close,
+                start_sample_index: self.burst_start_sample_index,
+            })
+        } else {
+            self.capturing = false;
+            None
+        }
+    }
+
+    pub(crate) fn summary(&self) -> String {
+        self.squelch.summary()
+    }
+
+    fn remember_pre_trigger(&mut self, sample: Complex32) {
+        if self.pre_trigger_samples == 0 {
+            return;
+        }
+        if self.pre_trigger.len() == self.pre_trigger_samples {
+            self.pre_trigger.pop_front();
+        }
+        self.pre_trigger.push_back(sample);
+    }
+
+    fn update_squelch(&mut self, input: Complex32) -> SquelchState {
+        let output = input * self.gain;
+        let level = output.norm();
+        self.signal_level = AGC_ALPHA * level + (1.0 - AGC_ALPHA) * self.signal_level;
+
+        if self.signal_level > 1e-6 {
+            self.gain *= (-0.5 * AGC_ALPHA * self.signal_level.ln()).exp();
+            self.gain = self.gain.clamp(1e-6, 1e6);
+        }
+
+        let rssi_db = -20.0 * self.gain.log10();
+        self.squelch.initialize(rssi_db);
+        if self.squelch.is_warming_up() {
+            self.squelch.observe_noise(rssi_db);
+            self.state = SquelchState::SignalLo;
+            return self.state;
+        }
+        let start_threshold_db = self.squelch.start_threshold_db();
+        let stop_threshold_db = self.squelch.stop_threshold_db();
+        let above_start = rssi_db > start_threshold_db;
+        let above_stop = rssi_db > stop_threshold_db;
+
+        self.state = match self.state {
+            SquelchState::SignalLo => {
+                if above_start {
+                    SquelchState::Rise
+                } else {
+                    SquelchState::SignalLo
+                }
+            }
+            SquelchState::Rise => {
+                if above_start {
+                    self.timer = 0;
+                    SquelchState::SignalHi
+                } else {
+                    self.timer = 0;
+                    SquelchState::SignalLo
+                }
+            }
+            SquelchState::SignalHi => {
+                if above_stop {
+                    self.timer = 0;
+                    SquelchState::SignalHi
+                } else {
+                    self.timer += 1;
+                    if self.timer >= SQUELCH_TIMEOUT_SAMPLES {
+                        SquelchState::Timeout
+                    } else {
+                        SquelchState::SignalHi
+                    }
+                }
+            }
+            SquelchState::Timeout => {
+                if above_start {
+                    SquelchState::Rise
+                } else {
+                    SquelchState::SignalLo
+                }
+            }
+        };
+
+        if self.state == SquelchState::SignalLo && !above_start {
+            self.squelch.observe_noise(rssi_db);
+        }
+
+        self.state
+    }
+}
+
+enum Squelch {
+    Adaptive {
+        noise_floor_db: Option<f32>,
+        margin_db: f32,
+        warmup_samples_remaining: usize,
+    },
+    Fixed {
+        threshold_db: f32,
+    },
+}
+
+impl Squelch {
+    fn new(config: SquelchConfig) -> Self {
+        match config {
+            SquelchConfig::Adaptive { margin_db } => Self::Adaptive {
+                noise_floor_db: None,
+                margin_db,
+                warmup_samples_remaining: ADAPTIVE_SQUELCH_WARMUP_SAMPLES,
+            },
+            SquelchConfig::Fixed { threshold_db } => Self::Fixed { threshold_db },
+        }
+    }
+
+    fn is_warming_up(&self) -> bool {
+        matches!(
+            self,
+            Self::Adaptive {
+                warmup_samples_remaining: 1..,
+                ..
+            }
+        )
+    }
+
+    fn initialize(&mut self, rssi_db: f32) {
+        if let Self::Adaptive { noise_floor_db, .. } = self
+            && noise_floor_db.is_none()
+        {
+            *noise_floor_db = Some(rssi_db);
+        }
+    }
+
+    fn start_threshold_db(&self) -> f32 {
+        match self {
+            Self::Adaptive {
+                noise_floor_db,
+                margin_db,
+                ..
+            } => noise_floor_db.unwrap_or(f32::NEG_INFINITY) + margin_db,
+            Self::Fixed { threshold_db } => *threshold_db,
+        }
+    }
+
+    fn stop_threshold_db(&self) -> f32 {
+        self.start_threshold_db() - SQUELCH_HYSTERESIS_DB
+    }
+
+    fn observe_noise(&mut self, rssi_db: f32) {
+        let Self::Adaptive {
+            noise_floor_db,
+            warmup_samples_remaining,
+            ..
+        } = self
+        else {
+            return;
+        };
+
+        let Some(noise_floor) = noise_floor_db.as_mut() else {
+            *noise_floor_db = Some(rssi_db);
+            return;
+        };
+        let alpha = if *warmup_samples_remaining > 0 {
+            *warmup_samples_remaining -= 1;
+            NOISE_FLOOR_WARMUP_ALPHA
+        } else if rssi_db > *noise_floor {
+            NOISE_FLOOR_RISE_ALPHA
+        } else {
+            NOISE_FLOOR_FALL_ALPHA
+        };
+        *noise_floor += alpha * (rssi_db - *noise_floor);
+    }
+
+    fn summary(&self) -> String {
+        match self {
+            Self::Adaptive {
+                noise_floor_db,
+                margin_db,
+                warmup_samples_remaining,
+            } => {
+                let noise_floor_db = noise_floor_db.unwrap_or(f32::NAN);
+                format!(
+                    "mode=adaptive noise_floor_db={noise_floor_db:.1} margin_db={margin_db:.1} start_db={:.1} stop_db={:.1} warmup_remaining={warmup_samples_remaining}",
+                    self.start_threshold_db(),
+                    self.stop_threshold_db()
+                )
+            }
+            Self::Fixed { threshold_db } => format!(
+                "mode=fixed start_db={threshold_db:.1} stop_db={:.1}",
+                self.stop_threshold_db()
+            ),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn adaptive_squelch_separates_a_burst_from_noise() {
+        let mut catcher = BurstCatcher::new(SquelchConfig::adaptive(8.0), 8);
+        let noise = Complex32::new(0.001, 0.0);
+        let signal = Complex32::new(0.1, 0.0);
+
+        for _ in 0..4_000 {
+            assert!(catcher.execute(noise).is_none());
+        }
+        for _ in 0..400 {
+            assert!(catcher.execute(signal).is_none());
+        }
+
+        let mut burst = None;
+        for _ in 0..1_000 {
+            if let Some(samples) = catcher.execute(noise) {
+                burst = Some(samples);
+                break;
+            }
+        }
+
+        let burst = burst.expect("signal burst should be returned");
+        assert!(burst.samples.len() >= 400);
+        assert!(burst.start_sample_index >= 3_992);
+        assert!(burst.start_sample_index < 4_400);
+    }
+
+    #[test]
+    fn burst_catcher_forces_a_maximum_length_close() {
+        let mut catcher = BurstCatcher::new(SquelchConfig::adaptive(8.0), 8);
+        let noise = Complex32::new(0.001, 0.0);
+        let signal = Complex32::new(0.1, 0.0);
+
+        for _ in 0..4_000 {
+            assert!(catcher.execute(noise).is_none());
+        }
+
+        let mut burst = None;
+        for _ in 0..MAX_BURST_SAMPLES + 100 {
+            if let Some(captured) = catcher.execute(signal) {
+                burst = Some(captured);
+                break;
+            }
+        }
+
+        let burst = burst.expect("maximum-length burst should be returned");
+        assert!(burst.forced_close);
+        assert_eq!(burst.samples.len(), MAX_BURST_SAMPLES);
+    }
+}

--- a/examples/bluetooth/src/ble_burst_decoder.rs
+++ b/examples/bluetooth/src/ble_burst_decoder.rs
@@ -1,0 +1,665 @@
+use std::error::Error;
+use std::fmt;
+
+use futuredsp::Filter;
+use futuredsp::FirFilter;
+use futuresdr::num_complex::Complex32;
+
+use crate::ble_burst_catcher::CapturedBurst;
+use crate::ble_burst_catcher::PRE_TRIGGER_SYMBOLS;
+use crate::ble_connection::ConnectionDecodeContext;
+use crate::ble_data::BLE_MAX_DATA_PAYLOAD_LEN;
+use crate::ble_data::BleDataPacket;
+use crate::ble_data::parse_data_pdu;
+use crate::ble_detector::DetectorEvent;
+use crate::ble_detector::DetectorStats;
+use crate::ble_detector::PacketDetector;
+use crate::ble_protocol::BleAdvPduType;
+use crate::ble_protocol::BlePacket;
+use crate::ble_protocol::BlePhy;
+use crate::diagnostics as debug_output;
+
+const MIN_BURST_SAMPLES: usize = 96;
+const PHASE_DUPLICATE_WINDOW_SYMBOLS: usize = 4;
+const CFO_MEDIAN_SYMBOLS: usize = 64;
+const MAX_FREQ_OFFSET: f32 = 0.85;
+
+type GmskFir = FirFilter<Complex32, Complex32, Vec<f32>>;
+
+pub(crate) struct BurstDecoder {
+    phy: BlePhy,
+    samples_per_symbol: usize,
+    channel_index: u8,
+    filter: GmskFir,
+}
+
+impl BurstDecoder {
+    pub(crate) fn new(
+        phy: BlePhy,
+        samples_per_symbol: usize,
+        channel_index: u8,
+        filter_taps: Vec<f32>,
+    ) -> Result<Self, UnsupportedPhy> {
+        if phy != BlePhy::Le1M {
+            return Err(UnsupportedPhy { phy });
+        }
+
+        Ok(Self {
+            phy,
+            samples_per_symbol,
+            channel_index,
+            filter: FirFilter::new(filter_taps),
+        })
+    }
+
+    pub(crate) fn decode(
+        &self,
+        burst: &CapturedBurst,
+        connections: &[ConnectionDecodeContext],
+        decode_advertising: bool,
+        diagnostics: bool,
+    ) -> BurstDecodeOutcome {
+        if burst.samples.len() < MIN_BURST_SAMPLES {
+            return BurstDecodeOutcome::Short;
+        }
+
+        let Some(filtered) = filter_burst(&burst.samples, &self.filter) else {
+            return BurstDecodeOutcome::Short;
+        };
+        let cfo_start = PRE_TRIGGER_SYMBOLS * self.samples_per_symbol
+            + self.filter.length().saturating_sub(1) / 2;
+        let Some(demod) = demodulate_burst(&filtered, self.samples_per_symbol, cfo_start) else {
+            return BurstDecodeOutcome::FskRejected;
+        };
+
+        let data = decode_data_candidates(
+            &demod,
+            self.samples_per_symbol,
+            self.channel_index,
+            connections,
+        );
+
+        if !decode_advertising {
+            return BurstDecodeOutcome::Decoded(BurstDecodeResult {
+                candidates: Vec::new(),
+                detector_stats: DetectorStats::default(),
+                phase_valid_packets: vec![0; self.samples_per_symbol],
+                phase_only_packets: vec![0; self.samples_per_symbol],
+                phase_duplicates: 0,
+                data,
+            });
+        }
+
+        let mut detector_stats = DetectorStats::default();
+        let mut candidates = Vec::new();
+
+        for phase in 0..self.samples_per_symbol {
+            let mut detector = PacketDetector::with_packet_output(phase, self.channel_index, false);
+
+            for (symbol_index, value) in demod
+                .iter()
+                .skip(phase)
+                .step_by(self.samples_per_symbol)
+                .enumerate()
+            {
+                match detector.process_symbol(u8::from(*value > 0.0)) {
+                    DetectorEvent::None | DetectorEvent::HeaderRejected => {}
+                    DetectorEvent::ValidPacket { packet } => {
+                        candidates.push(BurstPacketCandidate {
+                            sample_index: phase + symbol_index * self.samples_per_symbol,
+                            phase,
+                            packet,
+                        });
+                    }
+                    DetectorEvent::CrcRejected { reason } => {
+                        detector.add_crc_reject();
+                        if diagnostics && debug_output::enabled() {
+                            println!("BLE burst candidate rejected: phase={phase} {reason}");
+                        }
+                    }
+                }
+            }
+
+            let mut phase_stats = detector.stats();
+            phase_stats.packets = 0;
+            phase_stats.connect_ind_packets = 0;
+            detector_stats.merge(phase_stats);
+        }
+
+        let candidate_count = candidates.len();
+        let (phase_valid_packets, phase_only_packets) =
+            phase_candidate_counts(&candidates, self.samples_per_symbol);
+        let candidates = deduplicate_phase_candidates(candidates, self.samples_per_symbol);
+        let phase_duplicates = (candidate_count - candidates.len()) as u64;
+
+        detector_stats.packets = candidates.len() as u64;
+        detector_stats.connect_ind_packets = candidates
+            .iter()
+            .filter(|candidate| candidate.packet.pdu_type == BleAdvPduType::ConnectInd)
+            .count() as u64;
+
+        debug_assert!(
+            candidates
+                .iter()
+                .all(|candidate| candidate.packet.phy == self.phy)
+        );
+
+        BurstDecodeOutcome::Decoded(BurstDecodeResult {
+            candidates,
+            detector_stats,
+            phase_valid_packets,
+            phase_only_packets,
+            phase_duplicates,
+            data,
+        })
+    }
+
+    pub(crate) fn samples_per_symbol(&self) -> usize {
+        self.samples_per_symbol
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct UnsupportedPhy {
+    pub phy: BlePhy,
+}
+
+impl fmt::Display for UnsupportedPhy {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{0} burst decoding is not implemented", self.phy)
+    }
+}
+
+impl Error for UnsupportedPhy {}
+
+pub(crate) enum BurstDecodeOutcome {
+    Short,
+    FskRejected,
+    Decoded(BurstDecodeResult),
+}
+
+pub(crate) struct BurstDecodeResult {
+    pub(crate) candidates: Vec<BurstPacketCandidate>,
+    pub(crate) detector_stats: DetectorStats,
+    pub(crate) phase_valid_packets: Vec<u64>,
+    pub(crate) phase_only_packets: Vec<u64>,
+    pub(crate) phase_duplicates: u64,
+    pub(crate) data: DataDecodeResult,
+}
+
+#[derive(Default)]
+pub(crate) struct DataDecodeResult {
+    pub(crate) candidates: Vec<BurstDataPacketCandidate>,
+    pub(crate) aa_candidates: u64,
+    pub(crate) crc_rejects: u64,
+    pub(crate) phase_duplicates: u64,
+}
+
+pub(crate) struct BurstPacketCandidate {
+    pub(crate) sample_index: usize,
+    pub(crate) phase: usize,
+    pub(crate) packet: BlePacket,
+}
+
+pub(crate) struct BurstDataPacketCandidate {
+    pub(crate) sample_index: usize,
+    pub(crate) phase: usize,
+    pub(crate) packet: BleDataPacket,
+}
+
+fn deduplicate_phase_candidates(
+    mut candidates: Vec<BurstPacketCandidate>,
+    samples_per_symbol: usize,
+) -> Vec<BurstPacketCandidate> {
+    candidates.sort_unstable_by_key(|candidate| candidate.sample_index);
+    let duplicate_window = PHASE_DUPLICATE_WINDOW_SYMBOLS * samples_per_symbol;
+    let mut unique: Vec<BurstPacketCandidate> = Vec::with_capacity(candidates.len());
+
+    for candidate in candidates {
+        let duplicate = unique
+            .iter()
+            .rev()
+            .take_while(|previous| {
+                candidate.sample_index.saturating_sub(previous.sample_index) <= duplicate_window
+            })
+            .any(|previous| candidate.packet == previous.packet);
+        if !duplicate {
+            unique.push(candidate);
+        }
+    }
+
+    unique
+}
+
+fn phase_candidate_counts(
+    candidates: &[BurstPacketCandidate],
+    samples_per_symbol: usize,
+) -> (Vec<u64>, Vec<u64>) {
+    let duplicate_window = PHASE_DUPLICATE_WINDOW_SYMBOLS * samples_per_symbol;
+    let mut phase_valid_packets = vec![0; samples_per_symbol];
+    let mut phase_only_packets = vec![0; samples_per_symbol];
+
+    for (index, candidate) in candidates.iter().enumerate() {
+        phase_valid_packets[candidate.phase] += 1;
+        let shared_with_another_phase =
+            candidates.iter().enumerate().any(|(other_index, other)| {
+                index != other_index
+                    && candidate.phase != other.phase
+                    && candidate.sample_index.abs_diff(other.sample_index) <= duplicate_window
+                    && candidate.packet == other.packet
+            });
+        if !shared_with_another_phase {
+            phase_only_packets[candidate.phase] += 1;
+        }
+    }
+
+    (phase_valid_packets, phase_only_packets)
+}
+
+fn decode_data_candidates(
+    demod: &[f32],
+    samples_per_symbol: usize,
+    channel_index: u8,
+    connections: &[ConnectionDecodeContext],
+) -> DataDecodeResult {
+    if channel_index >= 37 || connections.is_empty() {
+        return DataDecodeResult::default();
+    }
+
+    let mut result = DataDecodeResult::default();
+    let mut candidates = Vec::new();
+
+    for phase in 0..samples_per_symbol {
+        let bits: Vec<_> = demod
+            .iter()
+            .skip(phase)
+            .step_by(samples_per_symbol)
+            .map(|value| u8::from(*value > 0.0))
+            .collect();
+
+        for connection in connections
+            .iter()
+            .filter(|connection| connection.phy == BlePhy::Le1M)
+        {
+            scan_data_phase(
+                &bits,
+                phase,
+                samples_per_symbol,
+                channel_index,
+                *connection,
+                &mut result,
+                &mut candidates,
+            );
+        }
+    }
+
+    let candidate_count = candidates.len();
+    result.candidates = deduplicate_data_candidates(candidates, samples_per_symbol);
+    result.phase_duplicates = (candidate_count - result.candidates.len()) as u64;
+    result
+}
+
+fn scan_data_phase(
+    bits: &[u8],
+    phase: usize,
+    samples_per_symbol: usize,
+    channel_index: u8,
+    connection: ConnectionDecodeContext,
+    result: &mut DataDecodeResult,
+    candidates: &mut Vec<BurstDataPacketCandidate>,
+) {
+    let mut shift_reg = 0u32;
+    let mut bit_index = 0usize;
+
+    while bit_index < bits.len() {
+        shift_reg = (shift_reg >> 1) | ((bits[bit_index] as u32) << 31);
+        let inverted = if shift_reg == connection.access_address {
+            Some(false)
+        } else if shift_reg == !connection.access_address {
+            Some(true)
+        } else {
+            None
+        };
+
+        let Some(inverted) = inverted else {
+            bit_index += 1;
+            continue;
+        };
+
+        result.aa_candidates += 1;
+        let pdu_start = bit_index + 1;
+        match decode_data_candidate(&bits[pdu_start..], inverted, channel_index, connection) {
+            DataCandidateOutcome::Incomplete => break,
+            DataCandidateOutcome::Rejected => {
+                result.crc_rejects += 1;
+                bit_index += 1;
+            }
+            DataCandidateOutcome::Valid {
+                packet,
+                consumed_bits,
+            } => {
+                candidates.push(BurstDataPacketCandidate {
+                    sample_index: phase + bit_index * samples_per_symbol,
+                    phase,
+                    packet,
+                });
+                bit_index = pdu_start + consumed_bits;
+                shift_reg = 0;
+            }
+        }
+    }
+}
+
+enum DataCandidateOutcome {
+    Incomplete,
+    Rejected,
+    Valid {
+        packet: BleDataPacket,
+        consumed_bits: usize,
+    },
+}
+
+fn decode_data_candidate(
+    bits: &[u8],
+    inverted: bool,
+    channel_index: u8,
+    connection: ConnectionDecodeContext,
+) -> DataCandidateOutcome {
+    if bits.len() < 16 {
+        return DataCandidateOutcome::Incomplete;
+    }
+
+    let header = bits_to_bytes(&bits[..16], inverted);
+    let Ok(header) = crate::ble_phy::apply_whitening(channel_index, &header) else {
+        return DataCandidateOutcome::Rejected;
+    };
+    let payload_len = header[1] as usize;
+    if payload_len > BLE_MAX_DATA_PAYLOAD_LEN {
+        return DataCandidateOutcome::Rejected;
+    }
+
+    let needed_bits = (2 + payload_len + 3) * 8;
+    if bits.len() < needed_bits {
+        return DataCandidateOutcome::Incomplete;
+    }
+
+    let whitened_pdu_crc = bits_to_bytes(&bits[..needed_bits], inverted);
+    match parse_data_pdu(
+        channel_index,
+        connection.phy,
+        connection.access_address,
+        connection.crc_init,
+        &whitened_pdu_crc,
+    ) {
+        Ok(packet) => DataCandidateOutcome::Valid {
+            packet,
+            consumed_bits: needed_bits,
+        },
+        Err(_) => DataCandidateOutcome::Rejected,
+    }
+}
+
+fn bits_to_bytes(bits: &[u8], inverted: bool) -> Vec<u8> {
+    bits.chunks_exact(8)
+        .map(|chunk| {
+            chunk
+                .iter()
+                .enumerate()
+                .fold(0u8, |byte, (bit_index, bit)| {
+                    byte | (((*bit ^ u8::from(inverted)) & 1) << bit_index)
+                })
+        })
+        .collect()
+}
+
+fn deduplicate_data_candidates(
+    mut candidates: Vec<BurstDataPacketCandidate>,
+    samples_per_symbol: usize,
+) -> Vec<BurstDataPacketCandidate> {
+    candidates.sort_unstable_by_key(|candidate| candidate.sample_index);
+    let duplicate_window = PHASE_DUPLICATE_WINDOW_SYMBOLS * samples_per_symbol;
+    let mut unique: Vec<BurstDataPacketCandidate> = Vec::with_capacity(candidates.len());
+
+    for candidate in candidates {
+        let duplicate = unique
+            .iter()
+            .rev()
+            .take_while(|previous| {
+                candidate.sample_index.saturating_sub(previous.sample_index) <= duplicate_window
+            })
+            .any(|previous| candidate.packet == previous.packet);
+        if !duplicate {
+            unique.push(candidate);
+        }
+    }
+
+    unique
+}
+
+fn filter_burst(samples: &[Complex32], filter: &GmskFir) -> Option<Vec<Complex32>> {
+    let output_len = samples.len().checked_add(1)?.checked_sub(filter.length())?;
+    if output_len == 0 {
+        return None;
+    }
+
+    let mut output = vec![Complex32::new(0.0, 0.0); output_len];
+    let (_, produced, _) = filter.filter(samples, &mut output);
+    output.truncate(produced);
+    Some(output)
+}
+
+fn demodulate_burst(
+    samples: &[Complex32],
+    samples_per_symbol: usize,
+    cfo_start: usize,
+) -> Option<Vec<f32>> {
+    if samples.len() < cfo_start + samples_per_symbol * CFO_MEDIAN_SYMBOLS {
+        return None;
+    }
+
+    let mut demod = Vec::with_capacity(samples.len().saturating_sub(1));
+    let mut prev = samples[0];
+    for &sample in &samples[1..] {
+        demod.push((sample * prev.conj()).arg() * std::f32::consts::FRAC_1_PI);
+        prev = sample;
+    }
+
+    let (cfo, deviation) = estimate_cfo_and_deviation(&demod, samples_per_symbol, cfo_start)?;
+    for value in &mut demod {
+        *value = (*value - cfo) / deviation;
+    }
+
+    Some(demod)
+}
+
+fn estimate_cfo_and_deviation(
+    demod: &[f32],
+    samples_per_symbol: usize,
+    start: usize,
+) -> Option<(f32, f32)> {
+    let end = start + samples_per_symbol * CFO_MEDIAN_SYMBOLS;
+    if end > demod.len() {
+        return None;
+    }
+
+    let mut pos = Vec::with_capacity(samples_per_symbol * CFO_MEDIAN_SYMBOLS);
+    let mut neg = Vec::with_capacity(samples_per_symbol * CFO_MEDIAN_SYMBOLS);
+
+    for &value in &demod[start..end] {
+        if value.abs() > MAX_FREQ_OFFSET {
+            return None;
+        }
+        if value > 0.0 {
+            pos.push(value);
+        } else if value < 0.0 {
+            neg.push(value);
+        }
+    }
+
+    if pos.len() < CFO_MEDIAN_SYMBOLS / 4 || neg.len() < CFO_MEDIAN_SYMBOLS / 4 {
+        return None;
+    }
+
+    pos.sort_unstable_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
+    neg.sort_unstable_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
+
+    let high = pos[pos.len() * 3 / 4];
+    let low = neg[neg.len() / 4];
+    let cfo = (high + low) * 0.5;
+    let deviation = (high - cfo).abs();
+
+    if deviation < 1e-6 {
+        None
+    } else {
+        Some((cfo, deviation))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::ble_sim::generate_ble_packet_samples;
+    use crate::gmsk_demod::gmsk_rx_taps;
+
+    #[test]
+    fn demodulates_simulated_burst() {
+        let samples = generate_ble_packet_samples(2, 1, 37);
+        let burst: Vec<_> = samples
+            .into_iter()
+            .filter(|sample| sample.norm() > 0.0)
+            .collect();
+        let demod = demodulate_burst(&burst, 2, PRE_TRIGGER_SYMBOLS * 2).unwrap();
+        let mut detector = PacketDetector::new(0, 37);
+
+        let mut decoded = false;
+        for value in demod.iter().step_by(2) {
+            if matches!(
+                detector.process_symbol(u8::from(*value > 0.0)),
+                DetectorEvent::ValidPacket { .. }
+            ) {
+                decoded = true;
+                break;
+            }
+        }
+
+        assert!(decoded);
+    }
+
+    #[test]
+    fn decodes_multiple_packets_from_one_burst() {
+        let packet: Vec<_> = generate_ble_packet_samples(2, 1, 37)
+            .into_iter()
+            .filter(|sample| sample.norm() > 0.0)
+            .collect();
+        let taps = gmsk_rx_taps(2).unwrap();
+        let filter_history = taps.len().saturating_sub(1);
+        let mut samples = vec![Complex32::new(0.0, 0.0); filter_history + PRE_TRIGGER_SYMBOLS * 2];
+        samples.extend(packet.iter().copied());
+        samples.extend(vec![Complex32::new(0.0, 0.0); 50]);
+        samples.extend(packet);
+        samples.extend(vec![Complex32::new(0.0, 0.0); 100]);
+
+        let decoder = BurstDecoder::new(BlePhy::Le1M, 2, 37, taps).unwrap();
+        let result = match decoder.decode(
+            &CapturedBurst {
+                samples,
+                forced_close: false,
+                start_sample_index: 0,
+            },
+            &[],
+            true,
+            false,
+        ) {
+            BurstDecodeOutcome::Decoded(result) => result,
+            _ => panic!("burst should decode"),
+        };
+
+        assert_eq!(result.candidates.len(), 2);
+        assert_eq!(result.detector_stats.packets, 2);
+        assert_eq!(result.phase_valid_packets, [2, 2]);
+        assert_eq!(result.phase_only_packets, [0, 0]);
+        assert_eq!(result.phase_duplicates, 2);
+    }
+
+    #[test]
+    fn decodes_connection_specific_data_packet_across_phases() {
+        use crate::ble_data::build_data_pdu_crc;
+
+        let connection = ConnectionDecodeContext {
+            access_address: 0x1234_5678,
+            crc_init: 0x00ab_cdef,
+            phy: BlePhy::Le1M,
+        };
+        let payload = [0x03, 0x00, 0x04, 0x00];
+        let whitened = build_data_pdu_crc(0, connection.crc_init, 0x02, &payload);
+        let mut bits = Vec::new();
+        for byte in connection.access_address.to_le_bytes() {
+            bits.extend((0..8).map(|bit| (byte >> bit) & 1));
+        }
+        for byte in whitened {
+            bits.extend((0..8).map(|bit| (byte >> bit) & 1));
+        }
+        let demod: Vec<_> = bits
+            .into_iter()
+            .flat_map(|bit| [bit, bit])
+            .map(|bit| if bit == 0 { -1.0 } else { 1.0 })
+            .collect();
+
+        let result = decode_data_candidates(&demod, 2, 0, &[connection]);
+
+        assert_eq!(result.candidates.len(), 1);
+        assert_eq!(result.candidates[0].packet.access_address, 0x1234_5678);
+        assert_eq!(result.candidates[0].packet.payload, payload);
+        assert_eq!(result.aa_candidates, 2);
+        assert_eq!(result.phase_duplicates, 1);
+        assert_eq!(result.crc_rejects, 0);
+    }
+
+    #[test]
+    fn skips_advertising_scan_when_disabled() {
+        let packet: Vec<_> = generate_ble_packet_samples(2, 1, 37)
+            .into_iter()
+            .filter(|sample| sample.norm() > 0.0)
+            .collect();
+        let taps = gmsk_rx_taps(2).unwrap();
+        let filter_history = taps.len().saturating_sub(1);
+        let mut samples = vec![Complex32::new(0.0, 0.0); filter_history + PRE_TRIGGER_SYMBOLS * 2];
+        samples.extend(packet);
+
+        let decoder = BurstDecoder::new(BlePhy::Le1M, 2, 0, taps).unwrap();
+        let result = match decoder.decode(
+            &CapturedBurst {
+                samples,
+                forced_close: false,
+                start_sample_index: 0,
+            },
+            &[],
+            false,
+            false,
+        ) {
+            BurstDecodeOutcome::Decoded(result) => result,
+            _ => panic!("burst should reach the decoder"),
+        };
+
+        assert!(result.candidates.is_empty());
+        assert_eq!(result.detector_stats.aa_candidates, 0);
+        assert_eq!(result.detector_stats.header_rejects, 0);
+        assert_eq!(result.detector_stats.pdu_attempts(), 0);
+        assert_eq!(result.phase_valid_packets, [0, 0]);
+        assert_eq!(result.phase_only_packets, [0, 0]);
+    }
+
+    #[test]
+    fn rejects_unsupported_phys_explicitly() {
+        assert!(matches!(
+            BurstDecoder::new(BlePhy::Le2M, 1, 37, vec![1.0]),
+            Err(UnsupportedPhy { phy: BlePhy::Le2M })
+        ));
+        assert!(matches!(
+            BurstDecoder::new(BlePhy::LeCoded, 2, 37, vec![1.0]),
+            Err(UnsupportedPhy {
+                phy: BlePhy::LeCoded
+            })
+        ));
+    }
+}

--- a/examples/bluetooth/src/ble_burst_stats.rs
+++ b/examples/bluetooth/src/ble_burst_stats.rs
@@ -1,0 +1,143 @@
+use crate::ble_detector::DetectorStats;
+
+pub(crate) struct BurstStats {
+    pub(crate) bursts: u64,
+    pub(crate) gated_bursts: u64,
+    pub(crate) decoded_bursts: u64,
+    pub(crate) short_bursts: u64,
+    pub(crate) fsk_rejects: u64,
+    pub(crate) total_burst_samples: u64,
+    pub(crate) max_burst_samples: usize,
+    pub(crate) forced_closes: u64,
+    pub(crate) multi_packet_bursts: u64,
+    pub(crate) phase_duplicates: u64,
+    pub(crate) crc_pass_bursts: u64,
+    crc_fail_bursts: u64,
+    pub(crate) data_packets: u64,
+    pub(crate) data_aa_candidates: u64,
+    pub(crate) data_crc_rejects: u64,
+    pub(crate) data_phase_duplicates: u64,
+    pub(crate) follower_locked_checks: u64,
+    pub(crate) follower_window_matches: u64,
+    pub(crate) follower_searching_checks: u64,
+    pub(crate) phase_valid_packets: Vec<u64>,
+    pub(crate) phase_only_packets: Vec<u64>,
+    pub(crate) detector: DetectorStats,
+}
+
+impl BurstStats {
+    pub(crate) fn new(samples_per_symbol: usize) -> Self {
+        Self {
+            bursts: 0,
+            gated_bursts: 0,
+            decoded_bursts: 0,
+            short_bursts: 0,
+            fsk_rejects: 0,
+            total_burst_samples: 0,
+            max_burst_samples: 0,
+            forced_closes: 0,
+            multi_packet_bursts: 0,
+            phase_duplicates: 0,
+            crc_pass_bursts: 0,
+            crc_fail_bursts: 0,
+            data_packets: 0,
+            data_aa_candidates: 0,
+            data_crc_rejects: 0,
+            data_phase_duplicates: 0,
+            follower_locked_checks: 0,
+            follower_window_matches: 0,
+            follower_searching_checks: 0,
+            phase_valid_packets: vec![0; samples_per_symbol],
+            phase_only_packets: vec![0; samples_per_symbol],
+            detector: DetectorStats::default(),
+        }
+    }
+
+    pub(crate) fn mean_burst_samples(&self) -> f64 {
+        ratio(self.total_burst_samples, self.bursts)
+    }
+
+    pub(crate) fn packets_per_burst(&self) -> f64 {
+        ratio(self.detector.packets + self.data_packets, self.bursts)
+    }
+
+    pub(crate) fn advertising_valid_candidates(&self) -> u64 {
+        self.phase_valid_packets.iter().sum()
+    }
+
+    pub(crate) fn advertising_candidate_crc_checks(&self) -> u64 {
+        self.advertising_valid_candidates() + self.detector.crc_rejects
+    }
+
+    pub(crate) fn advertising_candidate_crc_reject_rate(&self) -> f64 {
+        percentage(
+            self.detector.crc_rejects,
+            self.advertising_candidate_crc_checks(),
+        )
+    }
+
+    pub(crate) fn data_valid_candidates(&self) -> u64 {
+        self.data_packets + self.data_phase_duplicates
+    }
+
+    pub(crate) fn data_candidate_crc_checks(&self) -> u64 {
+        self.data_valid_candidates() + self.data_crc_rejects
+    }
+
+    pub(crate) fn data_candidate_crc_reject_rate(&self) -> f64 {
+        percentage(self.data_crc_rejects, self.data_candidate_crc_checks())
+    }
+
+    pub(crate) fn observe_crc_burst(&mut self, has_valid_packet: bool, crc_rejects: u64) {
+        if has_valid_packet {
+            self.crc_pass_bursts += 1;
+        } else if crc_rejects > 0 {
+            self.crc_fail_bursts += 1;
+        }
+    }
+
+    pub(crate) fn burst_crc_checks(&self) -> u64 {
+        self.crc_pass_bursts + self.crc_fail_bursts
+    }
+
+    pub(crate) fn burst_crc_pass_rate(&self) -> f64 {
+        percentage(self.crc_pass_bursts, self.burst_crc_checks())
+    }
+}
+
+fn ratio(numerator: u64, denominator: u64) -> f64 {
+    if denominator == 0 {
+        0.0
+    } else {
+        numerator as f64 / denominator as f64
+    }
+}
+
+fn percentage(numerator: u64, denominator: u64) -> f64 {
+    100.0 * ratio(numerator, denominator)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn crc_rates_use_phase_consistent_candidate_counts() {
+        let mut stats = BurstStats::new(2);
+        stats.phase_valid_packets = vec![40, 40];
+        stats.detector.crc_rejects = 20;
+        stats.data_packets = 30;
+        stats.data_phase_duplicates = 10;
+        stats.data_crc_rejects = 10;
+        stats.observe_crc_burst(true, 3);
+        stats.observe_crc_burst(false, 2);
+        stats.observe_crc_burst(false, 0);
+
+        assert_eq!(stats.advertising_candidate_crc_checks(), 100);
+        assert_eq!(stats.advertising_candidate_crc_reject_rate(), 20.0);
+        assert_eq!(stats.data_candidate_crc_checks(), 50);
+        assert_eq!(stats.data_candidate_crc_reject_rate(), 20.0);
+        assert_eq!(stats.burst_crc_checks(), 2);
+        assert_eq!(stats.burst_crc_pass_rate(), 50.0);
+    }
+}

--- a/examples/bluetooth/src/ble_channel_selection.rs
+++ b/examples/bluetooth/src/ble_channel_selection.rs
@@ -1,0 +1,248 @@
+use std::error::Error;
+use std::fmt;
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum BleChannelSelectionAlgorithm {
+    Csa1,
+    Csa2,
+}
+
+impl fmt::Display for BleChannelSelectionAlgorithm {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Csa1 => f.write_str("CSA#1"),
+            Self::Csa2 => f.write_str("CSA#2"),
+        }
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) struct BleChannelSelector {
+    algorithm: BleChannelSelectionAlgorithm,
+    access_address: u32,
+    hop_increment: u8,
+    channel_map: [u8; 5],
+    used_channels: Vec<u8>,
+}
+
+impl BleChannelSelector {
+    pub(crate) fn new(
+        algorithm: BleChannelSelectionAlgorithm,
+        access_address: u32,
+        hop_increment: u8,
+        channel_map: [u8; 5],
+    ) -> Result<Self, ChannelSelectionError> {
+        let used_channels = (0..37)
+            .filter(|channel| channel_is_used(&channel_map, *channel))
+            .collect::<Vec<_>>();
+        if used_channels.len() < 2 {
+            return Err(ChannelSelectionError::TooFewUsedChannels {
+                count: used_channels.len(),
+            });
+        }
+        if algorithm == BleChannelSelectionAlgorithm::Csa1 && !(5..=16).contains(&hop_increment) {
+            return Err(ChannelSelectionError::InvalidHopIncrement(hop_increment));
+        }
+
+        Ok(Self {
+            algorithm,
+            access_address,
+            hop_increment,
+            channel_map,
+            used_channels,
+        })
+    }
+
+    pub(crate) fn algorithm(&self) -> BleChannelSelectionAlgorithm {
+        self.algorithm
+    }
+
+    pub(crate) fn channel_for_event(&self, event_counter: u16) -> u8 {
+        match self.algorithm {
+            BleChannelSelectionAlgorithm::Csa1 => self.csa1_channel(event_counter),
+            BleChannelSelectionAlgorithm::Csa2 => self.csa2_channel(event_counter),
+        }
+    }
+
+    pub(crate) fn event_preview(&self, count: usize) -> String {
+        self.event_preview_from(0, count)
+    }
+
+    pub(crate) fn event_preview_from(&self, start: u16, count: usize) -> String {
+        (0..count)
+            .map(|event| {
+                let event_counter = start.wrapping_add(event as u16);
+                format!("{event_counter}:{}", self.channel_for_event(event_counter))
+            })
+            .collect::<Vec<_>>()
+            .join(",")
+    }
+
+    pub(crate) fn used_channels(&self) -> &[u8] {
+        &self.used_channels
+    }
+
+    pub(crate) fn monitored_event_hits(
+        &self,
+        monitored_channels: &[u8],
+        start: u16,
+        search_count: usize,
+        max_hits: usize,
+    ) -> String {
+        (0..search_count)
+            .filter_map(|offset| {
+                let event_counter = start.wrapping_add(offset as u16);
+                let channel = self.channel_for_event(event_counter);
+                monitored_channels
+                    .contains(&channel)
+                    .then_some(format!("{event_counter}:{channel}"))
+            })
+            .take(max_hits)
+            .collect::<Vec<_>>()
+            .join(",")
+    }
+
+    fn csa1_channel(&self, event_counter: u16) -> u8 {
+        let unmapped = (((event_counter as u32 + 1) * self.hop_increment as u32) % 37) as u8;
+        if channel_is_used(&self.channel_map, unmapped) {
+            unmapped
+        } else {
+            self.used_channels[unmapped as usize % self.used_channels.len()]
+        }
+    }
+
+    fn csa2_channel(&self, event_counter: u16) -> u8 {
+        let channel_identifier = (self.access_address >> 16) as u16 ^ self.access_address as u16;
+        let mut prn = event_counter ^ channel_identifier;
+        for _ in 0..3 {
+            prn = permute(prn);
+            prn = mam(prn, channel_identifier);
+        }
+        let prn_e = prn ^ channel_identifier;
+        let unmapped = (prn_e % 37) as u8;
+
+        if channel_is_used(&self.channel_map, unmapped) {
+            unmapped
+        } else {
+            let remapping_index = ((self.used_channels.len() as u32 * prn_e as u32) >> 16) as usize;
+            self.used_channels[remapping_index]
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum ChannelSelectionError {
+    InvalidHopIncrement(u8),
+    TooFewUsedChannels { count: usize },
+}
+
+impl fmt::Display for ChannelSelectionError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::InvalidHopIncrement(hop) => {
+                write!(f, "CSA#1 hop increment must be in 5..=16, got {hop}")
+            }
+            Self::TooFewUsedChannels { count } => {
+                write!(
+                    f,
+                    "BLE channel map must contain at least two used channels, got {count}"
+                )
+            }
+        }
+    }
+}
+
+impl Error for ChannelSelectionError {}
+
+fn channel_is_used(channel_map: &[u8; 5], channel: u8) -> bool {
+    channel < 37 && channel_map[channel as usize / 8] & (1 << (channel % 8)) != 0
+}
+
+fn permute(value: u16) -> u16 {
+    ((value & 0x00ff) as u8).reverse_bits() as u16
+        | ((((value >> 8) & 0x00ff) as u8).reverse_bits() as u16) << 8
+}
+
+fn mam(a: u16, b: u16) -> u16 {
+    a.wrapping_mul(17).wrapping_add(b)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const ALL_CHANNELS: [u8; 5] = [0xff, 0xff, 0xff, 0xff, 0x1f];
+
+    #[test]
+    fn csa1_starts_from_zero_and_applies_the_hop_increment() {
+        let selector = BleChannelSelector::new(
+            BleChannelSelectionAlgorithm::Csa1,
+            0x1234_5678,
+            12,
+            ALL_CHANNELS,
+        )
+        .unwrap();
+
+        assert_eq!(
+            (0..4)
+                .map(|event| selector.channel_for_event(event))
+                .collect::<Vec<_>>(),
+            [12, 24, 36, 11]
+        );
+    }
+
+    #[test]
+    fn csa1_remaps_unused_channels_in_ascending_map_order() {
+        let channel_map = channel_map(&[0, 5, 10]);
+        let selector = BleChannelSelector::new(
+            BleChannelSelectionAlgorithm::Csa1,
+            0x1234_5678,
+            12,
+            channel_map,
+        )
+        .unwrap();
+
+        assert_eq!(selector.channel_for_event(3), 10);
+    }
+
+    #[test]
+    fn csa2_matches_the_full_map_core_spec_sample() {
+        let selector = BleChannelSelector::new(
+            BleChannelSelectionAlgorithm::Csa2,
+            0x8e89_bed6,
+            0,
+            ALL_CHANNELS,
+        )
+        .unwrap();
+
+        assert_eq!(
+            (0..4)
+                .map(|event| selector.channel_for_event(event))
+                .collect::<Vec<_>>(),
+            [25, 20, 6, 21]
+        );
+    }
+
+    #[test]
+    fn csa2_matches_the_remapped_core_spec_sample() {
+        let selector = BleChannelSelector::new(
+            BleChannelSelectionAlgorithm::Csa2,
+            0x8e89_bed6,
+            0,
+            channel_map(&[9, 10, 21, 22, 23, 33, 34, 35, 36]),
+        )
+        .unwrap();
+
+        assert_eq!(selector.channel_for_event(6), 23);
+        assert_eq!(selector.channel_for_event(7), 9);
+        assert_eq!(selector.channel_for_event(8), 34);
+    }
+
+    fn channel_map(channels: &[u8]) -> [u8; 5] {
+        let mut map = [0u8; 5];
+        for &channel in channels {
+            map[channel as usize / 8] |= 1 << (channel % 8);
+        }
+        map
+    }
+}

--- a/examples/bluetooth/src/ble_connection.rs
+++ b/examples/bluetooth/src/ble_connection.rs
@@ -1,47 +1,198 @@
+use std::sync::Arc;
+use std::sync::RwLock;
+use std::sync::atomic::AtomicUsize;
+use std::sync::atomic::Ordering;
+use std::time::Instant;
+
+use crate::ble_channel_selection::BleChannelSelectionAlgorithm;
+use crate::ble_channel_selection::BleChannelSelector;
+use crate::ble_connection_follower::ConnectionEventPlanner;
+use crate::ble_connection_follower::ConnectionFollowPlan;
+use crate::ble_connection_report::ConnectionTrackingSummary;
+use crate::ble_control::BleControlPdu;
+use crate::ble_control::ChannelMapInd;
+use crate::ble_control::ConnectionUpdateInd;
+use crate::ble_control::parse_control_pdu;
+use crate::ble_data::BleDataPacket;
+use crate::ble_phy::BlePhy;
 use crate::ble_protocol;
 use crate::ble_protocol::BlePacket;
+use crate::ble_timing_recovery::TimingRecovery;
+
+const DATA_PACKET_PREFIX_SYMBOLS: u64 = 40;
+const MAX_TRACKED_CONNECTIONS: usize = 64;
+const MIN_CONNECTION_RETENTION_MS: u64 = 5_000;
+const TIMING_GUARD_SYMBOLS: u64 = 16;
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) struct ConnectionDecodeContext {
+    pub(crate) access_address: u32,
+    pub(crate) crc_init: u32,
+    pub(crate) phy: BlePhy,
+}
+
+#[derive(Debug, Default)]
+pub(crate) struct ConnectionDecodeSelection {
+    pub(crate) contexts: Vec<ConnectionDecodeContext>,
+    pub(crate) locked_checks: u64,
+    pub(crate) window_matches: u64,
+    pub(crate) searching_checks: u64,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) struct ConnectionEventObservation {
+    pub(crate) event_counter: u16,
+    pub(crate) channel_index: u8,
+    pub(crate) counter_exact: bool,
+    event_index: u64,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+struct PendingConnectionUpdate {
+    parameters: ConnectionUpdateInd,
+    instant_sample: u64,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+struct PendingChannelMapUpdate {
+    parameters: ChannelMapInd,
+    instant_sample: u64,
+}
+
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+struct ControlObservation {
+    terminate: bool,
+    parsed: u64,
+    parse_errors: u64,
+    unresolved_updates: u64,
+    connection_updates_scheduled: u64,
+    channel_map_updates_scheduled: u64,
+    encryption_starts: u64,
+}
+
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+struct TimingMissStats {
+    sample_rate: u64,
+    invalid_parameters: u64,
+    before_window: u64,
+    outside_window: u64,
+    channel: u64,
+}
+
+impl TimingMissStats {
+    fn total(self) -> u64 {
+        self.sample_rate
+            + self.invalid_parameters
+            + self.before_window
+            + self.outside_window
+            + self.channel
+    }
+}
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub(crate) struct BleConnection {
     pub(crate) access_address: u32,
     pub(crate) crc_init: u32,
+    pub(crate) phy: BlePhy,
     pub(crate) initiator_address: [u8; 6],
     pub(crate) advertiser_address: [u8; 6],
     pub(crate) initiator_random: bool,
     pub(crate) advertiser_random: bool,
     pub(crate) interval_units: u16,
+    pub(crate) window_size_units: u8,
+    pub(crate) window_offset_units: u16,
     pub(crate) latency: u16,
     pub(crate) timeout_units: u16,
-    pub(crate) channel_map: [u8; 5],
     pub(crate) hop_increment: u8,
     pub(crate) sca: u8,
     pub(crate) first_channel: u8,
     pub(crate) last_channel: u8,
     pub(crate) seen_count: u64,
+    pub(crate) data_packet_count: u64,
+    channel_selector: BleChannelSelector,
+    monitored_data_channels: Vec<u8>,
+    sample_rate_hz: Option<u64>,
+    connect_end_sample: Option<u64>,
+    event_zero_anchor_sample: Option<u64>,
+    last_event_index: Option<u64>,
+    event_counter_offset: u16,
+    event_counter_exact: bool,
+    pending_connection_update: Option<PendingConnectionUpdate>,
+    pending_channel_map_update: Option<PendingChannelMapUpdate>,
+    encrypted: bool,
+    connection_updates_applied: u64,
+    channel_map_updates_applied: u64,
+    timing_discontinuous: bool,
+    timing_recovery: Option<TimingRecovery>,
+    recovery_counter_hint: Option<u16>,
+    relock_count: u64,
+    timing_misses: TimingMissStats,
+    last_activity_sample: Option<u64>,
+    last_activity: Instant,
 }
 
 impl BleConnection {
-    fn from_connect_ind(packet: &BlePacket) -> Option<Self> {
+    fn from_connect_ind(
+        packet: &BlePacket,
+        monitored_data_channels: &[u8],
+        timing: Option<(u64, u64)>,
+    ) -> Option<Self> {
         let request = packet.connection_request()?;
         let initiator_address = packet.initiator_address()?;
         let advertiser_address = packet.advertiser_address()?;
 
+        let algorithm = if packet.channel_selection_2 {
+            BleChannelSelectionAlgorithm::Csa2
+        } else {
+            BleChannelSelectionAlgorithm::Csa1
+        };
+        let channel_selector = BleChannelSelector::new(
+            algorithm,
+            request.access_address,
+            request.hop_increment,
+            request.channel_map,
+        )
+        .ok()?;
+
         Some(Self {
             access_address: request.access_address,
             crc_init: request.crc_init,
+            phy: packet.phy,
             initiator_address,
             advertiser_address,
             initiator_random: packet.tx_add,
             advertiser_random: packet.rx_add,
             interval_units: request.interval_units,
+            window_size_units: request.window_size_units,
+            window_offset_units: request.window_offset_units,
             latency: request.latency,
             timeout_units: request.timeout_units,
-            channel_map: request.channel_map,
             hop_increment: request.hop_increment,
             sca: request.sca,
             first_channel: packet.channel_index,
             last_channel: packet.channel_index,
             seen_count: 1,
+            data_packet_count: 0,
+            channel_selector,
+            monitored_data_channels: monitored_data_channels.to_vec(),
+            sample_rate_hz: timing.map(|(_, sample_rate_hz)| sample_rate_hz),
+            connect_end_sample: timing.map(|(sample_index, _)| sample_index),
+            event_zero_anchor_sample: None,
+            last_event_index: None,
+            event_counter_offset: 0,
+            event_counter_exact: true,
+            pending_connection_update: None,
+            pending_channel_map_update: None,
+            encrypted: false,
+            connection_updates_applied: 0,
+            channel_map_updates_applied: 0,
+            timing_discontinuous: false,
+            timing_recovery: None,
+            recovery_counter_hint: None,
+            relock_count: 0,
+            timing_misses: TimingMissStats::default(),
+            last_activity_sample: timing.map(|(sample_index, _)| sample_index),
+            last_activity: Instant::now(),
         })
     }
 
@@ -53,62 +204,899 @@ impl BleConnection {
         self.timeout_units as u32 * 10
     }
 
-    fn used_channel_count(&self) -> u32 {
-        used_channel_count(&self.channel_map)
+    fn window_size_ms(&self) -> f32 {
+        self.window_size_units as f32 * 1.25
     }
+
+    fn window_offset_ms(&self) -> f32 {
+        self.window_offset_units as f32 * 1.25
+    }
+
+    fn retention_ms(&self) -> u64 {
+        let monitored_channels = self
+            .channel_selector
+            .used_channels()
+            .iter()
+            .filter(|channel| self.monitored_data_channels.contains(channel))
+            .count();
+        let coverage_scale = self
+            .channel_selector
+            .used_channels()
+            .len()
+            .div_ceil(monitored_channels.max(1)) as u64;
+        (self.timeout_ms() as u64 * coverage_scale).max(MIN_CONNECTION_RETENTION_MS)
+    }
+
+    fn is_stale_at(&self, sample_index: u64, sample_rate_hz: u64) -> bool {
+        if self.sample_rate_hz != Some(sample_rate_hz) {
+            return false;
+        }
+        let Some(last_activity_sample) = self.last_activity_sample else {
+            return false;
+        };
+        let Some(elapsed_samples) = sample_index.checked_sub(last_activity_sample) else {
+            return false;
+        };
+        let retention_samples = sample_rate_hz
+            .saturating_mul(self.retention_ms())
+            .saturating_div(1_000);
+        elapsed_samples > retention_samples
+    }
+
+    fn observe_data_timing(
+        &mut self,
+        packet: &BleDataPacket,
+        aa_end_sample: u64,
+        sample_rate_hz: u64,
+    ) -> Option<ConnectionEventObservation> {
+        if self.sample_rate_hz != Some(sample_rate_hz) {
+            self.timing_misses.sample_rate += 1;
+            return None;
+        }
+
+        let samples_per_symbol = sample_rate_hz / self.phy.symbol_rate_hz() as u64;
+        if samples_per_symbol == 0 {
+            self.timing_misses.invalid_parameters += 1;
+            return None;
+        }
+        let packet_start_sample =
+            aa_end_sample.saturating_sub(DATA_PACKET_PREFIX_SYMBOLS * samples_per_symbol);
+        self.apply_pending_updates(packet_start_sample);
+        let interval_samples = units_1_25_ms_to_samples(self.interval_units as u64, sample_rate_hz);
+        if interval_samples == 0 {
+            self.timing_misses.invalid_parameters += 1;
+            return None;
+        }
+        if self.timing_discontinuous {
+            return self.recover_data_timing(
+                packet.channel_index,
+                packet_start_sample,
+                interval_samples,
+            );
+        }
+
+        let event_index = if let Some(anchor) = self.event_zero_anchor_sample {
+            let elapsed = packet_start_sample.saturating_sub(anchor);
+            (elapsed + interval_samples / 2) / interval_samples
+        } else {
+            let connect_end = self.connect_end_sample?;
+            let window_start = connect_end
+                + units_1_25_ms_to_samples(1 + self.window_offset_units as u64, sample_rate_hz);
+            if packet_start_sample < window_start {
+                self.timing_misses.before_window += 1;
+                return None;
+            }
+            let elapsed = packet_start_sample - window_start;
+            let event_number = elapsed / interval_samples;
+            let position_in_window = elapsed % interval_samples;
+            let window_samples =
+                units_1_25_ms_to_samples(self.window_size_units as u64, sample_rate_hz);
+            let timing_guard = TIMING_GUARD_SYMBOLS * samples_per_symbol;
+            if position_in_window > window_samples + timing_guard {
+                self.timing_misses.outside_window += 1;
+                return None;
+            }
+            self.event_zero_anchor_sample =
+                Some(packet_start_sample - event_number * interval_samples);
+            event_number
+        };
+
+        let event_counter = self.event_counter_for_index(event_index);
+        let expected_channel = self.channel_selector.channel_for_event(event_counter);
+        if expected_channel != packet.channel_index {
+            self.timing_misses.channel += 1;
+            if self.last_event_index.is_none() {
+                self.event_zero_anchor_sample = None;
+            }
+            return None;
+        }
+
+        if self
+            .last_event_index
+            .is_none_or(|last_event| event_index >= last_event)
+        {
+            self.event_zero_anchor_sample = Some(
+                packet_start_sample.saturating_sub(event_index.saturating_mul(interval_samples)),
+            );
+            self.last_event_index = Some(event_index);
+        }
+        Some(ConnectionEventObservation {
+            event_counter,
+            channel_index: expected_channel,
+            counter_exact: self.event_counter_exact,
+            event_index,
+        })
+    }
+
+    fn recover_data_timing(
+        &mut self,
+        channel_index: u8,
+        packet_start_sample: u64,
+        interval_samples: u64,
+    ) -> Option<ConnectionEventObservation> {
+        let channel_selector = self.channel_selector.clone();
+        let recovery = self
+            .timing_recovery
+            .get_or_insert_with(|| TimingRecovery::new(self.recovery_counter_hint));
+        let resolution = recovery.observe(
+            &channel_selector,
+            interval_samples,
+            packet_start_sample,
+            channel_index,
+        )?;
+
+        let event_index = packet_start_sample / interval_samples;
+        self.event_zero_anchor_sample = Some(packet_start_sample % interval_samples);
+        self.last_event_index = Some(event_index);
+        self.event_counter_offset = resolution.event_counter.wrapping_sub(event_index as u16);
+        self.event_counter_exact = resolution.counter_exact;
+        self.timing_discontinuous = false;
+        self.timing_recovery = None;
+        self.recovery_counter_hint = None;
+        self.relock_count += 1;
+
+        Some(ConnectionEventObservation {
+            event_counter: resolution.event_counter,
+            channel_index,
+            counter_exact: resolution.counter_exact,
+            event_index,
+        })
+    }
+
+    fn observe_control_pdu(
+        &mut self,
+        packet: &BleDataPacket,
+        observation: Option<ConnectionEventObservation>,
+        sample_rate_hz: u64,
+    ) -> ControlObservation {
+        let mut result = ControlObservation::default();
+        if self.encrypted {
+            return result;
+        }
+        let control = match parse_control_pdu(packet) {
+            Ok(Some(control)) => control,
+            Ok(None) => return result,
+            Err(_) => {
+                result.parse_errors = 1;
+                return result;
+            }
+        };
+        result.parsed = 1;
+
+        match control {
+            BleControlPdu::ConnectionUpdateInd(parameters) => {
+                let Some(instant_sample) = observation.and_then(|observation| {
+                    self.sample_for_instant(observation, parameters.instant, sample_rate_hz)
+                }) else {
+                    result.unresolved_updates = 1;
+                    return result;
+                };
+                if !valid_connection_update(parameters) {
+                    result.parse_errors = 1;
+                    return result;
+                }
+                self.pending_connection_update = Some(PendingConnectionUpdate {
+                    parameters,
+                    instant_sample,
+                });
+                result.connection_updates_scheduled = 1;
+            }
+            BleControlPdu::ChannelMapInd(parameters) => {
+                let Some(instant_sample) = observation.and_then(|observation| {
+                    self.sample_for_instant(observation, parameters.instant, sample_rate_hz)
+                }) else {
+                    result.unresolved_updates = 1;
+                    return result;
+                };
+                if BleChannelSelector::new(
+                    self.channel_selector.algorithm(),
+                    self.access_address,
+                    self.hop_increment,
+                    parameters.channel_map,
+                )
+                .is_err()
+                {
+                    result.parse_errors = 1;
+                    return result;
+                }
+                self.pending_channel_map_update = Some(PendingChannelMapUpdate {
+                    parameters,
+                    instant_sample,
+                });
+                result.channel_map_updates_scheduled = 1;
+            }
+            BleControlPdu::TerminateInd { .. } => result.terminate = true,
+            BleControlPdu::StartEncryptionReq => {}
+            BleControlPdu::StartEncryptionRsp => {
+                self.encrypted = true;
+                result.encryption_starts = 1;
+            }
+            BleControlPdu::Unknown { .. } => {}
+        }
+        result
+    }
+
+    fn sample_for_instant(
+        &self,
+        observation: ConnectionEventObservation,
+        instant: u16,
+        sample_rate_hz: u64,
+    ) -> Option<u64> {
+        if !observation.counter_exact {
+            return None;
+        }
+        let event_delta = instant.wrapping_sub(observation.event_counter);
+        if event_delta >= 32_767 {
+            return None;
+        }
+        let interval_samples = units_1_25_ms_to_samples(self.interval_units as u64, sample_rate_hz);
+        let anchor = self.event_zero_anchor_sample?;
+        anchor.checked_add(
+            observation
+                .event_index
+                .checked_add(event_delta as u64)?
+                .checked_mul(interval_samples)?,
+        )
+    }
+
+    fn apply_pending_updates(&mut self, packet_start_sample: u64) {
+        if let Some(update) = self
+            .pending_channel_map_update
+            .take_if(|update| packet_start_sample >= update.instant_sample)
+            && let Ok(selector) = BleChannelSelector::new(
+                self.channel_selector.algorithm(),
+                self.access_address,
+                self.hop_increment,
+                update.parameters.channel_map,
+            )
+        {
+            self.channel_selector = selector;
+            self.channel_map_updates_applied += 1;
+        }
+
+        if let Some(update) = self
+            .pending_connection_update
+            .take_if(|update| packet_start_sample >= update.instant_sample)
+        {
+            self.interval_units = update.parameters.interval_units;
+            self.window_size_units = update.parameters.window_size_units;
+            self.window_offset_units = update.parameters.window_offset_units;
+            self.latency = update.parameters.latency;
+            self.timeout_units = update.parameters.timeout_units;
+            self.connect_end_sample = Some(update.instant_sample);
+            self.event_zero_anchor_sample = None;
+            self.last_event_index = None;
+            self.event_counter_offset = update.parameters.instant;
+            self.event_counter_exact = true;
+            self.timing_discontinuous = false;
+            self.timing_recovery = None;
+            self.recovery_counter_hint = None;
+            self.connection_updates_applied += 1;
+        }
+    }
+
+    fn event_counter_for_index(&self, event_index: u64) -> u16 {
+        (event_index as u16).wrapping_add(self.event_counter_offset)
+    }
+
+    fn timing_summary(&self) -> String {
+        let misses = self.timing_misses.total();
+        if self.timing_discontinuous {
+            let candidates = self
+                .timing_recovery
+                .as_ref()
+                .map_or(0, TimingRecovery::candidate_count);
+            return format!("discontinuous(candidates={candidates},misses={misses})");
+        }
+        match self.last_event_index {
+            Some(event) => {
+                let event_counter = self.event_counter_for_index(event);
+                let lock = if self.event_counter_exact {
+                    "locked"
+                } else {
+                    "phase_locked"
+                };
+                format!(
+                    "{lock}(last_event={event_counter},relocks={},misses={misses})",
+                    self.relock_count
+                )
+            }
+            None if self.connect_end_sample.is_some() => {
+                format!("searching(misses={misses})")
+            }
+            None => "unavailable".to_string(),
+        }
+    }
+
+    fn monitored_event_hits(&self) -> String {
+        let start = self.last_event_index.map_or(0, |event| {
+            self.event_counter_for_index(event).wrapping_add(1)
+        });
+        self.channel_selector
+            .monitored_event_hits(&self.monitored_data_channels, start, 128, 8)
+    }
+
+    fn follow_plan(&self, count: usize) -> Option<ConnectionFollowPlan> {
+        if self.pending_connection_update.is_some() || self.pending_channel_map_update.is_some() {
+            return None;
+        }
+        let sample_rate_hz = self.sample_rate_hz?;
+        let last_event_index = self.last_event_index?;
+        let event_zero_sample = self.event_zero_anchor_sample?;
+        let interval_samples = units_1_25_ms_to_samples(self.interval_units as u64, sample_rate_hz);
+        let planner = ConnectionEventPlanner::with_event_counter_offset(
+            self.channel_selector.clone(),
+            event_zero_sample,
+            interval_samples,
+            self.event_counter_offset,
+        )?;
+        Some(ConnectionFollowPlan {
+            access_address: self.access_address,
+            events: planner.plan_after(last_event_index, count),
+        })
+    }
+
+    fn event_overlaps(
+        &self,
+        channel_index: u8,
+        start_sample: u64,
+        end_sample: u64,
+        guard_samples: u64,
+    ) -> Option<bool> {
+        let pending_instant = self
+            .pending_connection_update
+            .map(|update| update.instant_sample)
+            .into_iter()
+            .chain(
+                self.pending_channel_map_update
+                    .map(|update| update.instant_sample),
+            )
+            .min();
+        if pending_instant.is_some_and(|instant| end_sample >= instant) {
+            return None;
+        }
+        let sample_rate_hz = self.sample_rate_hz?;
+        let event_zero_sample = self.event_zero_anchor_sample?;
+        self.last_event_index?;
+        let interval_samples = units_1_25_ms_to_samples(self.interval_units as u64, sample_rate_hz);
+        let planner = ConnectionEventPlanner::with_event_counter_offset(
+            self.channel_selector.clone(),
+            event_zero_sample,
+            interval_samples,
+            self.event_counter_offset,
+        )?;
+        Some(
+            planner
+                .event_overlapping(channel_index, start_sample, end_sample, guard_samples)
+                .is_some(),
+        )
+    }
+
+    fn invalidate_timing(&mut self) {
+        if let Some(last_event_index) = self.last_event_index {
+            self.recovery_counter_hint = Some(self.event_counter_for_index(last_event_index));
+        }
+        self.connect_end_sample = None;
+        self.event_zero_anchor_sample = None;
+        self.last_event_index = None;
+        self.timing_recovery = None;
+        self.pending_connection_update = None;
+        self.pending_channel_map_update = None;
+        self.timing_discontinuous = true;
+    }
+}
+
+fn valid_connection_update(update: ConnectionUpdateInd) -> bool {
+    (1..=8).contains(&update.window_size_units)
+        && (6..=3200).contains(&update.interval_units)
+        && (update.window_size_units as u16) < update.interval_units
+        && update.window_offset_units < update.interval_units
+        && update.latency <= 499
+        && (10..=3200).contains(&update.timeout_units)
+        && (update.timeout_units as u32) * 4
+            > (update.latency as u32 + 1) * update.interval_units as u32
+}
+
+fn units_1_25_ms_to_samples(units: u64, sample_rate_hz: u64) -> u64 {
+    sample_rate_hz.saturating_mul(units) / 800
 }
 
 #[derive(Default)]
 pub(crate) struct ConnectionTable {
     connections: Vec<BleConnection>,
+    monitored_data_channels: Vec<u8>,
+    last_overflow_sequence: Option<u64>,
+    overflow_events: u64,
+    tracked_data_packets: u64,
+    connect_ind_seen: u64,
+    relocks: u64,
+    recovery_observations: u64,
+    recovery_resets: u64,
+    control_pdus: u64,
+    control_parse_errors: u64,
+    unresolved_control_updates: u64,
+    connection_updates_scheduled: u64,
+    connection_updates_applied: u64,
+    channel_map_updates_scheduled: u64,
+    channel_map_updates_applied: u64,
+    terminated_connections: u64,
+    encryption_starts: u64,
+    expired_connections: u64,
 }
 
 impl ConnectionTable {
+    fn with_monitored_channels(channels: &[u8]) -> Self {
+        let mut monitored_data_channels = channels
+            .iter()
+            .copied()
+            .filter(|channel| *channel <= 36)
+            .collect::<Vec<_>>();
+        monitored_data_channels.sort_unstable();
+        monitored_data_channels.dedup();
+        Self {
+            connections: Vec::new(),
+            monitored_data_channels,
+            last_overflow_sequence: None,
+            overflow_events: 0,
+            tracked_data_packets: 0,
+            connect_ind_seen: 0,
+            relocks: 0,
+            recovery_observations: 0,
+            recovery_resets: 0,
+            control_pdus: 0,
+            control_parse_errors: 0,
+            unresolved_control_updates: 0,
+            connection_updates_scheduled: 0,
+            connection_updates_applied: 0,
+            channel_map_updates_scheduled: 0,
+            channel_map_updates_applied: 0,
+            terminated_connections: 0,
+            encryption_starts: 0,
+            expired_connections: 0,
+        }
+    }
+
     pub(crate) fn observe_packet(&mut self, packet: &BlePacket) {
-        let Some(connection) = BleConnection::from_connect_ind(packet) else {
+        self.observe_packet_with_timing(packet, None);
+    }
+
+    pub(crate) fn observe_packet_at(
+        &mut self,
+        packet: &BlePacket,
+        sample_index: u64,
+        sample_rate_hz: u64,
+    ) {
+        self.observe_packet_with_timing(packet, Some((sample_index, sample_rate_hz)));
+    }
+
+    fn observe_packet_with_timing(&mut self, packet: &BlePacket, timing: Option<(u64, u64)>) {
+        if let Some((sample_index, sample_rate_hz)) = timing {
+            self.expire_stale_connections(sample_index, sample_rate_hz);
+        }
+        let Some(mut connection) =
+            BleConnection::from_connect_ind(packet, &self.monitored_data_channels, timing)
+        else {
             return;
         };
+        self.connect_ind_seen += 1;
 
         if let Some(existing) = self
             .connections
             .iter_mut()
             .find(|entry| entry.access_address == connection.access_address)
         {
-            existing.last_channel = packet.channel_index;
-            existing.seen_count += 1;
+            connection.seen_count = existing.seen_count + 1;
+            connection.data_packet_count = existing.data_packet_count;
+            *existing = connection;
             return;
         }
 
+        if let Some(existing) = self.connections.iter_mut().find(|entry| {
+            entry.initiator_address == connection.initiator_address
+                && entry.advertiser_address == connection.advertiser_address
+        }) {
+            connection.seen_count = existing.seen_count + 1;
+            *existing = connection;
+            return;
+        }
+
+        if self.connections.len() >= MAX_TRACKED_CONNECTIONS {
+            let oldest = self
+                .connections
+                .iter()
+                .enumerate()
+                .min_by_key(|(_, connection)| connection.last_activity)
+                .map(|(index, _)| index)
+                .unwrap_or(0);
+            self.connections.swap_remove(oldest);
+        }
         self.connections.push(connection);
     }
 
-    pub(crate) fn len(&self) -> usize {
+    pub(crate) fn observe_data_packet_at(
+        &mut self,
+        packet: &BleDataPacket,
+        sample_index: u64,
+        sample_rate_hz: u64,
+    ) -> Option<ConnectionEventObservation> {
+        self.observe_data_packet_with_timing(packet, Some((sample_index, sample_rate_hz)))
+    }
+
+    fn observe_data_packet_with_timing(
+        &mut self,
+        packet: &BleDataPacket,
+        timing: Option<(u64, u64)>,
+    ) -> Option<ConnectionEventObservation> {
+        let connection_index = self
+            .connections
+            .iter()
+            .position(|entry| entry.access_address == packet.access_address)?;
+        let (observation, recovery_observation, relocked, control, applied_connection, applied_map) = {
+            let connection = &mut self.connections[connection_index];
+            let recovery_observation = timing.is_some() && connection.timing_discontinuous;
+            let old_connection_updates = connection.connection_updates_applied;
+            let old_channel_map_updates = connection.channel_map_updates_applied;
+            connection.last_channel = packet.channel_index;
+            connection.data_packet_count += 1;
+            if let Some((sample_index, _)) = timing {
+                connection.last_activity_sample = Some(sample_index);
+            }
+            connection.last_activity = Instant::now();
+            let observation = timing.and_then(|(sample_index, sample_rate_hz)| {
+                connection.observe_data_timing(packet, sample_index, sample_rate_hz)
+            });
+            let control = connection.observe_control_pdu(
+                packet,
+                observation,
+                timing.map_or(0, |(_, sample_rate_hz)| sample_rate_hz),
+            );
+            let relocked = recovery_observation && !connection.timing_discontinuous;
+            (
+                observation,
+                recovery_observation,
+                relocked,
+                control,
+                connection
+                    .connection_updates_applied
+                    .saturating_sub(old_connection_updates),
+                connection
+                    .channel_map_updates_applied
+                    .saturating_sub(old_channel_map_updates),
+            )
+        };
+        self.tracked_data_packets += 1;
+        self.recovery_observations += u64::from(recovery_observation);
+        self.relocks += u64::from(relocked);
+        self.control_pdus += control.parsed;
+        self.control_parse_errors += control.parse_errors;
+        self.unresolved_control_updates += control.unresolved_updates;
+        self.connection_updates_scheduled += control.connection_updates_scheduled;
+        self.connection_updates_applied += applied_connection;
+        self.channel_map_updates_scheduled += control.channel_map_updates_scheduled;
+        self.channel_map_updates_applied += applied_map;
+        self.encryption_starts += control.encryption_starts;
+        if control.terminate {
+            self.connections.swap_remove(connection_index);
+            self.terminated_connections += 1;
+        }
+        observation
+    }
+
+    #[cfg(test)]
+    fn len(&self) -> usize {
         self.connections.len()
     }
 
     pub(crate) fn iter(&self) -> impl Iterator<Item = &BleConnection> {
         self.connections.iter()
     }
+
+    fn decode_contexts(&self) -> Vec<ConnectionDecodeContext> {
+        self.connections
+            .iter()
+            .map(|connection| ConnectionDecodeContext {
+                access_address: connection.access_address,
+                crc_init: connection.crc_init,
+                phy: connection.phy,
+            })
+            .collect()
+    }
+
+    fn decode_contexts_for_window(
+        &self,
+        channel_index: u8,
+        start_sample: u64,
+        end_sample: u64,
+        guard_samples: u64,
+    ) -> ConnectionDecodeSelection {
+        self.connections.iter().fold(
+            ConnectionDecodeSelection::default(),
+            |mut selection, connection| {
+                let include = match connection.event_overlaps(
+                    channel_index,
+                    start_sample,
+                    end_sample,
+                    guard_samples,
+                ) {
+                    Some(overlaps) => {
+                        selection.locked_checks += 1;
+                        selection.window_matches += u64::from(overlaps);
+                        overlaps
+                    }
+                    None => {
+                        selection.searching_checks += 1;
+                        true
+                    }
+                };
+                if include {
+                    selection.contexts.push(ConnectionDecodeContext {
+                        access_address: connection.access_address,
+                        crc_init: connection.crc_init,
+                        phy: connection.phy,
+                    });
+                }
+                selection
+            },
+        )
+    }
+
+    fn observe_overflow(&mut self, sequence: u64) {
+        if self
+            .last_overflow_sequence
+            .is_some_and(|last| sequence <= last)
+        {
+            return;
+        }
+        self.last_overflow_sequence = Some(sequence);
+        self.overflow_events = sequence;
+        self.unresolved_control_updates += self
+            .connections
+            .iter()
+            .map(|connection| {
+                u64::from(connection.pending_connection_update.is_some())
+                    + u64::from(connection.pending_channel_map_update.is_some())
+            })
+            .sum::<u64>();
+        self.recovery_resets += self
+            .connections
+            .iter()
+            .filter(|connection| connection.timing_recovery.is_some())
+            .count() as u64;
+        for connection in &mut self.connections {
+            connection.invalidate_timing();
+        }
+    }
+
+    fn expire_stale_connections(&mut self, sample_index: u64, sample_rate_hz: u64) {
+        let mut expired = 0;
+        let mut unresolved_updates = 0;
+        self.connections.retain(|connection| {
+            let stale = connection.is_stale_at(sample_index, sample_rate_hz);
+            if stale {
+                expired += 1;
+                unresolved_updates += u64::from(connection.pending_connection_update.is_some())
+                    + u64::from(connection.pending_channel_map_update.is_some());
+            }
+            !stale
+        });
+        self.expired_connections += expired;
+        self.unresolved_control_updates += unresolved_updates;
+    }
+}
+
+#[derive(Clone)]
+pub(crate) struct SharedConnectionTable {
+    inner: Arc<RwLock<ConnectionTable>>,
+    reporters_remaining: Arc<AtomicUsize>,
+}
+
+impl Default for SharedConnectionTable {
+    fn default() -> Self {
+        Self {
+            inner: Arc::new(RwLock::new(ConnectionTable::default())),
+            reporters_remaining: Arc::new(AtomicUsize::new(1)),
+        }
+    }
+}
+
+impl SharedConnectionTable {
+    pub(crate) fn with_monitored_channels(channels: &[u8]) -> Self {
+        let mut reporter_channels = channels.to_vec();
+        reporter_channels.sort_unstable();
+        reporter_channels.dedup();
+        Self {
+            inner: Arc::new(RwLock::new(ConnectionTable::with_monitored_channels(
+                channels,
+            ))),
+            reporters_remaining: Arc::new(AtomicUsize::new(reporter_channels.len().max(1))),
+        }
+    }
+
+    pub(crate) fn observe_packet(&self, packet: &BlePacket) {
+        self.inner
+            .write()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .observe_packet(packet);
+    }
+
+    pub(crate) fn observe_packet_at(
+        &self,
+        packet: &BlePacket,
+        sample_index: u64,
+        sample_rate_hz: u64,
+    ) {
+        self.inner
+            .write()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .observe_packet_at(packet, sample_index, sample_rate_hz);
+    }
+
+    pub(crate) fn observe_data_packet_at(
+        &self,
+        packet: &BleDataPacket,
+        sample_index: u64,
+        sample_rate_hz: u64,
+    ) -> Option<ConnectionEventObservation> {
+        self.inner
+            .write()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .observe_data_packet_at(packet, sample_index, sample_rate_hz)
+    }
+
+    pub(crate) fn snapshot(&self) -> Vec<BleConnection> {
+        self.inner
+            .read()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .iter()
+            .cloned()
+            .collect()
+    }
+
+    pub(crate) fn decode_contexts(&self) -> Vec<ConnectionDecodeContext> {
+        self.inner
+            .read()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .decode_contexts()
+    }
+
+    pub(crate) fn decode_contexts_for_window(
+        &self,
+        channel_index: u8,
+        start_sample: u64,
+        end_sample: u64,
+        guard_samples: u64,
+    ) -> ConnectionDecodeSelection {
+        self.inner
+            .read()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .decode_contexts_for_window(channel_index, start_sample, end_sample, guard_samples)
+    }
+
+    pub(crate) fn observe_overflow(&self, sequence: u64) {
+        self.inner
+            .write()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .observe_overflow(sequence);
+    }
+
+    pub(crate) fn follow_plans(&self, count: usize) -> Vec<ConnectionFollowPlan> {
+        self.inner
+            .read()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .iter()
+            .filter_map(|connection| connection.follow_plan(count))
+            .collect()
+    }
+
+    pub(crate) fn finish_reporter(&self) -> bool {
+        self.reporters_remaining.fetch_sub(1, Ordering::AcqRel) == 1
+    }
+
+    pub(crate) fn tracking_summary(&self) -> ConnectionTrackingSummary {
+        let table = self
+            .inner
+            .read()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let mut summary = table.iter().fold(
+            ConnectionTrackingSummary::default(),
+            |mut summary, connection| {
+                summary.connections += 1;
+                summary.timing_sample_rate_misses += connection.timing_misses.sample_rate;
+                summary.timing_invalid_parameter_misses +=
+                    connection.timing_misses.invalid_parameters;
+                summary.timing_before_window_misses += connection.timing_misses.before_window;
+                summary.timing_outside_window_misses += connection.timing_misses.outside_window;
+                summary.timing_channel_misses += connection.timing_misses.channel;
+                summary.encrypted_connections += u64::from(connection.encrypted);
+                summary.pending_connection_updates +=
+                    u64::from(connection.pending_connection_update.is_some());
+                summary.pending_channel_map_updates +=
+                    u64::from(connection.pending_channel_map_update.is_some());
+                if connection.timing_discontinuous {
+                    summary.discontinuous_connections += 1;
+                    summary.recovery_candidates += connection
+                        .timing_recovery
+                        .as_ref()
+                        .map_or(0, |recovery| recovery.candidate_count() as u64);
+                } else if connection.last_event_index.is_some() {
+                    summary.locked_connections += 1;
+                } else {
+                    summary.searching_connections += 1;
+                }
+                summary
+            },
+        );
+        summary.connect_ind_seen = table.connect_ind_seen;
+        summary.data_packets = table.tracked_data_packets;
+        summary.overflow_events = table.overflow_events;
+        summary.relocks = table.relocks;
+        summary.recovery_observations = table.recovery_observations;
+        summary.recovery_resets = table.recovery_resets;
+        summary.expired_connections = table.expired_connections;
+        summary.control_pdus = table.control_pdus;
+        summary.control_parse_errors = table.control_parse_errors;
+        summary.unresolved_control_updates = table.unresolved_control_updates;
+        summary.connection_updates_scheduled = table.connection_updates_scheduled;
+        summary.connection_updates_applied = table.connection_updates_applied;
+        summary.channel_map_updates_scheduled = table.channel_map_updates_scheduled;
+        summary.channel_map_updates_applied = table.channel_map_updates_applied;
+        summary.terminated_connections = table.terminated_connections;
+        summary.encryption_starts = table.encryption_starts;
+        summary
+    }
 }
 
 pub(crate) fn format_connection_summary(connection: &BleConnection) -> String {
     format!(
-        "aa=0x{:08X} crc_init=0x{:06X} init_a={}{} adv_a={}{} interval={:.2}ms latency={} timeout={}ms hop={} sca={} channels={} first_ch={} last_ch={} seen={}",
+        "aa=0x{:08X} crc_init=0x{:06X} phy={} init_a={}{} adv_a={}{} win={:.2}ms offset={:.2}ms interval={:.2}ms latency={} timeout={}ms retention={}ms csa={} hop={} sca={} used={:?} events=[{}] monitored={:?} monitored_events=[{}] timing={} encrypted={} pending_updates={}/{} first_ch={} last_ch={} connect_ind_seen={} data_packets={}",
         connection.access_address,
         connection.crc_init,
+        connection.phy,
         ble_protocol::format_addr(&connection.initiator_address),
         addr_type_suffix(connection.initiator_random),
         ble_protocol::format_addr(&connection.advertiser_address),
         addr_type_suffix(connection.advertiser_random),
+        connection.window_size_ms(),
+        connection.window_offset_ms(),
         connection.interval_ms(),
         connection.latency,
         connection.timeout_ms(),
+        connection.retention_ms(),
+        connection.channel_selector.algorithm(),
         connection.hop_increment,
         connection.sca,
-        connection.used_channel_count(),
+        connection.channel_selector.used_channels(),
+        connection.channel_selector.event_preview(8),
+        connection.monitored_data_channels,
+        connection.monitored_event_hits(),
+        connection.timing_summary(),
+        connection.encrypted,
+        u8::from(connection.pending_connection_update.is_some()),
+        u8::from(connection.pending_channel_map_update.is_some()),
         connection.first_channel,
         connection.last_channel,
         connection.seen_count,
+        connection.data_packet_count,
     )
 }
 
@@ -116,84 +1104,6 @@ fn addr_type_suffix(random: bool) -> &'static str {
     if random { "(random)" } else { "(public)" }
 }
 
-fn used_channel_count(channel_map: &[u8; 5]) -> u32 {
-    channel_map
-        .iter()
-        .enumerate()
-        .map(|(byte_index, byte)| {
-            if byte_index == 4 {
-                (byte & 0x1f).count_ones()
-            } else {
-                byte.count_ones()
-            }
-        })
-        .sum()
-}
-
 #[cfg(test)]
-mod tests {
-    use super::*;
-    use crate::ble_phy::BLE_ADV_CRC_INIT;
-    use crate::ble_phy::apply_whitening;
-    use crate::ble_phy::build_advertising_pdu_crc;
-    use crate::ble_phy::crc24_ble;
-    use crate::ble_protocol::BleAdvPduType;
-    use crate::ble_protocol::parse_advertising_pdu;
-
-    #[test]
-    fn tracks_connection_request_once_per_access_address() {
-        let packet = connection_packet(37, 0xa1b2c3d4);
-        let mut table = ConnectionTable::default();
-
-        table.observe_packet(&packet);
-        table.observe_packet(&packet);
-
-        assert_eq!(table.len(), 1);
-        let connection = table.iter().next().unwrap();
-        assert_eq!(connection.access_address, 0xa1b2c3d4);
-        assert_eq!(connection.crc_init, 0x123456);
-        assert_eq!(connection.hop_increment, 12);
-        assert_eq!(connection.used_channel_count(), 37);
-        assert_eq!(connection.seen_count, 2);
-    }
-
-    #[test]
-    fn ignores_non_connection_packets() {
-        let adv_a = [0x11, 0x22, 0x33, 0x44, 0x55, 0x66];
-        let adv_data = [0x02, 0x01, 0x06];
-        let whitened = build_advertising_pdu_crc(37, BleAdvPduType::AdvInd, &adv_a, &adv_data);
-        let packet = parse_advertising_pdu(37, &whitened).unwrap();
-        let mut table = ConnectionTable::default();
-
-        table.observe_packet(&packet);
-
-        assert_eq!(table.len(), 0);
-    }
-
-    fn connection_packet(channel: u8, access_address: u32) -> BlePacket {
-        let init_a = [0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff];
-        let adv_a = [0x11, 0x22, 0x33, 0x44, 0x55, 0x66];
-        let mut payload = Vec::new();
-        payload.extend_from_slice(&init_a);
-        payload.extend_from_slice(&adv_a);
-        payload.extend_from_slice(&access_address.to_le_bytes());
-        payload.extend_from_slice(&[0x56, 0x34, 0x12]);
-        payload.push(2);
-        payload.extend_from_slice(&4u16.to_le_bytes());
-        payload.extend_from_slice(&24u16.to_le_bytes());
-        payload.extend_from_slice(&0u16.to_le_bytes());
-        payload.extend_from_slice(&200u16.to_le_bytes());
-        payload.extend_from_slice(&[0xff, 0xff, 0xff, 0xff, 0x1f]);
-        payload.push((3 << 5) | 12);
-
-        let mut pdu = vec![5, payload.len() as u8];
-        pdu.extend_from_slice(&payload);
-        let crc = crc24_ble(&pdu, BLE_ADV_CRC_INIT);
-        pdu.push((crc & 0xff) as u8);
-        pdu.push(((crc >> 8) & 0xff) as u8);
-        pdu.push(((crc >> 16) & 0xff) as u8);
-
-        let whitened = apply_whitening(channel, &pdu).unwrap();
-        parse_advertising_pdu(channel, &whitened).unwrap()
-    }
-}
+#[path = "ble_connection_tests.rs"]
+mod tests;

--- a/examples/bluetooth/src/ble_connection.rs
+++ b/examples/bluetooth/src/ble_connection.rs
@@ -1,0 +1,199 @@
+use crate::ble_protocol;
+use crate::ble_protocol::BlePacket;
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) struct BleConnection {
+    pub(crate) access_address: u32,
+    pub(crate) crc_init: u32,
+    pub(crate) initiator_address: [u8; 6],
+    pub(crate) advertiser_address: [u8; 6],
+    pub(crate) initiator_random: bool,
+    pub(crate) advertiser_random: bool,
+    pub(crate) interval_units: u16,
+    pub(crate) latency: u16,
+    pub(crate) timeout_units: u16,
+    pub(crate) channel_map: [u8; 5],
+    pub(crate) hop_increment: u8,
+    pub(crate) sca: u8,
+    pub(crate) first_channel: u8,
+    pub(crate) last_channel: u8,
+    pub(crate) seen_count: u64,
+}
+
+impl BleConnection {
+    fn from_connect_ind(packet: &BlePacket) -> Option<Self> {
+        let request = packet.connection_request()?;
+        let initiator_address = packet.initiator_address()?;
+        let advertiser_address = packet.advertiser_address()?;
+
+        Some(Self {
+            access_address: request.access_address,
+            crc_init: request.crc_init,
+            initiator_address,
+            advertiser_address,
+            initiator_random: packet.tx_add,
+            advertiser_random: packet.rx_add,
+            interval_units: request.interval_units,
+            latency: request.latency,
+            timeout_units: request.timeout_units,
+            channel_map: request.channel_map,
+            hop_increment: request.hop_increment,
+            sca: request.sca,
+            first_channel: packet.channel_index,
+            last_channel: packet.channel_index,
+            seen_count: 1,
+        })
+    }
+
+    fn interval_ms(&self) -> f32 {
+        self.interval_units as f32 * 1.25
+    }
+
+    fn timeout_ms(&self) -> u32 {
+        self.timeout_units as u32 * 10
+    }
+
+    fn used_channel_count(&self) -> u32 {
+        used_channel_count(&self.channel_map)
+    }
+}
+
+#[derive(Default)]
+pub(crate) struct ConnectionTable {
+    connections: Vec<BleConnection>,
+}
+
+impl ConnectionTable {
+    pub(crate) fn observe_packet(&mut self, packet: &BlePacket) {
+        let Some(connection) = BleConnection::from_connect_ind(packet) else {
+            return;
+        };
+
+        if let Some(existing) = self
+            .connections
+            .iter_mut()
+            .find(|entry| entry.access_address == connection.access_address)
+        {
+            existing.last_channel = packet.channel_index;
+            existing.seen_count += 1;
+            return;
+        }
+
+        self.connections.push(connection);
+    }
+
+    pub(crate) fn len(&self) -> usize {
+        self.connections.len()
+    }
+
+    pub(crate) fn iter(&self) -> impl Iterator<Item = &BleConnection> {
+        self.connections.iter()
+    }
+}
+
+pub(crate) fn format_connection_summary(connection: &BleConnection) -> String {
+    format!(
+        "aa=0x{:08X} crc_init=0x{:06X} init_a={}{} adv_a={}{} interval={:.2}ms latency={} timeout={}ms hop={} sca={} channels={} first_ch={} last_ch={} seen={}",
+        connection.access_address,
+        connection.crc_init,
+        ble_protocol::format_addr(&connection.initiator_address),
+        addr_type_suffix(connection.initiator_random),
+        ble_protocol::format_addr(&connection.advertiser_address),
+        addr_type_suffix(connection.advertiser_random),
+        connection.interval_ms(),
+        connection.latency,
+        connection.timeout_ms(),
+        connection.hop_increment,
+        connection.sca,
+        connection.used_channel_count(),
+        connection.first_channel,
+        connection.last_channel,
+        connection.seen_count,
+    )
+}
+
+fn addr_type_suffix(random: bool) -> &'static str {
+    if random { "(random)" } else { "(public)" }
+}
+
+fn used_channel_count(channel_map: &[u8; 5]) -> u32 {
+    channel_map
+        .iter()
+        .enumerate()
+        .map(|(byte_index, byte)| {
+            if byte_index == 4 {
+                (byte & 0x1f).count_ones()
+            } else {
+                byte.count_ones()
+            }
+        })
+        .sum()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::ble_phy::BLE_ADV_CRC_INIT;
+    use crate::ble_phy::apply_whitening;
+    use crate::ble_phy::build_advertising_pdu_crc;
+    use crate::ble_phy::crc24_ble;
+    use crate::ble_protocol::BleAdvPduType;
+    use crate::ble_protocol::parse_advertising_pdu;
+
+    #[test]
+    fn tracks_connection_request_once_per_access_address() {
+        let packet = connection_packet(37, 0xa1b2c3d4);
+        let mut table = ConnectionTable::default();
+
+        table.observe_packet(&packet);
+        table.observe_packet(&packet);
+
+        assert_eq!(table.len(), 1);
+        let connection = table.iter().next().unwrap();
+        assert_eq!(connection.access_address, 0xa1b2c3d4);
+        assert_eq!(connection.crc_init, 0x123456);
+        assert_eq!(connection.hop_increment, 12);
+        assert_eq!(connection.used_channel_count(), 37);
+        assert_eq!(connection.seen_count, 2);
+    }
+
+    #[test]
+    fn ignores_non_connection_packets() {
+        let adv_a = [0x11, 0x22, 0x33, 0x44, 0x55, 0x66];
+        let adv_data = [0x02, 0x01, 0x06];
+        let whitened = build_advertising_pdu_crc(37, BleAdvPduType::AdvInd, &adv_a, &adv_data);
+        let packet = parse_advertising_pdu(37, &whitened).unwrap();
+        let mut table = ConnectionTable::default();
+
+        table.observe_packet(&packet);
+
+        assert_eq!(table.len(), 0);
+    }
+
+    fn connection_packet(channel: u8, access_address: u32) -> BlePacket {
+        let init_a = [0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff];
+        let adv_a = [0x11, 0x22, 0x33, 0x44, 0x55, 0x66];
+        let mut payload = Vec::new();
+        payload.extend_from_slice(&init_a);
+        payload.extend_from_slice(&adv_a);
+        payload.extend_from_slice(&access_address.to_le_bytes());
+        payload.extend_from_slice(&[0x56, 0x34, 0x12]);
+        payload.push(2);
+        payload.extend_from_slice(&4u16.to_le_bytes());
+        payload.extend_from_slice(&24u16.to_le_bytes());
+        payload.extend_from_slice(&0u16.to_le_bytes());
+        payload.extend_from_slice(&200u16.to_le_bytes());
+        payload.extend_from_slice(&[0xff, 0xff, 0xff, 0xff, 0x1f]);
+        payload.push((3 << 5) | 12);
+
+        let mut pdu = vec![5, payload.len() as u8];
+        pdu.extend_from_slice(&payload);
+        let crc = crc24_ble(&pdu, BLE_ADV_CRC_INIT);
+        pdu.push((crc & 0xff) as u8);
+        pdu.push(((crc >> 8) & 0xff) as u8);
+        pdu.push(((crc >> 16) & 0xff) as u8);
+
+        let whitened = apply_whitening(channel, &pdu).unwrap();
+        parse_advertising_pdu(channel, &whitened).unwrap()
+    }
+}

--- a/examples/bluetooth/src/ble_connection_follower.rs
+++ b/examples/bluetooth/src/ble_connection_follower.rs
@@ -1,0 +1,231 @@
+use crate::ble_channel_selection::BleChannelSelector;
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) struct PlannedConnectionEvent {
+    pub(crate) event_index: u64,
+    pub(crate) event_counter: u16,
+    pub(crate) channel_index: u8,
+    pub(crate) sample_index: u64,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) struct ConnectionFollowPlan {
+    pub(crate) access_address: u32,
+    pub(crate) events: Vec<PlannedConnectionEvent>,
+}
+
+#[derive(Clone, Debug)]
+pub(crate) struct ConnectionEventPlanner {
+    channel_selector: BleChannelSelector,
+    event_zero_sample: u64,
+    interval_samples: u64,
+    event_counter_offset: u16,
+}
+
+impl ConnectionEventPlanner {
+    pub(crate) fn with_event_counter_offset(
+        channel_selector: BleChannelSelector,
+        event_zero_sample: u64,
+        interval_samples: u64,
+        event_counter_offset: u16,
+    ) -> Option<Self> {
+        (interval_samples > 0).then_some(Self {
+            channel_selector,
+            event_zero_sample,
+            interval_samples,
+            event_counter_offset,
+        })
+    }
+
+    fn event_counter(&self, event_index: u64) -> u16 {
+        (event_index as u16).wrapping_add(self.event_counter_offset)
+    }
+
+    pub(crate) fn plan_after(
+        &self,
+        last_event_index: u64,
+        count: usize,
+    ) -> Vec<PlannedConnectionEvent> {
+        (1..=count)
+            .map_while(|offset| {
+                let event_index = last_event_index.checked_add(offset as u64)?;
+                let sample_index = self
+                    .event_zero_sample
+                    .checked_add(event_index.checked_mul(self.interval_samples)?)?;
+                let event_counter = self.event_counter(event_index);
+                Some(PlannedConnectionEvent {
+                    event_index,
+                    event_counter,
+                    channel_index: self.channel_selector.channel_for_event(event_counter),
+                    sample_index,
+                })
+            })
+            .collect()
+    }
+
+    pub(crate) fn event_overlapping(
+        &self,
+        channel_index: u8,
+        start_sample: u64,
+        end_sample: u64,
+        guard_samples: u64,
+    ) -> Option<PlannedConnectionEvent> {
+        let expanded_start = start_sample.saturating_sub(guard_samples);
+        let expanded_end = end_sample.saturating_add(guard_samples);
+        if expanded_end < self.event_zero_sample {
+            return None;
+        }
+
+        let first_event = expanded_start
+            .saturating_sub(self.event_zero_sample)
+            .div_ceil(self.interval_samples);
+        let last_event =
+            expanded_end.saturating_sub(self.event_zero_sample) / self.interval_samples;
+
+        (first_event..=last_event).find_map(|event_index| {
+            let event_counter = self.event_counter(event_index);
+            let planned_channel = self.channel_selector.channel_for_event(event_counter);
+            (planned_channel == channel_index).then(|| PlannedConnectionEvent {
+                event_index,
+                event_counter,
+                channel_index: planned_channel,
+                sample_index: self.event_zero_sample + event_index * self.interval_samples,
+            })
+        })
+    }
+}
+
+pub(crate) fn format_planned_events(events: &[PlannedConnectionEvent]) -> String {
+    events
+        .iter()
+        .map(|event| {
+            format!(
+                "{}:{}@{}",
+                event.event_counter, event.channel_index, event.sample_index
+            )
+        })
+        .collect::<Vec<_>>()
+        .join(",")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::ble_channel_selection::BleChannelSelectionAlgorithm;
+
+    const ALL_CHANNELS: [u8; 5] = [0xff, 0xff, 0xff, 0xff, 0x1f];
+
+    #[test]
+    fn plans_csa1_channels_and_sample_times() {
+        let selector = BleChannelSelector::new(
+            BleChannelSelectionAlgorithm::Csa1,
+            0x1234_5678,
+            12,
+            ALL_CHANNELS,
+        )
+        .unwrap();
+        let planner =
+            ConnectionEventPlanner::with_event_counter_offset(selector, 1_000, 60_000, 0).unwrap();
+
+        assert_eq!(
+            planner.plan_after(3, 3),
+            vec![
+                PlannedConnectionEvent {
+                    event_index: 4,
+                    event_counter: 4,
+                    channel_index: 23,
+                    sample_index: 241_000,
+                },
+                PlannedConnectionEvent {
+                    event_index: 5,
+                    event_counter: 5,
+                    channel_index: 35,
+                    sample_index: 301_000,
+                },
+                PlannedConnectionEvent {
+                    event_index: 6,
+                    event_counter: 6,
+                    channel_index: 10,
+                    sample_index: 361_000,
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn preserves_sample_time_across_event_counter_wrap() {
+        let selector = BleChannelSelector::new(
+            BleChannelSelectionAlgorithm::Csa2,
+            0x8e89_bed6,
+            0,
+            ALL_CHANNELS,
+        )
+        .unwrap();
+        let expected_before_wrap = selector.channel_for_event(u16::MAX);
+        let expected_after_wrap = selector.channel_for_event(0);
+        let planner =
+            ConnectionEventPlanner::with_event_counter_offset(selector, 500, 10, 0).unwrap();
+
+        let events = planner.plan_after(u16::MAX as u64 - 1, 2);
+
+        assert_eq!(events[0].event_index, u16::MAX as u64);
+        assert_eq!(events[0].event_counter, u16::MAX);
+        assert_eq!(events[0].channel_index, expected_before_wrap);
+        assert_eq!(events[0].sample_index, 655_850);
+        assert_eq!(events[1].event_index, u16::MAX as u64 + 1);
+        assert_eq!(events[1].event_counter, 0);
+        assert_eq!(events[1].channel_index, expected_after_wrap);
+        assert_eq!(events[1].sample_index, 655_860);
+    }
+
+    #[test]
+    fn matches_only_the_planned_channel_and_window() {
+        let selector = BleChannelSelector::new(
+            BleChannelSelectionAlgorithm::Csa1,
+            0x1234_5678,
+            12,
+            ALL_CHANNELS,
+        )
+        .unwrap();
+        let planner =
+            ConnectionEventPlanner::with_event_counter_offset(selector, 1_000, 60_000, 0).unwrap();
+
+        let event = planner
+            .event_overlapping(23, 240_900, 241_100, 200)
+            .unwrap();
+
+        assert_eq!(event.event_index, 4);
+        assert_eq!(event.sample_index, 241_000);
+        assert!(
+            planner
+                .event_overlapping(22, 240_900, 241_100, 200)
+                .is_none()
+        );
+        assert!(
+            planner
+                .event_overlapping(23, 242_000, 243_000, 200)
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn applies_recovered_event_counter_offset() {
+        let selector = BleChannelSelector::new(
+            BleChannelSelectionAlgorithm::Csa1,
+            0x1234_5678,
+            12,
+            ALL_CHANNELS,
+        )
+        .unwrap();
+        let expected_channel = selector.channel_for_event(10);
+        let planner =
+            ConnectionEventPlanner::with_event_counter_offset(selector, 40_000, 60_000, 4).unwrap();
+
+        let event = planner.plan_after(5, 1).remove(0);
+
+        assert_eq!(event.event_index, 6);
+        assert_eq!(event.event_counter, 10);
+        assert_eq!(event.channel_index, expected_channel);
+        assert_eq!(event.sample_index, 400_000);
+    }
+}

--- a/examples/bluetooth/src/ble_connection_report.rs
+++ b/examples/bluetooth/src/ble_connection_report.rs
@@ -1,0 +1,135 @@
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub(crate) struct ConnectionTrackingSummary {
+    pub(crate) connect_ind_seen: u64,
+    pub(crate) connections: u64,
+    pub(crate) locked_connections: u64,
+    pub(crate) searching_connections: u64,
+    pub(crate) discontinuous_connections: u64,
+    pub(crate) data_packets: u64,
+    pub(crate) overflow_events: u64,
+    pub(crate) relocks: u64,
+    pub(crate) recovery_observations: u64,
+    pub(crate) recovery_resets: u64,
+    pub(crate) recovery_candidates: u64,
+    pub(crate) expired_connections: u64,
+    pub(crate) timing_sample_rate_misses: u64,
+    pub(crate) timing_invalid_parameter_misses: u64,
+    pub(crate) timing_before_window_misses: u64,
+    pub(crate) timing_outside_window_misses: u64,
+    pub(crate) timing_channel_misses: u64,
+    pub(crate) control_pdus: u64,
+    pub(crate) control_parse_errors: u64,
+    pub(crate) unresolved_control_updates: u64,
+    pub(crate) connection_updates_scheduled: u64,
+    pub(crate) connection_updates_applied: u64,
+    pub(crate) channel_map_updates_scheduled: u64,
+    pub(crate) channel_map_updates_applied: u64,
+    pub(crate) pending_connection_updates: u64,
+    pub(crate) pending_channel_map_updates: u64,
+    pub(crate) terminated_connections: u64,
+    pub(crate) encryption_starts: u64,
+    pub(crate) encrypted_connections: u64,
+}
+
+pub(crate) fn format_control_summary(summary: ConnectionTrackingSummary) -> Option<String> {
+    (summary.control_pdus > 0
+        || summary.control_parse_errors > 0
+        || summary.unresolved_control_updates > 0
+        || summary.connection_updates_scheduled > 0
+        || summary.channel_map_updates_scheduled > 0
+        || summary.terminated_connections > 0
+        || summary.encryption_starts > 0)
+        .then(|| {
+            format!(
+                "pdus={} connection_updates={}/{} channel_map_updates={}/{} pending={}/{} terminations={} encryption_starts={} encrypted_connections={} unresolved_updates={} parse_errors={}",
+                summary.control_pdus,
+                summary.connection_updates_applied,
+                summary.connection_updates_scheduled,
+                summary.channel_map_updates_applied,
+                summary.channel_map_updates_scheduled,
+                summary.pending_connection_updates,
+                summary.pending_channel_map_updates,
+                summary.terminated_connections,
+                summary.encryption_starts,
+                summary.encrypted_connections,
+                summary.unresolved_control_updates,
+                summary.control_parse_errors,
+            )
+        })
+}
+
+pub(crate) fn format_tracking_summary(summary: ConnectionTrackingSummary) -> String {
+    let timing_misses = summary.timing_sample_rate_misses
+        + summary.timing_invalid_parameter_misses
+        + summary.timing_before_window_misses
+        + summary.timing_outside_window_misses
+        + summary.timing_channel_misses;
+    let mut reasons = Vec::new();
+    append_nonzero_reason(
+        &mut reasons,
+        "sample_rate",
+        summary.timing_sample_rate_misses,
+    );
+    append_nonzero_reason(
+        &mut reasons,
+        "invalid_parameters",
+        summary.timing_invalid_parameter_misses,
+    );
+    append_nonzero_reason(
+        &mut reasons,
+        "before_window",
+        summary.timing_before_window_misses,
+    );
+    append_nonzero_reason(
+        &mut reasons,
+        "outside_window",
+        summary.timing_outside_window_misses,
+    );
+    append_nonzero_reason(&mut reasons, "channel", summary.timing_channel_misses);
+    let timing = if reasons.is_empty() {
+        timing_misses.to_string()
+    } else {
+        format!("{}({})", timing_misses, reasons.join(","))
+    };
+    format!(
+        "connect_ind={} connections={} expired_connections={} locked={} searching={} discontinuous={} tracked_data_packets={} rx_overflows={} relocks={} recovery_observations={} recovery_resets={} recovery_candidates={} timing_misses={}",
+        summary.connect_ind_seen,
+        summary.connections,
+        summary.expired_connections,
+        summary.locked_connections,
+        summary.searching_connections,
+        summary.discontinuous_connections,
+        summary.data_packets,
+        summary.overflow_events,
+        summary.relocks,
+        summary.recovery_observations,
+        summary.recovery_resets,
+        summary.recovery_candidates,
+        timing,
+    )
+}
+
+fn append_nonzero_reason(reasons: &mut Vec<String>, name: &str, value: u64) {
+    if value > 0 {
+        reasons.push(format!("{name}={value}"));
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn tracking_summary_formats_only_nonzero_miss_reasons() {
+        let summary = ConnectionTrackingSummary {
+            timing_outside_window_misses: 1,
+            timing_channel_misses: 83,
+            ..ConnectionTrackingSummary::default()
+        };
+
+        assert_eq!(
+            format_tracking_summary(summary),
+            "connect_ind=0 connections=0 expired_connections=0 locked=0 searching=0 discontinuous=0 tracked_data_packets=0 rx_overflows=0 relocks=0 recovery_observations=0 recovery_resets=0 recovery_candidates=0 timing_misses=84(outside_window=1,channel=83)"
+        );
+    }
+}

--- a/examples/bluetooth/src/ble_connection_tests.rs
+++ b/examples/bluetooth/src/ble_connection_tests.rs
@@ -1,0 +1,464 @@
+use super::*;
+use crate::ble_data::build_data_pdu_crc;
+use crate::ble_data::parse_data_pdu;
+use crate::ble_phy::BLE_ADV_CRC_INIT;
+use crate::ble_phy::apply_whitening;
+use crate::ble_phy::build_advertising_pdu_crc;
+use crate::ble_phy::crc24_ble;
+use crate::ble_protocol::BleAdvPduType;
+use crate::ble_protocol::parse_advertising_pdu;
+
+#[test]
+fn tracks_connection_request_once_per_access_address() {
+    let packet = connection_packet(37, 0xa1b2c3d4);
+    let mut table = ConnectionTable::default();
+
+    table.observe_packet(&packet);
+    table.observe_packet(&packet);
+
+    assert_eq!(table.len(), 1);
+    let connection = table.iter().next().unwrap();
+    assert_eq!(connection.access_address, 0xa1b2c3d4);
+    assert_eq!(connection.crc_init, 0x123456);
+    assert_eq!(connection.hop_increment, 12);
+    assert_eq!(connection.channel_selector.used_channels().len(), 37);
+    assert_eq!(connection.seen_count, 2);
+}
+
+#[test]
+fn tracking_summary_separates_requests_from_connections() {
+    let packet = connection_packet(37, 0xa1b2c3d4);
+    let table = SharedConnectionTable::with_monitored_channels(&[0, 1, 37]);
+
+    table.observe_packet(&packet);
+    table.observe_packet(&packet);
+
+    assert_eq!(
+        table.tracking_summary(),
+        ConnectionTrackingSummary {
+            connect_ind_seen: 2,
+            connections: 1,
+            locked_connections: 0,
+            searching_connections: 1,
+            ..ConnectionTrackingSummary::default()
+        }
+    );
+}
+
+#[test]
+fn ignores_non_connection_packets() {
+    let mut table = ConnectionTable::default();
+
+    table.observe_packet(&advertising_packet(37));
+
+    assert_eq!(table.len(), 0);
+}
+
+#[test]
+fn expires_stale_connections_and_refreshes_activity_from_data() {
+    let sample_rate_hz = 2_000_000;
+    let connect_sample = 100_000;
+    let access_address = 0xa1b2c3d4;
+    let mut table = ConnectionTable::with_monitored_channels(&[0, 1]);
+    table.observe_packet_at(
+        &connection_packet(37, access_address),
+        connect_sample,
+        sample_rate_hz,
+    );
+    let retention_ms = table.iter().next().unwrap().retention_ms();
+    assert_eq!(retention_ms, 38_000);
+    let retention_samples = sample_rate_hz * retention_ms / 1_000;
+
+    let data_sample = 293_580;
+    let data = data_packet(11, access_address, 0x01, &[]);
+    table.observe_data_packet_at(&data, data_sample, sample_rate_hz);
+
+    table.observe_packet_at(
+        &advertising_packet(37),
+        connect_sample + retention_samples + 1,
+        sample_rate_hz,
+    );
+    assert_eq!(table.len(), 1);
+
+    table.observe_packet_at(
+        &advertising_packet(37),
+        data_sample + retention_samples + 1,
+        sample_rate_hz,
+    );
+    assert_eq!(table.len(), 0);
+    assert_eq!(table.expired_connections, 1);
+    assert_eq!(table.connect_ind_seen, 1);
+}
+
+#[test]
+fn replaces_an_older_connection_attempt_for_the_same_devices() {
+    use crate::ble_data::build_data_pdu_crc;
+    use crate::ble_data::parse_data_pdu;
+
+    let mut table = ConnectionTable::default();
+
+    table.observe_packet(&connection_packet(37, 0xa1b2c3d4));
+    let data = build_data_pdu_crc(11, 0x123456, 0x01, &[]);
+    let data = parse_data_pdu(11, BlePhy::Le1M, 0xa1b2c3d4, 0x123456, &data).unwrap();
+    table.observe_data_packet_with_timing(&data, None);
+    table.observe_packet(&connection_packet(37, 0x12345678));
+
+    assert_eq!(table.len(), 1);
+    let connection = table.iter().next().unwrap();
+    assert_eq!(connection.access_address, 0x12345678);
+    assert_eq!(connection.seen_count, 2);
+    assert_eq!(connection.data_packet_count, 0);
+    assert_eq!(table.tracked_data_packets, 1);
+}
+
+#[test]
+fn locks_connection_event_timing_from_a_data_packet() {
+    use crate::ble_data::build_data_pdu_crc;
+    use crate::ble_data::parse_data_pdu;
+
+    let sample_rate_hz = 2_000_000;
+    let connect_end_sample = 100_000;
+    let access_address = 0xa1b2c3d4;
+    let mut table = ConnectionTable::with_monitored_channels(&[11]);
+    table.observe_packet_at(
+        &connection_packet(37, access_address),
+        connect_end_sample,
+        sample_rate_hz,
+    );
+
+    let packet_start_sample = 293_500;
+    let aa_end_sample = packet_start_sample + DATA_PACKET_PREFIX_SYMBOLS * 2;
+    let whitened = build_data_pdu_crc(11, 0x123456, 0x01, &[]);
+    let packet = parse_data_pdu(11, BlePhy::Le1M, access_address, 0x123456, &whitened).unwrap();
+
+    let observation = table
+        .observe_data_packet_at(&packet, aa_end_sample, sample_rate_hz)
+        .unwrap();
+
+    assert_eq!(observation.event_counter, 3);
+    assert_eq!(observation.channel_index, 11);
+    let connection = table.iter().next().unwrap();
+    assert_eq!(connection.event_zero_anchor_sample, Some(113_500));
+    assert_eq!(connection.last_event_index, Some(3));
+    assert_eq!(connection.timing_misses.total(), 0);
+    assert_eq!(connection.last_channel, 11);
+    assert_eq!(connection.data_packet_count, 1);
+
+    let plan = connection.follow_plan(2).unwrap();
+    assert_eq!(plan.access_address, access_address);
+    assert_eq!(plan.events[0].event_index, 4);
+    assert_eq!(plan.events[0].event_counter, 4);
+    assert_eq!(plan.events[0].sample_index, 353_500);
+    assert_eq!(plan.events[1].event_index, 5);
+    assert_eq!(plan.events[1].sample_index, 413_500);
+
+    let matching = table.decode_contexts_for_window(23, 353_300, 353_700, 200);
+    assert_eq!(matching.locked_checks, 1);
+    assert_eq!(matching.window_matches, 1);
+    assert_eq!(matching.contexts.len(), 1);
+    let wrong_channel = table.decode_contexts_for_window(22, 353_300, 353_700, 200);
+    assert_eq!(wrong_channel.locked_checks, 1);
+    assert_eq!(wrong_channel.window_matches, 0);
+    assert!(wrong_channel.contexts.is_empty());
+
+    let older_packet_start_sample = 233_500;
+    let older_aa_end_sample = older_packet_start_sample + DATA_PACKET_PREFIX_SYMBOLS * 2;
+    let older_whitened = build_data_pdu_crc(36, 0x123456, 0x01, &[]);
+    let older_packet =
+        parse_data_pdu(36, BlePhy::Le1M, access_address, 0x123456, &older_whitened).unwrap();
+
+    let older_observation = table
+        .observe_data_packet_at(&older_packet, older_aa_end_sample, sample_rate_hz)
+        .unwrap();
+
+    assert_eq!(older_observation.event_counter, 2);
+    assert_eq!(table.iter().next().unwrap().last_event_index, Some(3));
+}
+
+#[test]
+fn overflow_disables_timing_gating_but_keeps_decode_context() {
+    use crate::ble_data::build_data_pdu_crc;
+    use crate::ble_data::parse_data_pdu;
+
+    let sample_rate_hz = 2_000_000;
+    let access_address = 0xa1b2c3d4;
+    let mut table = ConnectionTable::with_monitored_channels(&[11]);
+    table.observe_packet_at(
+        &connection_packet(37, access_address),
+        100_000,
+        sample_rate_hz,
+    );
+
+    let packet_start_sample = 293_500;
+    let aa_end_sample = packet_start_sample + DATA_PACKET_PREFIX_SYMBOLS * 2;
+    let whitened = build_data_pdu_crc(11, 0x123456, 0x01, &[]);
+    let packet = parse_data_pdu(11, BlePhy::Le1M, access_address, 0x123456, &whitened).unwrap();
+    assert!(
+        table
+            .observe_data_packet_at(&packet, aa_end_sample, sample_rate_hz)
+            .is_some()
+    );
+
+    table.observe_overflow(7);
+    table.observe_overflow(7);
+
+    let selection = table.decode_contexts_for_window(22, 400_000, 401_000, 200);
+    assert_eq!(selection.locked_checks, 0);
+    assert_eq!(selection.searching_checks, 1);
+    assert_eq!(selection.contexts.len(), 1);
+    let connection = table.iter().next().unwrap();
+    assert!(connection.timing_discontinuous);
+    assert_eq!(connection.last_event_index, None);
+    assert_eq!(table.overflow_events, 7);
+
+    table.connections[0].timing_recovery = Some(TimingRecovery::new(None));
+    table.observe_overflow(8);
+    table.observe_overflow(8);
+    assert_eq!(table.recovery_resets, 1);
+}
+
+#[test]
+fn csa1_relocks_hopping_phase_after_overflow() {
+    use crate::ble_data::build_data_pdu_crc;
+    use crate::ble_data::parse_data_pdu;
+
+    let sample_rate_hz = 2_000_000;
+    let interval_samples = 60_000;
+    let access_address = 0xa1b2c3d4;
+    let mut table = ConnectionTable::with_monitored_channels(&[0, 1, 37]);
+    table.observe_packet_at(
+        &connection_packet(37, access_address),
+        100_000,
+        sample_rate_hz,
+    );
+
+    let initial_start = 293_500;
+    let initial = build_data_pdu_crc(11, 0x123456, 0x01, &[]);
+    let initial = parse_data_pdu(11, BlePhy::Le1M, access_address, 0x123456, &initial).unwrap();
+    assert!(
+        table
+            .observe_data_packet_at(
+                &initial,
+                initial_start + DATA_PACKET_PREFIX_SYMBOLS * 2,
+                sample_rate_hz,
+            )
+            .is_some()
+    );
+    table.observe_overflow(1);
+
+    let recovery_counter = 10;
+    let recovery_channel = table
+        .iter()
+        .next()
+        .unwrap()
+        .channel_selector
+        .channel_for_event(recovery_counter);
+    let recovery_start = 400_000;
+    let recovery = build_data_pdu_crc(recovery_channel, 0x123456, 0x01, &[]);
+    let recovery = parse_data_pdu(
+        recovery_channel,
+        BlePhy::Le1M,
+        access_address,
+        0x123456,
+        &recovery,
+    )
+    .unwrap();
+    let observation = table
+        .observe_data_packet_at(
+            &recovery,
+            recovery_start + DATA_PACKET_PREFIX_SYMBOLS * 2,
+            sample_rate_hz,
+        )
+        .unwrap();
+
+    assert_eq!(observation.event_counter, recovery_counter);
+    assert!(!observation.counter_exact);
+    let connection = table.iter().next().unwrap();
+    assert!(!connection.timing_discontinuous);
+    assert_eq!(connection.relock_count, 1);
+    assert_eq!(table.recovery_observations, 1);
+    assert_eq!(table.relocks, 1);
+
+    let next_counter = recovery_counter + 1;
+    let next_channel = connection.channel_selector.channel_for_event(next_counter);
+    let next_sample = recovery_start + interval_samples;
+    let selection =
+        table.decode_contexts_for_window(next_channel, next_sample - 100, next_sample + 100, 200);
+    assert_eq!(selection.locked_checks, 1);
+    assert_eq!(selection.window_matches, 1);
+    assert_eq!(selection.contexts.len(), 1);
+}
+
+#[test]
+fn applies_channel_map_at_the_instant() {
+    let sample_rate_hz = 2_000_000;
+    let access_address = 0xa1b2c3d4;
+    let mut table = locked_connection(access_address, sample_rate_hz);
+    let update = data_packet(
+        11,
+        access_address,
+        0x03,
+        &[0x01, 0x03, 0x00, 0x00, 0x00, 0x00, 0x05, 0x00],
+    );
+
+    table.observe_data_packet_at(&update, 293_580, sample_rate_hz);
+    assert_eq!(table.channel_map_updates_scheduled, 1);
+    assert_eq!(table.channel_map_updates_applied, 0);
+    let selection = table.decode_contexts_for_window(1, 413_400, 413_600, 0);
+    assert_eq!(selection.locked_checks, 0);
+    assert_eq!(selection.searching_checks, 1);
+    assert_eq!(selection.contexts.len(), 1);
+
+    let packet = data_packet(1, access_address, 0x01, &[]);
+    let observation = table
+        .observe_data_packet_at(&packet, 413_580, sample_rate_hz)
+        .unwrap();
+
+    assert_eq!(observation.event_counter, 5);
+    assert_eq!(observation.channel_index, 1);
+    assert_eq!(table.channel_map_updates_applied, 1);
+    assert_eq!(
+        table
+            .iter()
+            .next()
+            .unwrap()
+            .channel_selector
+            .used_channels(),
+        &[0, 1]
+    );
+    let selection = table.decode_contexts_for_window(0, 473_400, 473_600, 0);
+    assert_eq!(selection.locked_checks, 1);
+}
+
+#[test]
+fn connection_update_reanchors_from_the_new_transmit_window() {
+    let sample_rate_hz = 2_000_000;
+    let access_address = 0xa1b2c3d4;
+    let mut table = locked_connection(access_address, sample_rate_hz);
+    let update = data_packet(
+        11,
+        access_address,
+        0x03,
+        &[
+            0x00, 0x02, 0x00, 0x00, 0x28, 0x00, 0x00, 0x00, 0xc8, 0x00, 0x05, 0x00,
+        ],
+    );
+
+    table.observe_data_packet_at(&update, 293_580, sample_rate_hz);
+    assert_eq!(table.connection_updates_scheduled, 1);
+
+    let first_new_anchor = 416_000;
+    let packet = data_packet(35, access_address, 0x01, &[]);
+    let observation = table
+        .observe_data_packet_at(
+            &packet,
+            first_new_anchor + DATA_PACKET_PREFIX_SYMBOLS * 2,
+            sample_rate_hz,
+        )
+        .unwrap();
+
+    assert_eq!(observation.event_counter, 5);
+    let connection = table.iter().next().unwrap();
+    assert_eq!(connection.interval_units, 40);
+    assert_eq!(connection.event_zero_anchor_sample, Some(first_new_anchor));
+    assert_eq!(
+        connection.follow_plan(1).unwrap().events[0].sample_index,
+        516_000
+    );
+    assert_eq!(table.connection_updates_applied, 1);
+}
+
+#[test]
+fn terminate_ind_removes_the_connection() {
+    let sample_rate_hz = 2_000_000;
+    let access_address = 0xa1b2c3d4;
+    let mut table = locked_connection(access_address, sample_rate_hz);
+    let terminate = data_packet(23, access_address, 0x03, &[0x02, 0x13]);
+
+    assert!(
+        table
+            .observe_data_packet_at(&terminate, 353_580, sample_rate_hz)
+            .is_some()
+    );
+
+    assert_eq!(table.len(), 0);
+    assert_eq!(table.terminated_connections, 1);
+    assert_eq!(table.control_pdus, 1);
+}
+
+#[test]
+fn encrypted_payload_is_not_interpreted_as_a_control_update() {
+    let sample_rate_hz = 2_000_000;
+    let access_address = 0xa1b2c3d4;
+    let mut table = locked_connection(access_address, sample_rate_hz);
+    let start_encryption = data_packet(23, access_address, 0x03, &[0x06]);
+    table.observe_data_packet_at(&start_encryption, 353_580, sample_rate_hz);
+    let ciphertext = data_packet(
+        35,
+        access_address,
+        0x03,
+        &[0x01, 0x03, 0x00, 0x00, 0x00, 0x00, 0x08, 0x00],
+    );
+    table.observe_data_packet_at(&ciphertext, 413_580, sample_rate_hz);
+
+    let connection = table.iter().next().unwrap();
+    assert!(connection.encrypted);
+    assert!(connection.pending_channel_map_update.is_none());
+    assert_eq!(table.encryption_starts, 1);
+    assert_eq!(table.channel_map_updates_scheduled, 0);
+}
+
+fn locked_connection(access_address: u32, sample_rate_hz: u64) -> ConnectionTable {
+    let mut table = ConnectionTable::with_monitored_channels(&[0, 1, 11, 23, 35]);
+    table.observe_packet_at(
+        &connection_packet(37, access_address),
+        100_000,
+        sample_rate_hz,
+    );
+    let packet = data_packet(11, access_address, 0x01, &[]);
+    assert!(
+        table
+            .observe_data_packet_at(&packet, 293_580, sample_rate_hz)
+            .is_some()
+    );
+    table
+}
+
+fn data_packet(channel: u8, access_address: u32, header: u8, payload: &[u8]) -> BleDataPacket {
+    let whitened = build_data_pdu_crc(channel, 0x123456, header, payload);
+    parse_data_pdu(channel, BlePhy::Le1M, access_address, 0x123456, &whitened).unwrap()
+}
+
+fn advertising_packet(channel: u8) -> BlePacket {
+    let adv_a = [0x11, 0x22, 0x33, 0x44, 0x55, 0x66];
+    let adv_data = [0x02, 0x01, 0x06];
+    let whitened = build_advertising_pdu_crc(channel, BleAdvPduType::AdvInd, &adv_a, &adv_data);
+    parse_advertising_pdu(channel, &whitened).unwrap()
+}
+
+fn connection_packet(channel: u8, access_address: u32) -> BlePacket {
+    let init_a = [0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff];
+    let adv_a = [0x11, 0x22, 0x33, 0x44, 0x55, 0x66];
+    let mut payload = Vec::new();
+    payload.extend_from_slice(&init_a);
+    payload.extend_from_slice(&adv_a);
+    payload.extend_from_slice(&access_address.to_le_bytes());
+    payload.extend_from_slice(&[0x56, 0x34, 0x12]);
+    payload.push(2);
+    payload.extend_from_slice(&4u16.to_le_bytes());
+    payload.extend_from_slice(&24u16.to_le_bytes());
+    payload.extend_from_slice(&0u16.to_le_bytes());
+    payload.extend_from_slice(&200u16.to_le_bytes());
+    payload.extend_from_slice(&[0xff, 0xff, 0xff, 0xff, 0x1f]);
+    payload.push((3 << 5) | 12);
+
+    let mut pdu = vec![5, payload.len() as u8];
+    pdu.extend_from_slice(&payload);
+    let crc = crc24_ble(&pdu, BLE_ADV_CRC_INIT);
+    pdu.push((crc & 0xff) as u8);
+    pdu.push(((crc >> 8) & 0xff) as u8);
+    pdu.push(((crc >> 16) & 0xff) as u8);
+
+    let whitened = apply_whitening(channel, &pdu).unwrap();
+    parse_advertising_pdu(channel, &whitened).unwrap()
+}

--- a/examples/bluetooth/src/ble_control.rs
+++ b/examples/bluetooth/src/ble_control.rs
@@ -1,0 +1,221 @@
+use std::error::Error;
+use std::fmt;
+
+use crate::ble_data::BleDataLlid;
+use crate::ble_data::BleDataPacket;
+
+const LL_CONNECTION_UPDATE_IND: u8 = 0x00;
+const LL_CHANNEL_MAP_IND: u8 = 0x01;
+const LL_TERMINATE_IND: u8 = 0x02;
+const LL_START_ENC_REQ: u8 = 0x05;
+const LL_START_ENC_RSP: u8 = 0x06;
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) struct ConnectionUpdateInd {
+    pub(crate) window_size_units: u8,
+    pub(crate) window_offset_units: u16,
+    pub(crate) interval_units: u16,
+    pub(crate) latency: u16,
+    pub(crate) timeout_units: u16,
+    pub(crate) instant: u16,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) struct ChannelMapInd {
+    pub(crate) channel_map: [u8; 5],
+    pub(crate) instant: u16,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum BleControlPdu {
+    ConnectionUpdateInd(ConnectionUpdateInd),
+    ChannelMapInd(ChannelMapInd),
+    TerminateInd { error_code: u8 },
+    StartEncryptionReq,
+    StartEncryptionRsp,
+    Unknown { opcode: u8 },
+}
+
+impl fmt::Display for BleControlPdu {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::ConnectionUpdateInd(update) => write!(
+                f,
+                "LL_CONNECTION_UPDATE_IND(interval={:.2}ms,latency={},timeout={}ms,instant={})",
+                update.interval_units as f32 * 1.25,
+                update.latency,
+                update.timeout_units as u32 * 10,
+                update.instant,
+            ),
+            Self::ChannelMapInd(update) => write!(
+                f,
+                "LL_CHANNEL_MAP_IND(map={:02X?},instant={})",
+                update.channel_map, update.instant,
+            ),
+            Self::TerminateInd { error_code } => {
+                write!(f, "LL_TERMINATE_IND(error=0x{error_code:02X})")
+            }
+            Self::StartEncryptionReq => f.write_str("LL_START_ENC_REQ"),
+            Self::StartEncryptionRsp => f.write_str("LL_START_ENC_RSP"),
+            Self::Unknown { opcode } => write!(f, "LL_CONTROL(opcode=0x{opcode:02X})"),
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum BleControlParseError {
+    MissingOpcode,
+    InvalidLength {
+        opcode: u8,
+        expected: usize,
+        actual: usize,
+    },
+}
+
+impl fmt::Display for BleControlParseError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::MissingOpcode => f.write_str("LL Control PDU is missing its opcode"),
+            Self::InvalidLength {
+                opcode,
+                expected,
+                actual,
+            } => write!(
+                f,
+                "LL Control opcode 0x{opcode:02X} expects {expected} payload bytes, got {actual}",
+            ),
+        }
+    }
+}
+
+impl Error for BleControlParseError {}
+
+pub(crate) fn parse_control_pdu(
+    packet: &BleDataPacket,
+) -> Result<Option<BleControlPdu>, BleControlParseError> {
+    if packet.header.llid != BleDataLlid::Control {
+        return Ok(None);
+    }
+    let opcode = *packet
+        .payload
+        .first()
+        .ok_or(BleControlParseError::MissingOpcode)?;
+    let control = match opcode {
+        LL_CONNECTION_UPDATE_IND => {
+            expect_len(opcode, &packet.payload, 12)?;
+            BleControlPdu::ConnectionUpdateInd(ConnectionUpdateInd {
+                window_size_units: packet.payload[1],
+                window_offset_units: u16::from_le_bytes([packet.payload[2], packet.payload[3]]),
+                interval_units: u16::from_le_bytes([packet.payload[4], packet.payload[5]]),
+                latency: u16::from_le_bytes([packet.payload[6], packet.payload[7]]),
+                timeout_units: u16::from_le_bytes([packet.payload[8], packet.payload[9]]),
+                instant: u16::from_le_bytes([packet.payload[10], packet.payload[11]]),
+            })
+        }
+        LL_CHANNEL_MAP_IND => {
+            expect_len(opcode, &packet.payload, 8)?;
+            let mut channel_map = [0u8; 5];
+            channel_map.copy_from_slice(&packet.payload[1..6]);
+            BleControlPdu::ChannelMapInd(ChannelMapInd {
+                channel_map,
+                instant: u16::from_le_bytes([packet.payload[6], packet.payload[7]]),
+            })
+        }
+        LL_TERMINATE_IND => {
+            expect_len(opcode, &packet.payload, 2)?;
+            BleControlPdu::TerminateInd {
+                error_code: packet.payload[1],
+            }
+        }
+        LL_START_ENC_REQ => {
+            expect_len(opcode, &packet.payload, 1)?;
+            BleControlPdu::StartEncryptionReq
+        }
+        LL_START_ENC_RSP => {
+            expect_len(opcode, &packet.payload, 1)?;
+            BleControlPdu::StartEncryptionRsp
+        }
+        _ => BleControlPdu::Unknown { opcode },
+    };
+    Ok(Some(control))
+}
+
+fn expect_len(opcode: u8, payload: &[u8], expected: usize) -> Result<(), BleControlParseError> {
+    if payload.len() == expected {
+        Ok(())
+    } else {
+        Err(BleControlParseError::InvalidLength {
+            opcode,
+            expected,
+            actual: payload.len(),
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::ble_data::build_data_pdu_crc;
+    use crate::ble_data::parse_data_pdu;
+    use crate::ble_phy::BlePhy;
+
+    const AA: u32 = 0x1234_5678;
+    const CRC_INIT: u32 = 0x00ab_cdef;
+
+    #[test]
+    fn parses_connection_update_ind() {
+        let payload = [
+            0x00, 0x02, 0x04, 0x00, 0x18, 0x00, 0x01, 0x00, 0xc8, 0x00, 0x2a, 0x00,
+        ];
+        let packet = control_packet(0, &payload);
+
+        assert_eq!(
+            parse_control_pdu(&packet).unwrap(),
+            Some(BleControlPdu::ConnectionUpdateInd(ConnectionUpdateInd {
+                window_size_units: 2,
+                window_offset_units: 4,
+                interval_units: 24,
+                latency: 1,
+                timeout_units: 200,
+                instant: 42,
+            }))
+        );
+    }
+
+    #[test]
+    fn parses_channel_map_and_terminate_indications() {
+        let channel_map = control_packet(1, &[0x01, 0x03, 0x00, 0x00, 0x00, 0x00, 0x34, 0x12]);
+        let terminate = control_packet(1, &[0x02, 0x13]);
+
+        assert_eq!(
+            parse_control_pdu(&channel_map).unwrap(),
+            Some(BleControlPdu::ChannelMapInd(ChannelMapInd {
+                channel_map: [0x03, 0, 0, 0, 0],
+                instant: 0x1234,
+            }))
+        );
+        assert_eq!(
+            parse_control_pdu(&terminate).unwrap(),
+            Some(BleControlPdu::TerminateInd { error_code: 0x13 })
+        );
+    }
+
+    #[test]
+    fn rejects_malformed_known_control_pdu() {
+        let packet = control_packet(0, &[0x01, 0x03]);
+
+        assert!(matches!(
+            parse_control_pdu(&packet),
+            Err(BleControlParseError::InvalidLength {
+                opcode: LL_CHANNEL_MAP_IND,
+                expected: 8,
+                actual: 2,
+            })
+        ));
+    }
+
+    fn control_packet(channel: u8, payload: &[u8]) -> BleDataPacket {
+        let whitened = build_data_pdu_crc(channel, CRC_INIT, 0x03, payload);
+        parse_data_pdu(channel, BlePhy::Le1M, AA, CRC_INIT, &whitened).unwrap()
+    }
+}

--- a/examples/bluetooth/src/ble_data.rs
+++ b/examples/bluetooth/src/ble_data.rs
@@ -1,0 +1,219 @@
+use std::error::Error;
+use std::fmt;
+
+use crate::ble_phy::BlePhy;
+use crate::ble_phy::apply_whitening;
+use crate::ble_phy::crc24_ble;
+
+pub(crate) const BLE_MAX_DATA_PAYLOAD_LEN: usize = 251;
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum BleDataLlid {
+    Reserved,
+    ContinuationOrEmpty,
+    StartOrComplete,
+    Control,
+}
+
+impl BleDataLlid {
+    fn from_header(header: u8) -> Self {
+        match header & 0x03 {
+            0 => Self::Reserved,
+            1 => Self::ContinuationOrEmpty,
+            2 => Self::StartOrComplete,
+            _ => Self::Control,
+        }
+    }
+}
+
+impl fmt::Display for BleDataLlid {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Reserved => write!(f, "reserved"),
+            Self::ContinuationOrEmpty => write!(f, "continuation/empty"),
+            Self::StartOrComplete => write!(f, "start/complete"),
+            Self::Control => write!(f, "control"),
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) struct BleDataHeader {
+    pub(crate) llid: BleDataLlid,
+    pub(crate) nesn: bool,
+    pub(crate) sn: bool,
+    pub(crate) more_data: bool,
+    pub(crate) cte_info_present: bool,
+    pub(crate) payload_len: usize,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) struct BleDataPacket {
+    pub(crate) access_address: u32,
+    pub(crate) channel_index: u8,
+    pub(crate) phy: BlePhy,
+    pub(crate) header: BleDataHeader,
+    pub(crate) payload: Vec<u8>,
+    pub(crate) pdu: Vec<u8>,
+    pub(crate) crc: u32,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) enum BleDataParseError {
+    TooShort { actual: usize },
+    PayloadTooLong { len: usize },
+    Truncated { needed: usize, actual: usize },
+    InvalidCrc { expected: u32, received: u32 },
+    InvalidChannel(u8),
+}
+
+impl fmt::Display for BleDataParseError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::TooShort { actual } => write!(f, "data PDU is too short: {actual} bytes"),
+            Self::PayloadTooLong { len } => {
+                write!(
+                    f,
+                    "data payload length {len} exceeds {BLE_MAX_DATA_PAYLOAD_LEN}"
+                )
+            }
+            Self::Truncated { needed, actual } => {
+                write!(f, "truncated data PDU: need {needed} bytes, got {actual}")
+            }
+            Self::InvalidCrc { expected, received } => write!(
+                f,
+                "invalid BLE data CRC: expected 0x{expected:06X}, received 0x{received:06X}"
+            ),
+            Self::InvalidChannel(channel) => write!(f, "invalid BLE channel index {channel}"),
+        }
+    }
+}
+
+impl Error for BleDataParseError {}
+
+pub(crate) fn parse_data_pdu(
+    channel_index: u8,
+    phy: BlePhy,
+    access_address: u32,
+    crc_init: u32,
+    whitened_pdu_crc: &[u8],
+) -> Result<BleDataPacket, BleDataParseError> {
+    if whitened_pdu_crc.len() < 5 {
+        return Err(BleDataParseError::TooShort {
+            actual: whitened_pdu_crc.len(),
+        });
+    }
+
+    let pdu_crc = apply_whitening(channel_index, whitened_pdu_crc)
+        .map_err(|_| BleDataParseError::InvalidChannel(channel_index))?;
+    let payload_len = pdu_crc[1] as usize;
+    if payload_len > BLE_MAX_DATA_PAYLOAD_LEN {
+        return Err(BleDataParseError::PayloadTooLong { len: payload_len });
+    }
+
+    let needed = 2 + payload_len + 3;
+    if pdu_crc.len() < needed {
+        return Err(BleDataParseError::Truncated {
+            needed,
+            actual: pdu_crc.len(),
+        });
+    }
+
+    let pdu = pdu_crc[..2 + payload_len].to_vec();
+    let crc_bytes = &pdu_crc[2 + payload_len..needed];
+    let received_crc =
+        crc_bytes[0] as u32 | ((crc_bytes[1] as u32) << 8) | ((crc_bytes[2] as u32) << 16);
+    let expected_crc = crc24_ble(&pdu, crc_init);
+    if expected_crc != received_crc {
+        return Err(BleDataParseError::InvalidCrc {
+            expected: expected_crc,
+            received: received_crc,
+        });
+    }
+
+    let header_byte = pdu[0];
+    Ok(BleDataPacket {
+        access_address,
+        channel_index,
+        phy,
+        header: BleDataHeader {
+            llid: BleDataLlid::from_header(header_byte),
+            nesn: header_byte & 0x04 != 0,
+            sn: header_byte & 0x08 != 0,
+            more_data: header_byte & 0x10 != 0,
+            cte_info_present: header_byte & 0x20 != 0,
+            payload_len,
+        },
+        payload: pdu[2..].to_vec(),
+        pdu,
+        crc: received_crc,
+    })
+}
+
+pub(crate) fn format_data_packet_summary(packet: &BleDataPacket) -> String {
+    format!(
+        "ch={} phy={} pdu=DATA aa=0x{:08X} llid={} payload_len={} nesn={} sn={} md={}",
+        packet.channel_index,
+        packet.phy.short_name(),
+        packet.access_address,
+        packet.header.llid,
+        packet.header.payload_len,
+        u8::from(packet.header.nesn),
+        u8::from(packet.header.sn),
+        u8::from(packet.header.more_data),
+    )
+}
+
+#[cfg(test)]
+pub(crate) fn build_data_pdu_crc(
+    channel_index: u8,
+    crc_init: u32,
+    header: u8,
+    payload: &[u8],
+) -> Vec<u8> {
+    let mut pdu = Vec::with_capacity(2 + payload.len() + 3);
+    pdu.push(header);
+    pdu.push(payload.len() as u8);
+    pdu.extend_from_slice(payload);
+    let crc = crc24_ble(&pdu, crc_init);
+    pdu.push((crc & 0xff) as u8);
+    pdu.push(((crc >> 8) & 0xff) as u8);
+    pdu.push(((crc >> 16) & 0xff) as u8);
+    apply_whitening(channel_index, &pdu).unwrap()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_connection_specific_data_pdu() {
+        let access_address = 0x1234_5678;
+        let crc_init = 0x00ab_cdef;
+        let payload = [0x03, 0x00, 0x04, 0x00];
+        let whitened = build_data_pdu_crc(0, crc_init, 0x1e, &payload);
+
+        let packet = parse_data_pdu(0, BlePhy::Le1M, access_address, crc_init, &whitened).unwrap();
+
+        assert_eq!(packet.access_address, access_address);
+        assert_eq!(packet.header.llid, BleDataLlid::StartOrComplete);
+        assert!(packet.header.nesn);
+        assert!(packet.header.sn);
+        assert!(packet.header.more_data);
+        assert_eq!(packet.payload, payload);
+        assert_eq!(
+            format_data_packet_summary(&packet),
+            "ch=0 phy=1M pdu=DATA aa=0x12345678 llid=start/complete payload_len=4 nesn=1 sn=1 md=1"
+        );
+    }
+
+    #[test]
+    fn rejects_wrong_connection_crc_init() {
+        let whitened = build_data_pdu_crc(12, 0x0012_3456, 0x01, &[]);
+
+        assert!(matches!(
+            parse_data_pdu(12, BlePhy::Le1M, 0x8765_4321, 0x0065_4321, &whitened),
+            Err(BleDataParseError::InvalidCrc { .. })
+        ));
+    }
+}

--- a/examples/bluetooth/src/ble_detector.rs
+++ b/examples/bluetooth/src/ble_detector.rs
@@ -1,0 +1,332 @@
+use crate::ble_protocol;
+
+const BLE_ACCESS_ADDRESS_INVERT: u32 = !ble_protocol::BLE_ACCESS_ADDRESS;
+const MAX_HAMMING_DISTANCE: u32 = 2;
+const BLE_CRC_LEN: usize = 3;
+const PDU_OFFSET_RADIUS_BITS: usize = 2;
+const PDU_OFFSET_COUNT: usize = PDU_OFFSET_RADIUS_BITS * 2 + 1;
+const BLE_MAX_PDU_CRC_BITS: usize = (2 + ble_protocol::BLE_MAX_ADV_PAYLOAD_LEN + BLE_CRC_LEN) * 8;
+const BLE_CAPTURE_WINDOW_BITS: usize = BLE_MAX_PDU_CRC_BITS + PDU_OFFSET_RADIUS_BITS * 2;
+
+fn print_diagnostics() -> bool {
+    cfg!(debug_assertions)
+}
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+enum PacketState {
+    SearchingAccessAddress,
+    CapturingCandidateWindow,
+}
+
+#[derive(Clone, Debug)]
+pub(crate) enum DetectorEvent {
+    None,
+    ValidPacket,
+    CrcRejected { reason: String },
+    HeaderRejected,
+}
+
+pub(crate) struct PacketDetector {
+    phase: usize,
+    shift_reg: u32,
+    state: PacketState,
+    candidate_bits: Vec<u8>,
+    channel_index: u8,
+    invert_signal: bool,
+    aa_candidates: u64,
+    header_rejects: u64,
+    packets: u64,
+    crc_rejects: u64,
+    duplicate_crc_rejects: u64,
+}
+
+impl PacketDetector {
+    pub(crate) fn new(phase: usize, channel_index: u8) -> Self {
+        Self {
+            phase,
+            shift_reg: 0,
+            state: PacketState::SearchingAccessAddress,
+            candidate_bits: Vec::new(),
+            channel_index,
+            invert_signal: false,
+            aa_candidates: 0,
+            header_rejects: 0,
+            packets: 0,
+            crc_rejects: 0,
+            duplicate_crc_rejects: 0,
+        }
+    }
+
+    pub(crate) fn process_symbol(&mut self, mut bit: u8) -> DetectorEvent {
+        if self.invert_signal {
+            bit ^= 1;
+        }
+
+        self.shift_reg = (self.shift_reg >> 1) | ((bit as u32) << 31);
+
+        match self.state {
+            PacketState::SearchingAccessAddress => self.search_access_address(),
+            PacketState::CapturingCandidateWindow => self.capture_candidate_bit(bit),
+        }
+    }
+
+    pub(crate) fn reset_to_search(&mut self) {
+        self.state = PacketState::SearchingAccessAddress;
+        self.invert_signal = false;
+        self.shift_reg = 0;
+        self.candidate_bits.clear();
+    }
+
+    pub(crate) fn add_crc_reject(&mut self) {
+        self.crc_rejects += 1;
+    }
+
+    pub(crate) fn add_duplicate_crc_reject(&mut self) {
+        self.duplicate_crc_rejects += 1;
+    }
+
+    pub(crate) fn stats(&self) -> DetectorStats {
+        DetectorStats {
+            aa_candidates: self.aa_candidates,
+            header_rejects: self.header_rejects,
+            packets: self.packets,
+            crc_rejects: self.crc_rejects,
+            duplicate_crc_rejects: self.duplicate_crc_rejects,
+        }
+    }
+
+    fn search_access_address(&mut self) -> DetectorEvent {
+        let window = self.shift_reg;
+        let diff_normal = (window ^ ble_protocol::BLE_ACCESS_ADDRESS).count_ones();
+        let diff_invert = (window ^ BLE_ACCESS_ADDRESS_INVERT).count_ones();
+
+        if diff_normal <= MAX_HAMMING_DISTANCE {
+            self.aa_candidates += 1;
+            if print_diagnostics() {
+                println!(
+                    "BLE access address caught: phase={} aa=0x{:08X} hamming={}",
+                    self.phase,
+                    ble_protocol::BLE_ACCESS_ADDRESS,
+                    diff_normal
+                );
+            }
+            self.start_packet_recovery(false);
+        } else if diff_invert <= MAX_HAMMING_DISTANCE {
+            self.aa_candidates += 1;
+            if print_diagnostics() {
+                println!(
+                    "BLE access address caught with inverted phase: phase={} aa=0x{:08X} hamming={}",
+                    self.phase,
+                    ble_protocol::BLE_ACCESS_ADDRESS,
+                    diff_invert
+                );
+            }
+            self.start_packet_recovery(true);
+        }
+
+        DetectorEvent::None
+    }
+
+    fn capture_candidate_bit(&mut self, bit: u8) -> DetectorEvent {
+        self.candidate_bits.push(bit);
+
+        if self.candidate_bits.len() < PDU_OFFSET_COUNT + 16 {
+            return DetectorEvent::None;
+        }
+
+        match self.try_candidate_offsets() {
+            CandidateWindowResult::NeedMoreBits => DetectorEvent::None,
+            CandidateWindowResult::HeaderRejected => {
+                self.header_rejects += 1;
+                if print_diagnostics() {
+                    println!(
+                        "BLE header rejected: phase={} no plausible offset",
+                        self.phase
+                    );
+                }
+                self.reset_to_search();
+                DetectorEvent::HeaderRejected
+            }
+            CandidateWindowResult::CrcRejected { reason } => {
+                self.reset_to_search();
+                DetectorEvent::CrcRejected { reason }
+            }
+            CandidateWindowResult::ValidPacket => {
+                self.packets += 1;
+                self.reset_to_search();
+                DetectorEvent::ValidPacket
+            }
+        }
+    }
+
+    fn try_candidate_offsets(&self) -> CandidateWindowResult {
+        let mut plausible = 0usize;
+        let mut max_needed = 0usize;
+        let mut last_error = None;
+
+        for offset in 0..PDU_OFFSET_COUNT {
+            let Some(needed_bits) = self.candidate_needed_bits(offset) else {
+                continue;
+            };
+
+            plausible += 1;
+            max_needed = max_needed.max(needed_bits);
+
+            if self.candidate_bits.len() < needed_bits {
+                continue;
+            }
+
+            let whitened_pdu_crc = bits_to_bytes(&self.candidate_bits[offset..needed_bits]);
+            match ble_protocol::parse_advertising_pdu(self.channel_index, &whitened_pdu_crc) {
+                Ok(packet) => {
+                    if print_diagnostics() {
+                        let relative_offset = offset as isize - PDU_OFFSET_RADIUS_BITS as isize;
+                        println!(
+                            "BLE packet: phase={} offset={} {}",
+                            self.phase,
+                            relative_offset,
+                            ble_protocol::format_packet_summary(&packet)
+                        );
+                    } else {
+                        println!(
+                            "BLE packet: {}",
+                            ble_protocol::format_packet_summary(&packet)
+                        );
+                    }
+                    return CandidateWindowResult::ValidPacket;
+                }
+                Err(err) => last_error = Some(err.to_string()),
+            }
+        }
+
+        if plausible == 0 && self.candidate_bits.len() >= PDU_OFFSET_COUNT + 16 {
+            return CandidateWindowResult::HeaderRejected;
+        }
+
+        if self.candidate_bits.len() >= BLE_CAPTURE_WINDOW_BITS
+            || (plausible > 0 && self.candidate_bits.len() >= max_needed)
+        {
+            return CandidateWindowResult::CrcRejected {
+                reason: last_error.unwrap_or_else(|| "candidate window did not pass CRC".into()),
+            };
+        }
+
+        CandidateWindowResult::NeedMoreBits
+    }
+
+    fn candidate_needed_bits(&self, offset: usize) -> Option<usize> {
+        if self.candidate_bits.len() < offset + 16 {
+            return None;
+        }
+
+        let header = bits_to_bytes(&self.candidate_bits[offset..offset + 16]);
+        let header = ble_protocol::apply_whitening(self.channel_index, &header).ok()?;
+        let payload_len = (header[1] & 0x3f) as usize;
+
+        if payload_len > ble_protocol::BLE_MAX_ADV_PAYLOAD_LEN {
+            return None;
+        }
+
+        Some(offset + (2 + payload_len + BLE_CRC_LEN) * 8)
+    }
+
+    fn start_packet_recovery(&mut self, invert: bool) {
+        self.state = PacketState::CapturingCandidateWindow;
+        self.invert_signal = invert;
+        self.candidate_bits.clear();
+
+        for bit_index in 32 - PDU_OFFSET_RADIUS_BITS..32 {
+            let mut bit = ((self.shift_reg >> bit_index) & 1) as u8;
+            if invert {
+                bit ^= 1;
+            }
+            self.candidate_bits.push(bit);
+        }
+    }
+}
+
+enum CandidateWindowResult {
+    NeedMoreBits,
+    HeaderRejected,
+    CrcRejected { reason: String },
+    ValidPacket,
+}
+
+fn bits_to_bytes(bits: &[u8]) -> Vec<u8> {
+    bits.chunks(8)
+        .map(|chunk| {
+            chunk
+                .iter()
+                .enumerate()
+                .fold(0u8, |byte, (bit_index, bit)| {
+                    byte | ((*bit & 1) << bit_index)
+                })
+        })
+        .collect()
+}
+
+#[derive(Clone, Copy, Debug, Default)]
+pub(crate) struct DetectorStats {
+    pub(crate) aa_candidates: u64,
+    pub(crate) header_rejects: u64,
+    pub(crate) packets: u64,
+    pub(crate) crc_rejects: u64,
+    pub(crate) duplicate_crc_rejects: u64,
+}
+
+impl DetectorStats {
+    pub(crate) fn pdu_attempts(&self) -> u64 {
+        self.packets + self.crc_rejects
+    }
+
+    pub(crate) fn aa_per_packet(&self) -> f64 {
+        if self.packets == 0 {
+            0.0
+        } else {
+            self.aa_candidates as f64 / self.packets as f64
+        }
+    }
+
+    pub(crate) fn crc_reject_rate(&self) -> f64 {
+        percentage(self.crc_rejects, self.pdu_attempts())
+    }
+
+    pub(crate) fn raw_crc_rejects(&self) -> u64 {
+        self.crc_rejects + self.duplicate_crc_rejects
+    }
+}
+
+fn percentage(numerator: u64, denominator: u64) -> f64 {
+    if denominator == 0 {
+        0.0
+    } else {
+        numerator as f64 * 100.0 / denominator as f64
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::DetectorStats;
+    use super::bits_to_bytes;
+
+    #[test]
+    fn stats_report_reject_rates() {
+        let stats = DetectorStats {
+            aa_candidates: 10,
+            header_rejects: 2,
+            packets: 4,
+            crc_rejects: 4,
+            duplicate_crc_rejects: 2,
+        };
+
+        assert_eq!(stats.pdu_attempts(), 8);
+        assert_eq!(stats.aa_per_packet(), 2.5);
+        assert_eq!(stats.crc_reject_rate(), 50.0);
+        assert_eq!(stats.raw_crc_rejects(), 6);
+    }
+
+    #[test]
+    fn converts_lsb_first_bits_to_bytes() {
+        assert_eq!(bits_to_bytes(&[0, 1, 1, 0, 1, 1, 0, 1]), [0xb6]);
+    }
+}

--- a/examples/bluetooth/src/ble_detector.rs
+++ b/examples/bluetooth/src/ble_detector.rs
@@ -9,9 +9,7 @@ const PDU_OFFSET_COUNT: usize = PDU_OFFSET_RADIUS_BITS * 2 + 1;
 const BLE_MAX_PDU_CRC_BITS: usize = (2 + ble_protocol::BLE_MAX_ADV_PAYLOAD_LEN + BLE_CRC_LEN) * 8;
 const BLE_CAPTURE_WINDOW_BITS: usize = BLE_MAX_PDU_CRC_BITS + PDU_OFFSET_RADIUS_BITS * 2;
 
-fn print_diagnostics() -> bool {
-    cfg!(debug_assertions)
-}
+use crate::diagnostics;
 
 #[derive(Clone, Copy, Debug, PartialEq)]
 enum PacketState {
@@ -113,7 +111,7 @@ impl PacketDetector {
 
         if diff_normal <= MAX_HAMMING_DISTANCE {
             self.aa_candidates += 1;
-            if print_diagnostics() {
+            if self.print_packets && diagnostics::enabled() {
                 println!(
                     "BLE access address caught: phase={} aa=0x{:08X} hamming={}",
                     self.phase,
@@ -124,7 +122,7 @@ impl PacketDetector {
             self.start_packet_recovery(false);
         } else if diff_invert <= MAX_HAMMING_DISTANCE {
             self.aa_candidates += 1;
-            if print_diagnostics() {
+            if self.print_packets && diagnostics::enabled() {
                 println!(
                     "BLE access address caught with inverted phase: phase={} aa=0x{:08X} hamming={}",
                     self.phase,
@@ -149,7 +147,7 @@ impl PacketDetector {
             CandidateWindowResult::NeedMoreBits => DetectorEvent::None,
             CandidateWindowResult::HeaderRejected => {
                 self.header_rejects += 1;
-                if print_diagnostics() {
+                if self.print_packets && diagnostics::enabled() {
                     println!(
                         "BLE header rejected: phase={} no plausible offset",
                         self.phase
@@ -193,7 +191,7 @@ impl PacketDetector {
             let whitened_pdu_crc = bits_to_bytes(&self.candidate_bits[offset..needed_bits]);
             match ble_protocol::parse_advertising_pdu(self.channel_index, &whitened_pdu_crc) {
                 Ok(packet) => {
-                    if self.print_packets && print_diagnostics() {
+                    if self.print_packets && diagnostics::enabled() {
                         let relative_offset = offset as isize - PDU_OFFSET_RADIUS_BITS as isize;
                         println!(
                             "BLE packet: phase={} offset={} {}",
@@ -290,6 +288,15 @@ pub(crate) struct DetectorStats {
 }
 
 impl DetectorStats {
+    pub(crate) fn merge(&mut self, other: Self) {
+        self.aa_candidates += other.aa_candidates;
+        self.header_rejects += other.header_rejects;
+        self.packets += other.packets;
+        self.crc_rejects += other.crc_rejects;
+        self.duplicate_crc_rejects += other.duplicate_crc_rejects;
+        self.connect_ind_packets += other.connect_ind_packets;
+    }
+
     pub(crate) fn pdu_attempts(&self) -> u64 {
         self.packets + self.crc_rejects
     }
@@ -302,8 +309,8 @@ impl DetectorStats {
         }
     }
 
-    pub(crate) fn crc_reject_rate(&self) -> f64 {
-        percentage(self.crc_rejects, self.pdu_attempts())
+    pub(crate) fn crc_pass_rate(&self) -> f64 {
+        percentage(self.packets, self.pdu_attempts())
     }
 
     pub(crate) fn raw_crc_rejects(&self) -> u64 {
@@ -325,7 +332,7 @@ mod tests {
     use super::bits_to_bytes;
 
     #[test]
-    fn stats_report_reject_rates() {
+    fn stats_report_crc_rates() {
         let stats = DetectorStats {
             aa_candidates: 10,
             header_rejects: 2,
@@ -337,7 +344,7 @@ mod tests {
 
         assert_eq!(stats.pdu_attempts(), 8);
         assert_eq!(stats.aa_per_packet(), 2.5);
-        assert_eq!(stats.crc_reject_rate(), 50.0);
+        assert_eq!(stats.crc_pass_rate(), 50.0);
         assert_eq!(stats.raw_crc_rejects(), 6);
     }
 

--- a/examples/bluetooth/src/ble_detector.rs
+++ b/examples/bluetooth/src/ble_detector.rs
@@ -1,4 +1,5 @@
 use crate::ble_protocol;
+use crate::ble_protocol::BlePacket;
 
 const BLE_ACCESS_ADDRESS_INVERT: u32 = !ble_protocol::BLE_ACCESS_ADDRESS;
 const MAX_HAMMING_DISTANCE: u32 = 2;
@@ -21,7 +22,7 @@ enum PacketState {
 #[derive(Clone, Debug)]
 pub(crate) enum DetectorEvent {
     None,
-    ValidPacket,
+    ValidPacket { packet: BlePacket },
     CrcRejected { reason: String },
     HeaderRejected,
 }
@@ -38,10 +39,17 @@ pub(crate) struct PacketDetector {
     packets: u64,
     crc_rejects: u64,
     duplicate_crc_rejects: u64,
+    connect_ind_packets: u64,
+    print_packets: bool,
 }
 
 impl PacketDetector {
+    #[cfg(test)]
     pub(crate) fn new(phase: usize, channel_index: u8) -> Self {
+        Self::with_packet_output(phase, channel_index, true)
+    }
+
+    pub(crate) fn with_packet_output(phase: usize, channel_index: u8, print_packets: bool) -> Self {
         Self {
             phase,
             shift_reg: 0,
@@ -54,6 +62,8 @@ impl PacketDetector {
             packets: 0,
             crc_rejects: 0,
             duplicate_crc_rejects: 0,
+            connect_ind_packets: 0,
+            print_packets,
         }
     }
 
@@ -92,6 +102,7 @@ impl PacketDetector {
             packets: self.packets,
             crc_rejects: self.crc_rejects,
             duplicate_crc_rejects: self.duplicate_crc_rejects,
+            connect_ind_packets: self.connect_ind_packets,
         }
     }
 
@@ -151,10 +162,13 @@ impl PacketDetector {
                 self.reset_to_search();
                 DetectorEvent::CrcRejected { reason }
             }
-            CandidateWindowResult::ValidPacket => {
+            CandidateWindowResult::ValidPacket { packet } => {
                 self.packets += 1;
+                if packet.pdu_type == ble_protocol::BleAdvPduType::ConnectInd {
+                    self.connect_ind_packets += 1;
+                }
                 self.reset_to_search();
-                DetectorEvent::ValidPacket
+                DetectorEvent::ValidPacket { packet }
             }
         }
     }
@@ -179,7 +193,7 @@ impl PacketDetector {
             let whitened_pdu_crc = bits_to_bytes(&self.candidate_bits[offset..needed_bits]);
             match ble_protocol::parse_advertising_pdu(self.channel_index, &whitened_pdu_crc) {
                 Ok(packet) => {
-                    if print_diagnostics() {
+                    if self.print_packets && print_diagnostics() {
                         let relative_offset = offset as isize - PDU_OFFSET_RADIUS_BITS as isize;
                         println!(
                             "BLE packet: phase={} offset={} {}",
@@ -187,13 +201,13 @@ impl PacketDetector {
                             relative_offset,
                             ble_protocol::format_packet_summary(&packet)
                         );
-                    } else {
+                    } else if self.print_packets {
                         println!(
                             "BLE packet: {}",
                             ble_protocol::format_packet_summary(&packet)
                         );
                     }
-                    return CandidateWindowResult::ValidPacket;
+                    return CandidateWindowResult::ValidPacket { packet };
                 }
                 Err(err) => last_error = Some(err.to_string()),
             }
@@ -249,7 +263,7 @@ enum CandidateWindowResult {
     NeedMoreBits,
     HeaderRejected,
     CrcRejected { reason: String },
-    ValidPacket,
+    ValidPacket { packet: BlePacket },
 }
 
 fn bits_to_bytes(bits: &[u8]) -> Vec<u8> {
@@ -272,6 +286,7 @@ pub(crate) struct DetectorStats {
     pub(crate) packets: u64,
     pub(crate) crc_rejects: u64,
     pub(crate) duplicate_crc_rejects: u64,
+    pub(crate) connect_ind_packets: u64,
 }
 
 impl DetectorStats {
@@ -317,6 +332,7 @@ mod tests {
             packets: 4,
             crc_rejects: 4,
             duplicate_crc_rejects: 2,
+            connect_ind_packets: 1,
         };
 
         assert_eq!(stats.pdu_attempts(), 8);

--- a/examples/bluetooth/src/ble_iq_burst.rs
+++ b/examples/bluetooth/src/ble_iq_burst.rs
@@ -1,27 +1,39 @@
 use futuresdr::num_complex::Complex32;
 use futuresdr::runtime::dev::prelude::*;
 
-use crate::ble_connection::ConnectionTable;
+use crate::ble_burst_catcher::BurstCatcher;
+use crate::ble_burst_catcher::CapturedBurst;
+use crate::ble_burst_catcher::PRE_TRIGGER_SYMBOLS;
+use crate::ble_burst_decoder::BurstDecodeOutcome;
+use crate::ble_burst_decoder::BurstDecodeResult;
+use crate::ble_burst_decoder::BurstDecoder;
+use crate::ble_burst_decoder::UnsupportedPhy;
+use crate::ble_burst_stats::BurstStats;
+use crate::ble_connection::SharedConnectionTable;
 use crate::ble_connection::format_connection_summary;
-use crate::ble_detector::DetectorEvent;
-use crate::ble_detector::DetectorStats;
-use crate::ble_detector::PacketDetector;
+use crate::ble_connection_follower::format_planned_events;
+use crate::ble_connection_report::format_control_summary;
+use crate::ble_connection_report::format_tracking_summary;
+use crate::ble_data::BleDataPacket;
+use crate::ble_data::format_data_packet_summary;
 use crate::ble_protocol::BlePacket;
+use crate::ble_protocol::BlePhy;
 use crate::ble_wireshark;
+use crate::diagnostics;
 
-const AGC_ALPHA: f32 = 0.25;
-const SQUELCH_TIMEOUT_SAMPLES: usize = 100;
-const BURST_START_CAPACITY: usize = 2048;
-const MIN_BURST_SAMPLES: usize = 96;
-const MAX_BURST_SAMPLES: usize = 8192;
-const CFO_MEDIAN_SYMBOLS: usize = 64;
-const MAX_FREQ_OFFSET: f32 = 0.85;
+pub use crate::ble_burst_catcher::SquelchConfig;
 
-fn print_diagnostics() -> bool {
-    cfg!(debug_assertions)
+const FOLLOW_GUARD_SYMBOLS: u64 = 2_048;
+
+#[derive(Clone, Copy, Debug, Default)]
+pub(crate) struct BleIqBurstOptions {
+    pub(crate) print_packets: bool,
+    pub(crate) wireshark_output: bool,
+    pub(crate) follow_connections: bool,
 }
 
 #[derive(Block)]
+#[message_inputs(rx_overflow)]
 #[message_outputs(wireshark)]
 pub struct BleIqBurstBlock<I = DefaultCpuReader<Complex32>, O = DefaultCpuWriter<u8>>
 where
@@ -32,13 +44,15 @@ where
     input: I,
     #[output]
     output: O,
-    samples_per_symbol: usize,
     channel_index: u8,
+    sample_rate_hz: u64,
     print_packets: bool,
     wireshark_output: bool,
+    follow_connections: bool,
+    decoder: BurstDecoder,
     catcher: BurstCatcher,
     stats: BurstStats,
-    connections: ConnectionTable,
+    connections: SharedConnectionTable,
 }
 
 impl<I, O> BleIqBurstBlock<I, O>
@@ -47,104 +61,321 @@ where
     O: CpuBufferWriter<Item = u8>,
 {
     pub fn with_packet_and_wireshark_output(
+        phy: BlePhy,
         samples_per_symbol: usize,
         channel_index: u8,
-        squelch_db: f32,
-        print_packets: bool,
-        wireshark_output: bool,
-    ) -> Self {
-        Self {
+        filter_taps: Vec<f32>,
+        squelch: SquelchConfig,
+        options: BleIqBurstOptions,
+    ) -> std::result::Result<Self, UnsupportedPhy> {
+        let samples_per_symbol = samples_per_symbol.max(1);
+        let filter_history = filter_taps.len().saturating_sub(1);
+        Ok(Self {
             input: I::default(),
             output: O::default(),
-            samples_per_symbol: samples_per_symbol.max(1),
             channel_index,
-            print_packets,
-            wireshark_output,
-            catcher: BurstCatcher::new(squelch_db),
-            stats: BurstStats::default(),
-            connections: ConnectionTable::default(),
-        }
+            sample_rate_hz: phy.symbol_rate_hz() as u64 * samples_per_symbol as u64,
+            print_packets: options.print_packets,
+            wireshark_output: options.wireshark_output,
+            follow_connections: options.follow_connections,
+            decoder: BurstDecoder::new(phy, samples_per_symbol, channel_index, filter_taps)?,
+            catcher: BurstCatcher::new(
+                squelch,
+                filter_history + PRE_TRIGGER_SYMBOLS * samples_per_symbol,
+            ),
+            stats: BurstStats::new(samples_per_symbol),
+            connections: SharedConnectionTable::default(),
+        })
     }
 
-    fn process_burst(&mut self, burst: Vec<Complex32>) -> Vec<BlePacket> {
-        self.stats.bursts += 1;
+    pub(crate) fn with_connections(mut self, connections: SharedConnectionTable) -> Self {
+        self.connections = connections;
+        self
+    }
 
-        if burst.len() < MIN_BURST_SAMPLES {
-            self.stats.short_bursts += 1;
-            return Vec::new();
+    async fn rx_overflow(
+        &mut self,
+        _io: &mut WorkIo,
+        _mo: &mut MessageOutputs,
+        _meta: &mut BlockMeta,
+        p: Pmt,
+    ) -> Result<Pmt> {
+        let Pmt::U64(sequence) = p else {
+            return Ok(Pmt::InvalidValue);
+        };
+        self.connections.observe_overflow(sequence);
+        Ok(Pmt::Ok)
+    }
+
+    fn process_burst(&mut self, burst: CapturedBurst) -> ProcessedBurst {
+        let burst_start_sample = burst.start_sample_index;
+        self.stats.bursts += 1;
+        self.stats.total_burst_samples += burst.samples.len() as u64;
+        self.stats.max_burst_samples = self.stats.max_burst_samples.max(burst.samples.len());
+        self.stats.forced_closes += u64::from(burst.forced_close);
+
+        let burst_end_sample =
+            burst_start_sample.saturating_add(burst.samples.len().saturating_sub(1) as u64);
+        let connections = if self.follow_connections {
+            let selection = self.connections.decode_contexts_for_window(
+                self.channel_index,
+                burst_start_sample,
+                burst_end_sample,
+                FOLLOW_GUARD_SYMBOLS * self.decoder.samples_per_symbol() as u64,
+            );
+            self.stats.follower_locked_checks += selection.locked_checks;
+            self.stats.follower_window_matches += selection.window_matches;
+            self.stats.follower_searching_checks += selection.searching_checks;
+            selection.contexts
+        } else {
+            self.connections.decode_contexts()
+        };
+        if should_gate_data_burst(
+            self.follow_connections,
+            self.channel_index,
+            connections.len(),
+        ) {
+            self.stats.gated_bursts += 1;
+            return ProcessedBurst::default();
         }
 
-        let Some(demod) = demodulate_burst(&burst, self.samples_per_symbol) else {
-            self.stats.fsk_rejects += 1;
-            return Vec::new();
-        };
+        let decode_advertising = !self.follow_connections || self.channel_index >= 37;
+        let diagnostics = self.print_packets && diagnostics::enabled();
+        let result =
+            match self
+                .decoder
+                .decode(&burst, &connections, decode_advertising, diagnostics)
+            {
+                BurstDecodeOutcome::Short => {
+                    self.stats.short_bursts += 1;
+                    return ProcessedBurst::default();
+                }
+                BurstDecodeOutcome::FskRejected => {
+                    self.stats.fsk_rejects += 1;
+                    return ProcessedBurst::default();
+                }
+                BurstDecodeOutcome::Decoded(result) => result,
+            };
 
-        let mut burst_stats = DetectorStats::default();
-        let mut decoded = false;
-        let mut packets = Vec::new();
+        let BurstDecodeResult {
+            candidates,
+            detector_stats,
+            phase_valid_packets,
+            phase_only_packets,
+            phase_duplicates,
+            data,
+        } = result;
 
-        for phase in 0..self.samples_per_symbol {
-            let mut detector =
-                PacketDetector::with_packet_output(phase, self.channel_index, self.print_packets);
+        if self.channel_index >= 37 {
+            self.stats
+                .observe_crc_burst(!candidates.is_empty(), detector_stats.crc_rejects);
+        } else {
+            self.stats
+                .observe_crc_burst(!data.candidates.is_empty(), data.crc_rejects);
+        }
 
-            for value in demod.iter().skip(phase).step_by(self.samples_per_symbol) {
-                match detector.process_symbol(u8::from(*value > 0.0)) {
-                    DetectorEvent::None | DetectorEvent::HeaderRejected => {}
-                    DetectorEvent::ValidPacket { packet } => {
-                        self.connections.observe_packet(&packet);
-                        packets.push(packet);
-                        decoded = true;
-                        break;
-                    }
-                    DetectorEvent::CrcRejected { reason } => {
-                        detector.add_crc_reject();
-                        if print_diagnostics() {
-                            println!("BLE burst candidate rejected: phase={phase} {reason}");
-                        }
+        add_phase_counts(&mut self.stats.phase_valid_packets, &phase_valid_packets);
+        add_phase_counts(&mut self.stats.phase_only_packets, &phase_only_packets);
+        self.stats.phase_duplicates += phase_duplicates;
+
+        let advertising: Vec<_> = candidates
+            .into_iter()
+            .map(|candidate| {
+                if self.print_packets {
+                    if diagnostics {
+                        println!(
+                            "BLE packet: phase={} sample={} {}",
+                            candidate.phase,
+                            candidate.sample_index,
+                            crate::ble_protocol::format_packet_summary(&candidate.packet)
+                        );
+                    } else {
+                        println!(
+                            "BLE packet: {}",
+                            crate::ble_protocol::format_packet_summary(&candidate.packet)
+                        );
                     }
                 }
-            }
+                self.connections.observe_packet_at(
+                    &candidate.packet,
+                    burst_start_sample + candidate.sample_index as u64,
+                    self.sample_rate_hz,
+                );
+                candidate.packet
+            })
+            .collect();
 
-            add_stats(&mut burst_stats, detector.stats());
+        let data_packets: Vec<_> = data
+            .candidates
+            .into_iter()
+            .map(|candidate| {
+                let event = self.connections.observe_data_packet_at(
+                    &candidate.packet,
+                    burst_start_sample + candidate.sample_index as u64,
+                    self.sample_rate_hz,
+                );
+                let event_summary = event
+                    .map(|event| {
+                        let event_label = if event.counter_exact {
+                            "event"
+                        } else {
+                            "event_phase"
+                        };
+                        format!(
+                            " {event_label}={} hop_ch={}",
+                            event.event_counter, event.channel_index
+                        )
+                    })
+                    .unwrap_or_default();
+                if self.print_packets {
+                    if diagnostics {
+                        println!(
+                            "BLE data packet: phase={} sample={} {}{}",
+                            candidate.phase,
+                            candidate.sample_index,
+                            format_data_packet_summary(&candidate.packet),
+                            event_summary,
+                        );
+                    } else {
+                        println!(
+                            "BLE data packet: {}{}",
+                            format_data_packet_summary(&candidate.packet),
+                            event_summary,
+                        );
+                    }
+                }
+                candidate.packet
+            })
+            .collect();
 
-            if decoded {
-                break;
-            }
-        }
-
-        add_stats(&mut self.stats.detector, burst_stats);
-        if decoded {
+        self.stats.detector.merge(detector_stats);
+        self.stats.data_packets += data_packets.len() as u64;
+        self.stats.data_aa_candidates += data.aa_candidates;
+        self.stats.data_crc_rejects += data.crc_rejects;
+        self.stats.data_phase_duplicates += data.phase_duplicates;
+        let packet_count = advertising.len() + data_packets.len();
+        if packet_count > 0 {
             self.stats.decoded_bursts += 1;
         }
+        if packet_count > 1 {
+            self.stats.multi_packet_bursts += 1;
+        }
 
-        packets
+        ProcessedBurst {
+            advertising,
+            data: data_packets,
+        }
     }
 
     fn print_stats(&self) {
         let stats = self.stats.detector;
-        println!(
-            "BLE burst stats: ch={} bursts={} decoded_bursts={} short_bursts={} fsk_rejects={} packets={} connect_ind={} connections={} aa_candidates={} aa_per_packet={:.2} header_rejects={} pdu_attempts={} crc_rejects={} crc_reject_rate={:.1}%",
-            self.channel_index,
-            self.stats.bursts,
-            self.stats.decoded_bursts,
-            self.stats.short_bursts,
-            self.stats.fsk_rejects,
-            stats.packets,
-            stats.connect_ind_packets,
-            self.connections.len(),
-            stats.aa_candidates,
-            stats.aa_per_packet(),
-            stats.header_rejects,
-            stats.pdu_attempts(),
-            stats.crc_rejects,
-            stats.crc_reject_rate(),
-        );
-        for connection in self.connections.iter() {
+        let diagnostics = self.print_packets && diagnostics::enabled();
+        if self.channel_index >= 37 {
             println!(
-                "BLE connection: ch={} {}",
+                "BLE summary: ch={} mode=burst packets={} connect_ind={} crc_passes={} crc_checks={} crc_pass_rate={:.1}%",
                 self.channel_index,
-                format_connection_summary(connection)
+                stats.packets,
+                stats.connect_ind_packets,
+                self.stats.crc_pass_bursts,
+                self.stats.burst_crc_checks(),
+                self.stats.burst_crc_pass_rate(),
             );
+        } else {
+            println!(
+                "BLE summary: ch={} mode=burst data_packets={} crc_passes={} crc_checks={} crc_pass_rate={:.1}% gated_bursts={}",
+                self.channel_index,
+                self.stats.data_packets,
+                self.stats.crc_pass_bursts,
+                self.stats.burst_crc_checks(),
+                self.stats.burst_crc_pass_rate(),
+                self.stats.gated_bursts,
+            );
+        }
+
+        if diagnostics && self.channel_index >= 37 {
+            println!(
+                "BLE detector diagnostics: ch={} aa_candidates={} header_rejects={} valid_phase_candidates={} phase_duplicates={} phase_only_packets={:?} candidate_crc_checks={} candidate_crc_rejects={} candidate_crc_reject_rate={:.1}%",
+                self.channel_index,
+                stats.aa_candidates,
+                stats.header_rejects,
+                self.stats.advertising_valid_candidates(),
+                self.stats.phase_duplicates,
+                self.stats.phase_only_packets,
+                self.stats.advertising_candidate_crc_checks(),
+                stats.crc_rejects,
+                self.stats.advertising_candidate_crc_reject_rate(),
+            );
+        }
+        if diagnostics && self.channel_index < 37 {
+            println!(
+                "BLE detector diagnostics: ch={} aa_candidates={} valid_phase_candidates={} phase_duplicates={} candidate_crc_checks={} candidate_crc_rejects={} candidate_crc_reject_rate={:.1}%",
+                self.channel_index,
+                self.stats.data_aa_candidates,
+                self.stats.data_valid_candidates(),
+                self.stats.data_phase_duplicates,
+                self.stats.data_candidate_crc_checks(),
+                self.stats.data_crc_rejects,
+                self.stats.data_candidate_crc_reject_rate(),
+            );
+        }
+        if diagnostics && self.follow_connections {
+            println!(
+                "BLE follower diagnostics: ch={} locked_checks={} window_matches={} skipped={} searching_checks={}",
+                self.channel_index,
+                self.stats.follower_locked_checks,
+                self.stats.follower_window_matches,
+                self.stats
+                    .follower_locked_checks
+                    .saturating_sub(self.stats.follower_window_matches),
+                self.stats.follower_searching_checks,
+            );
+        }
+        if diagnostics {
+            println!(
+                "BLE burst diagnostics: ch={} bursts={} gated_bursts={} decoded_bursts={} short_bursts={} fsk_rejects={} mean_samples={:.1} max_samples={} forced_closes={} multi_packet_bursts={} packets_per_burst={:.2}",
+                self.channel_index,
+                self.stats.bursts,
+                self.stats.gated_bursts,
+                self.stats.decoded_bursts,
+                self.stats.short_bursts,
+                self.stats.fsk_rejects,
+                self.stats.mean_burst_samples(),
+                self.stats.max_burst_samples,
+                self.stats.forced_closes,
+                self.stats.multi_packet_bursts,
+                self.stats.packets_per_burst(),
+            );
+            println!(
+                "BLE squelch diagnostics: ch={} {}",
+                self.channel_index,
+                self.catcher.summary()
+            );
+        }
+
+        if self.connections.finish_reporter() {
+            if diagnostics {
+                for connection in self.connections.snapshot() {
+                    println!(
+                        "BLE connection: ch={} {}",
+                        connection.first_channel,
+                        format_connection_summary(&connection)
+                    );
+                }
+                for plan in self.connections.follow_plans(8) {
+                    println!(
+                        "BLE follow plan: aa=0x{:08X} next_events=[{}]",
+                        plan.access_address,
+                        format_planned_events(&plan.events)
+                    );
+                }
+            }
+            let summary = self.connections.tracking_summary();
+            if self.follow_connections || summary.connect_ind_seen > 0 {
+                println!("BLE tracking summary: {}", format_tracking_summary(summary));
+            }
+            if let Some(control) = format_control_summary(summary) {
+                println!("BLE control summary: {control}");
+            }
         }
     }
 }
@@ -194,7 +425,7 @@ where
     }
 
     async fn deinit(&mut self, _mo: &mut MessageOutputs, _meta: &mut BlockMeta) -> Result<()> {
-        if let Some(burst) = self.catcher.finish() {
+        if let Some(burst) = self.catcher.finish(false) {
             let packets = self.process_burst(burst);
             if self.wireshark_output {
                 post_wireshark_packets(_mo, &packets).await?;
@@ -208,11 +439,24 @@ where
     }
 }
 
-async fn post_wireshark_packets(mo: &mut MessageOutputs, packets: &[BlePacket]) -> Result<()> {
-    for packet in packets {
+#[derive(Default)]
+struct ProcessedBurst {
+    advertising: Vec<BlePacket>,
+    data: Vec<BleDataPacket>,
+}
+
+async fn post_wireshark_packets(mo: &mut MessageOutputs, packets: &ProcessedBurst) -> Result<()> {
+    for packet in &packets.advertising {
         mo.post(
             "wireshark",
             Pmt::Blob(ble_wireshark::packet_to_udp_payload(packet)),
+        )
+        .await?;
+    }
+    for packet in &packets.data {
+        mo.post(
+            "wireshark",
+            Pmt::Blob(ble_wireshark::data_packet_to_udp_payload(packet)),
         )
         .await?;
     }
@@ -220,229 +464,29 @@ async fn post_wireshark_packets(mo: &mut MessageOutputs, packets: &[BlePacket]) 
     Ok(())
 }
 
-#[derive(Default)]
-struct BurstStats {
-    bursts: u64,
-    decoded_bursts: u64,
-    short_bursts: u64,
-    fsk_rejects: u64,
-    detector: DetectorStats,
+fn should_gate_data_burst(
+    follow_connections: bool,
+    channel_index: u8,
+    connection_count: usize,
+) -> bool {
+    follow_connections && channel_index < 37 && connection_count == 0
 }
 
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-enum SquelchState {
-    SignalLo,
-    Rise,
-    SignalHi,
-    Timeout,
-}
-
-struct BurstCatcher {
-    gain: f32,
-    signal_level: f32,
-    squelch_db: f32,
-    state: SquelchState,
-    timer: usize,
-    burst_buf: Vec<Complex32>,
-    capturing: bool,
-}
-
-impl BurstCatcher {
-    fn new(squelch_db: f32) -> Self {
-        Self {
-            gain: 1000.0,
-            signal_level: 1e-3,
-            squelch_db,
-            state: SquelchState::SignalLo,
-            timer: 0,
-            burst_buf: Vec::new(),
-            capturing: false,
-        }
+fn add_phase_counts(accumulator: &mut [u64], counts: &[u64]) {
+    for (accumulator, count) in accumulator.iter_mut().zip(counts) {
+        *accumulator += count;
     }
-
-    fn execute(&mut self, sample: Complex32) -> Option<Vec<Complex32>> {
-        let (sample, state) = self.agc_and_squelch(sample);
-
-        match state {
-            SquelchState::Rise => {
-                self.burst_buf = Vec::with_capacity(BURST_START_CAPACITY);
-                self.burst_buf.push(sample);
-                self.capturing = true;
-                None
-            }
-            SquelchState::SignalHi => {
-                if self.capturing && self.burst_buf.len() < MAX_BURST_SAMPLES {
-                    self.burst_buf.push(sample);
-                }
-                None
-            }
-            SquelchState::Timeout => self.finish(),
-            SquelchState::SignalLo => None,
-        }
-    }
-
-    fn finish(&mut self) -> Option<Vec<Complex32>> {
-        if self.capturing && !self.burst_buf.is_empty() {
-            self.capturing = false;
-            Some(std::mem::take(&mut self.burst_buf))
-        } else {
-            self.capturing = false;
-            None
-        }
-    }
-
-    fn agc_and_squelch(&mut self, input: Complex32) -> (Complex32, SquelchState) {
-        let output = input * self.gain;
-        let level = output.norm();
-        self.signal_level = AGC_ALPHA * level + (1.0 - AGC_ALPHA) * self.signal_level;
-
-        if self.signal_level > 1e-6 {
-            self.gain *= (-0.5 * AGC_ALPHA * self.signal_level.ln()).exp();
-            self.gain = self.gain.clamp(1e-6, 1e6);
-        }
-
-        let rssi_db = -20.0 * self.gain.log10();
-        let above_threshold = rssi_db > self.squelch_db;
-
-        self.state = match self.state {
-            SquelchState::SignalLo => {
-                if above_threshold {
-                    SquelchState::Rise
-                } else {
-                    SquelchState::SignalLo
-                }
-            }
-            SquelchState::Rise => {
-                if above_threshold {
-                    self.timer = 0;
-                    SquelchState::SignalHi
-                } else {
-                    self.timer = 0;
-                    SquelchState::SignalLo
-                }
-            }
-            SquelchState::SignalHi => {
-                if above_threshold {
-                    self.timer = 0;
-                    SquelchState::SignalHi
-                } else {
-                    self.timer += 1;
-                    if self.timer >= SQUELCH_TIMEOUT_SAMPLES {
-                        SquelchState::Timeout
-                    } else {
-                        SquelchState::SignalHi
-                    }
-                }
-            }
-            SquelchState::Timeout => {
-                if above_threshold {
-                    SquelchState::Rise
-                } else {
-                    SquelchState::SignalLo
-                }
-            }
-        };
-
-        (output, self.state)
-    }
-}
-
-fn demodulate_burst(samples: &[Complex32], samples_per_symbol: usize) -> Option<Vec<f32>> {
-    if samples.len() < 8 + samples_per_symbol * CFO_MEDIAN_SYMBOLS {
-        return None;
-    }
-
-    let mut demod = Vec::with_capacity(samples.len().saturating_sub(1));
-    let mut prev = samples[0];
-    for &sample in &samples[1..] {
-        demod.push((sample * prev.conj()).arg() * std::f32::consts::FRAC_1_PI);
-        prev = sample;
-    }
-
-    let (cfo, deviation) = estimate_cfo_and_deviation(&demod, samples_per_symbol)?;
-    for value in &mut demod {
-        *value = (*value - cfo) / deviation;
-    }
-
-    Some(demod)
-}
-
-fn estimate_cfo_and_deviation(demod: &[f32], samples_per_symbol: usize) -> Option<(f32, f32)> {
-    let end = 8 + samples_per_symbol * CFO_MEDIAN_SYMBOLS;
-    if end > demod.len() {
-        return None;
-    }
-
-    let mut pos = Vec::with_capacity(samples_per_symbol * CFO_MEDIAN_SYMBOLS);
-    let mut neg = Vec::with_capacity(samples_per_symbol * CFO_MEDIAN_SYMBOLS);
-
-    for &value in &demod[8..end] {
-        if value.abs() > MAX_FREQ_OFFSET {
-            return None;
-        }
-        if value > 0.0 {
-            pos.push(value);
-        } else if value < 0.0 {
-            neg.push(value);
-        }
-    }
-
-    if pos.len() < CFO_MEDIAN_SYMBOLS / 4 || neg.len() < CFO_MEDIAN_SYMBOLS / 4 {
-        return None;
-    }
-
-    pos.sort_unstable_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
-    neg.sort_unstable_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
-
-    let high = pos[pos.len() * 3 / 4];
-    let low = neg[neg.len() / 4];
-    let cfo = (high + low) * 0.5;
-    let deviation = (high - cfo).abs();
-
-    if deviation < 1e-6 {
-        None
-    } else {
-        Some((cfo, deviation))
-    }
-}
-
-fn add_stats(acc: &mut DetectorStats, stats: DetectorStats) {
-    acc.aa_candidates += stats.aa_candidates;
-    acc.header_rejects += stats.header_rejects;
-    acc.packets += stats.packets;
-    acc.crc_rejects += stats.crc_rejects;
-    acc.duplicate_crc_rejects += stats.duplicate_crc_rejects;
-    acc.connect_ind_packets += stats.connect_ind_packets;
 }
 
 #[cfg(test)]
 mod tests {
-    use super::demodulate_burst;
-    use crate::ble_detector::DetectorEvent;
-    use crate::ble_detector::PacketDetector;
-    use crate::ble_sim::generate_ble_packet_samples;
+    use super::should_gate_data_burst;
 
     #[test]
-    fn demodulates_simulated_burst() {
-        let samples = generate_ble_packet_samples(2, 1, 37);
-        let burst: Vec<_> = samples
-            .into_iter()
-            .filter(|sample| sample.norm() > 0.0)
-            .collect();
-        let demod = demodulate_burst(&burst, 2).unwrap();
-        let mut detector = PacketDetector::new(0, 37);
-
-        let mut decoded = false;
-        for value in demod.iter().step_by(2) {
-            if matches!(
-                detector.process_symbol(u8::from(*value > 0.0)),
-                DetectorEvent::ValidPacket { .. }
-            ) {
-                decoded = true;
-                break;
-            }
-        }
-
-        assert!(decoded);
+    fn gates_unmatched_follower_data_bursts() {
+        assert!(should_gate_data_burst(true, 0, 0));
+        assert!(!should_gate_data_burst(true, 0, 1));
+        assert!(!should_gate_data_burst(true, 37, 0));
+        assert!(!should_gate_data_burst(false, 0, 0));
     }
 }

--- a/examples/bluetooth/src/ble_iq_burst.rs
+++ b/examples/bluetooth/src/ble_iq_burst.rs
@@ -6,6 +6,8 @@ use crate::ble_connection::format_connection_summary;
 use crate::ble_detector::DetectorEvent;
 use crate::ble_detector::DetectorStats;
 use crate::ble_detector::PacketDetector;
+use crate::ble_protocol::BlePacket;
+use crate::ble_wireshark;
 
 const AGC_ALPHA: f32 = 0.25;
 const SQUELCH_TIMEOUT_SAMPLES: usize = 100;
@@ -20,6 +22,7 @@ fn print_diagnostics() -> bool {
 }
 
 #[derive(Block)]
+#[message_outputs(wireshark)]
 pub struct BleIqBurstBlock<I = DefaultCpuReader<Complex32>, O = DefaultCpuWriter<u8>>
 where
     I: CpuBufferReader<Item = Complex32>,
@@ -32,6 +35,7 @@ where
     samples_per_symbol: usize,
     channel_index: u8,
     print_packets: bool,
+    wireshark_output: bool,
     catcher: BurstCatcher,
     stats: BurstStats,
     connections: ConnectionTable,
@@ -42,11 +46,12 @@ where
     I: CpuBufferReader<Item = Complex32>,
     O: CpuBufferWriter<Item = u8>,
 {
-    pub fn with_packet_output(
+    pub fn with_packet_and_wireshark_output(
         samples_per_symbol: usize,
         channel_index: u8,
         squelch_db: f32,
         print_packets: bool,
+        wireshark_output: bool,
     ) -> Self {
         Self {
             input: I::default(),
@@ -54,27 +59,29 @@ where
             samples_per_symbol: samples_per_symbol.max(1),
             channel_index,
             print_packets,
+            wireshark_output,
             catcher: BurstCatcher::new(squelch_db),
             stats: BurstStats::default(),
             connections: ConnectionTable::default(),
         }
     }
 
-    fn process_burst(&mut self, burst: Vec<Complex32>) {
+    fn process_burst(&mut self, burst: Vec<Complex32>) -> Vec<BlePacket> {
         self.stats.bursts += 1;
 
         if burst.len() < MIN_BURST_SAMPLES {
             self.stats.short_bursts += 1;
-            return;
+            return Vec::new();
         }
 
         let Some(demod) = demodulate_burst(&burst, self.samples_per_symbol) else {
             self.stats.fsk_rejects += 1;
-            return;
+            return Vec::new();
         };
 
         let mut burst_stats = DetectorStats::default();
         let mut decoded = false;
+        let mut packets = Vec::new();
 
         for phase in 0..self.samples_per_symbol {
             let mut detector =
@@ -85,6 +92,7 @@ where
                     DetectorEvent::None | DetectorEvent::HeaderRejected => {}
                     DetectorEvent::ValidPacket { packet } => {
                         self.connections.observe_packet(&packet);
+                        packets.push(packet);
                         decoded = true;
                         break;
                     }
@@ -108,6 +116,8 @@ where
         if decoded {
             self.stats.decoded_bursts += 1;
         }
+
+        packets
     }
 
     fn print_stats(&self) {
@@ -152,6 +162,9 @@ where
     ) -> Result<()> {
         let n = self.input.slice().len();
         if n == 0 {
+            if self.input.finished() {
+                _io.finished = true;
+            }
             return Ok(());
         }
 
@@ -168,7 +181,10 @@ where
 
         self.input.consume(n);
         for burst in bursts {
-            self.process_burst(burst);
+            let packets = self.process_burst(burst);
+            if self.wireshark_output {
+                post_wireshark_packets(_mo, &packets).await?;
+            }
         }
 
         if self.input.finished() {
@@ -179,11 +195,29 @@ where
 
     async fn deinit(&mut self, _mo: &mut MessageOutputs, _meta: &mut BlockMeta) -> Result<()> {
         if let Some(burst) = self.catcher.finish() {
-            self.process_burst(burst);
+            let packets = self.process_burst(burst);
+            if self.wireshark_output {
+                post_wireshark_packets(_mo, &packets).await?;
+            }
+        }
+        if self.wireshark_output {
+            _mo.post("wireshark", Pmt::Finished).await?;
         }
         self.print_stats();
         Ok(())
     }
+}
+
+async fn post_wireshark_packets(mo: &mut MessageOutputs, packets: &[BlePacket]) -> Result<()> {
+    for packet in packets {
+        mo.post(
+            "wireshark",
+            Pmt::Blob(ble_wireshark::packet_to_udp_payload(packet)),
+        )
+        .await?;
+    }
+
+    Ok(())
 }
 
 #[derive(Default)]

--- a/examples/bluetooth/src/ble_iq_burst.rs
+++ b/examples/bluetooth/src/ble_iq_burst.rs
@@ -1,0 +1,414 @@
+use futuresdr::num_complex::Complex32;
+use futuresdr::runtime::dev::prelude::*;
+
+use crate::ble_connection::ConnectionTable;
+use crate::ble_connection::format_connection_summary;
+use crate::ble_detector::DetectorEvent;
+use crate::ble_detector::DetectorStats;
+use crate::ble_detector::PacketDetector;
+
+const AGC_ALPHA: f32 = 0.25;
+const SQUELCH_TIMEOUT_SAMPLES: usize = 100;
+const BURST_START_CAPACITY: usize = 2048;
+const MIN_BURST_SAMPLES: usize = 96;
+const MAX_BURST_SAMPLES: usize = 8192;
+const CFO_MEDIAN_SYMBOLS: usize = 64;
+const MAX_FREQ_OFFSET: f32 = 0.85;
+
+fn print_diagnostics() -> bool {
+    cfg!(debug_assertions)
+}
+
+#[derive(Block)]
+pub struct BleIqBurstBlock<I = DefaultCpuReader<Complex32>, O = DefaultCpuWriter<u8>>
+where
+    I: CpuBufferReader<Item = Complex32>,
+    O: CpuBufferWriter<Item = u8>,
+{
+    #[input]
+    input: I,
+    #[output]
+    output: O,
+    samples_per_symbol: usize,
+    channel_index: u8,
+    print_packets: bool,
+    catcher: BurstCatcher,
+    stats: BurstStats,
+    connections: ConnectionTable,
+}
+
+impl<I, O> BleIqBurstBlock<I, O>
+where
+    I: CpuBufferReader<Item = Complex32>,
+    O: CpuBufferWriter<Item = u8>,
+{
+    pub fn with_packet_output(
+        samples_per_symbol: usize,
+        channel_index: u8,
+        squelch_db: f32,
+        print_packets: bool,
+    ) -> Self {
+        Self {
+            input: I::default(),
+            output: O::default(),
+            samples_per_symbol: samples_per_symbol.max(1),
+            channel_index,
+            print_packets,
+            catcher: BurstCatcher::new(squelch_db),
+            stats: BurstStats::default(),
+            connections: ConnectionTable::default(),
+        }
+    }
+
+    fn process_burst(&mut self, burst: Vec<Complex32>) {
+        self.stats.bursts += 1;
+
+        if burst.len() < MIN_BURST_SAMPLES {
+            self.stats.short_bursts += 1;
+            return;
+        }
+
+        let Some(demod) = demodulate_burst(&burst, self.samples_per_symbol) else {
+            self.stats.fsk_rejects += 1;
+            return;
+        };
+
+        let mut burst_stats = DetectorStats::default();
+        let mut decoded = false;
+
+        for phase in 0..self.samples_per_symbol {
+            let mut detector =
+                PacketDetector::with_packet_output(phase, self.channel_index, self.print_packets);
+
+            for value in demod.iter().skip(phase).step_by(self.samples_per_symbol) {
+                match detector.process_symbol(u8::from(*value > 0.0)) {
+                    DetectorEvent::None | DetectorEvent::HeaderRejected => {}
+                    DetectorEvent::ValidPacket { packet } => {
+                        self.connections.observe_packet(&packet);
+                        decoded = true;
+                        break;
+                    }
+                    DetectorEvent::CrcRejected { reason } => {
+                        detector.add_crc_reject();
+                        if print_diagnostics() {
+                            println!("BLE burst candidate rejected: phase={phase} {reason}");
+                        }
+                    }
+                }
+            }
+
+            add_stats(&mut burst_stats, detector.stats());
+
+            if decoded {
+                break;
+            }
+        }
+
+        add_stats(&mut self.stats.detector, burst_stats);
+        if decoded {
+            self.stats.decoded_bursts += 1;
+        }
+    }
+
+    fn print_stats(&self) {
+        let stats = self.stats.detector;
+        println!(
+            "BLE burst stats: ch={} bursts={} decoded_bursts={} short_bursts={} fsk_rejects={} packets={} connect_ind={} connections={} aa_candidates={} aa_per_packet={:.2} header_rejects={} pdu_attempts={} crc_rejects={} crc_reject_rate={:.1}%",
+            self.channel_index,
+            self.stats.bursts,
+            self.stats.decoded_bursts,
+            self.stats.short_bursts,
+            self.stats.fsk_rejects,
+            stats.packets,
+            stats.connect_ind_packets,
+            self.connections.len(),
+            stats.aa_candidates,
+            stats.aa_per_packet(),
+            stats.header_rejects,
+            stats.pdu_attempts(),
+            stats.crc_rejects,
+            stats.crc_reject_rate(),
+        );
+        for connection in self.connections.iter() {
+            println!(
+                "BLE connection: ch={} {}",
+                self.channel_index,
+                format_connection_summary(connection)
+            );
+        }
+    }
+}
+
+impl<I, O> Kernel for BleIqBurstBlock<I, O>
+where
+    I: CpuBufferReader<Item = Complex32>,
+    O: CpuBufferWriter<Item = u8>,
+{
+    async fn work(
+        &mut self,
+        _io: &mut WorkIo,
+        _mo: &mut MessageOutputs,
+        _meta: &mut BlockMeta,
+    ) -> Result<()> {
+        let n = self.input.slice().len();
+        if n == 0 {
+            return Ok(());
+        }
+
+        let mut bursts = Vec::new();
+        {
+            let input_samples = &self.input.slice()[..n];
+            let catcher = &mut self.catcher;
+            for &sample in input_samples {
+                if let Some(burst) = catcher.execute(sample) {
+                    bursts.push(burst);
+                }
+            }
+        }
+
+        self.input.consume(n);
+        for burst in bursts {
+            self.process_burst(burst);
+        }
+
+        if self.input.finished() {
+            _io.finished = true;
+        }
+        Ok(())
+    }
+
+    async fn deinit(&mut self, _mo: &mut MessageOutputs, _meta: &mut BlockMeta) -> Result<()> {
+        if let Some(burst) = self.catcher.finish() {
+            self.process_burst(burst);
+        }
+        self.print_stats();
+        Ok(())
+    }
+}
+
+#[derive(Default)]
+struct BurstStats {
+    bursts: u64,
+    decoded_bursts: u64,
+    short_bursts: u64,
+    fsk_rejects: u64,
+    detector: DetectorStats,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum SquelchState {
+    SignalLo,
+    Rise,
+    SignalHi,
+    Timeout,
+}
+
+struct BurstCatcher {
+    gain: f32,
+    signal_level: f32,
+    squelch_db: f32,
+    state: SquelchState,
+    timer: usize,
+    burst_buf: Vec<Complex32>,
+    capturing: bool,
+}
+
+impl BurstCatcher {
+    fn new(squelch_db: f32) -> Self {
+        Self {
+            gain: 1000.0,
+            signal_level: 1e-3,
+            squelch_db,
+            state: SquelchState::SignalLo,
+            timer: 0,
+            burst_buf: Vec::new(),
+            capturing: false,
+        }
+    }
+
+    fn execute(&mut self, sample: Complex32) -> Option<Vec<Complex32>> {
+        let (sample, state) = self.agc_and_squelch(sample);
+
+        match state {
+            SquelchState::Rise => {
+                self.burst_buf = Vec::with_capacity(BURST_START_CAPACITY);
+                self.burst_buf.push(sample);
+                self.capturing = true;
+                None
+            }
+            SquelchState::SignalHi => {
+                if self.capturing && self.burst_buf.len() < MAX_BURST_SAMPLES {
+                    self.burst_buf.push(sample);
+                }
+                None
+            }
+            SquelchState::Timeout => self.finish(),
+            SquelchState::SignalLo => None,
+        }
+    }
+
+    fn finish(&mut self) -> Option<Vec<Complex32>> {
+        if self.capturing && !self.burst_buf.is_empty() {
+            self.capturing = false;
+            Some(std::mem::take(&mut self.burst_buf))
+        } else {
+            self.capturing = false;
+            None
+        }
+    }
+
+    fn agc_and_squelch(&mut self, input: Complex32) -> (Complex32, SquelchState) {
+        let output = input * self.gain;
+        let level = output.norm();
+        self.signal_level = AGC_ALPHA * level + (1.0 - AGC_ALPHA) * self.signal_level;
+
+        if self.signal_level > 1e-6 {
+            self.gain *= (-0.5 * AGC_ALPHA * self.signal_level.ln()).exp();
+            self.gain = self.gain.clamp(1e-6, 1e6);
+        }
+
+        let rssi_db = -20.0 * self.gain.log10();
+        let above_threshold = rssi_db > self.squelch_db;
+
+        self.state = match self.state {
+            SquelchState::SignalLo => {
+                if above_threshold {
+                    SquelchState::Rise
+                } else {
+                    SquelchState::SignalLo
+                }
+            }
+            SquelchState::Rise => {
+                if above_threshold {
+                    self.timer = 0;
+                    SquelchState::SignalHi
+                } else {
+                    self.timer = 0;
+                    SquelchState::SignalLo
+                }
+            }
+            SquelchState::SignalHi => {
+                if above_threshold {
+                    self.timer = 0;
+                    SquelchState::SignalHi
+                } else {
+                    self.timer += 1;
+                    if self.timer >= SQUELCH_TIMEOUT_SAMPLES {
+                        SquelchState::Timeout
+                    } else {
+                        SquelchState::SignalHi
+                    }
+                }
+            }
+            SquelchState::Timeout => {
+                if above_threshold {
+                    SquelchState::Rise
+                } else {
+                    SquelchState::SignalLo
+                }
+            }
+        };
+
+        (output, self.state)
+    }
+}
+
+fn demodulate_burst(samples: &[Complex32], samples_per_symbol: usize) -> Option<Vec<f32>> {
+    if samples.len() < 8 + samples_per_symbol * CFO_MEDIAN_SYMBOLS {
+        return None;
+    }
+
+    let mut demod = Vec::with_capacity(samples.len().saturating_sub(1));
+    let mut prev = samples[0];
+    for &sample in &samples[1..] {
+        demod.push((sample * prev.conj()).arg() * std::f32::consts::FRAC_1_PI);
+        prev = sample;
+    }
+
+    let (cfo, deviation) = estimate_cfo_and_deviation(&demod, samples_per_symbol)?;
+    for value in &mut demod {
+        *value = (*value - cfo) / deviation;
+    }
+
+    Some(demod)
+}
+
+fn estimate_cfo_and_deviation(demod: &[f32], samples_per_symbol: usize) -> Option<(f32, f32)> {
+    let end = 8 + samples_per_symbol * CFO_MEDIAN_SYMBOLS;
+    if end > demod.len() {
+        return None;
+    }
+
+    let mut pos = Vec::with_capacity(samples_per_symbol * CFO_MEDIAN_SYMBOLS);
+    let mut neg = Vec::with_capacity(samples_per_symbol * CFO_MEDIAN_SYMBOLS);
+
+    for &value in &demod[8..end] {
+        if value.abs() > MAX_FREQ_OFFSET {
+            return None;
+        }
+        if value > 0.0 {
+            pos.push(value);
+        } else if value < 0.0 {
+            neg.push(value);
+        }
+    }
+
+    if pos.len() < CFO_MEDIAN_SYMBOLS / 4 || neg.len() < CFO_MEDIAN_SYMBOLS / 4 {
+        return None;
+    }
+
+    pos.sort_unstable_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
+    neg.sort_unstable_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
+
+    let high = pos[pos.len() * 3 / 4];
+    let low = neg[neg.len() / 4];
+    let cfo = (high + low) * 0.5;
+    let deviation = (high - cfo).abs();
+
+    if deviation < 1e-6 {
+        None
+    } else {
+        Some((cfo, deviation))
+    }
+}
+
+fn add_stats(acc: &mut DetectorStats, stats: DetectorStats) {
+    acc.aa_candidates += stats.aa_candidates;
+    acc.header_rejects += stats.header_rejects;
+    acc.packets += stats.packets;
+    acc.crc_rejects += stats.crc_rejects;
+    acc.duplicate_crc_rejects += stats.duplicate_crc_rejects;
+    acc.connect_ind_packets += stats.connect_ind_packets;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::demodulate_burst;
+    use crate::ble_detector::DetectorEvent;
+    use crate::ble_detector::PacketDetector;
+    use crate::ble_sim::generate_ble_packet_samples;
+
+    #[test]
+    fn demodulates_simulated_burst() {
+        let samples = generate_ble_packet_samples(2, 1, 37);
+        let burst: Vec<_> = samples
+            .into_iter()
+            .filter(|sample| sample.norm() > 0.0)
+            .collect();
+        let demod = demodulate_burst(&burst, 2).unwrap();
+        let mut detector = PacketDetector::new(0, 37);
+
+        let mut decoded = false;
+        for value in demod.iter().step_by(2) {
+            if matches!(
+                detector.process_symbol(u8::from(*value > 0.0)),
+                DetectorEvent::ValidPacket { .. }
+            ) {
+                decoded = true;
+                break;
+            }
+        }
+
+        assert!(decoded);
+    }
+}

--- a/examples/bluetooth/src/ble_phy.rs
+++ b/examples/bluetooth/src/ble_phy.rs
@@ -1,9 +1,46 @@
+use std::fmt;
+
 use crate::ble_protocol::BleAdvPduType;
 use crate::ble_protocol::BleParseError;
 
 pub const BLE_ACCESS_ADDRESS: u32 = 0x8E89_BED6;
 pub const BLE_ADV_CRC_INIT: u32 = 0x55_55_55;
 pub const BLE_MAX_ADV_PAYLOAD_LEN: usize = 37;
+
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub enum BlePhy {
+    #[default]
+    Le1M,
+    Le2M,
+    LeCoded,
+}
+
+impl BlePhy {
+    pub const fn symbol_rate_hz(self) -> f64 {
+        match self {
+            Self::Le1M | Self::LeCoded => 1.0e6,
+            Self::Le2M => 2.0e6,
+        }
+    }
+
+    pub const fn short_name(self) -> &'static str {
+        match self {
+            Self::Le1M => "1M",
+            Self::Le2M => "2M",
+            Self::LeCoded => "coded",
+        }
+    }
+}
+
+impl fmt::Display for BlePhy {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Le1M => write!(f, "LE 1M"),
+            Self::Le2M => write!(f, "LE 2M"),
+            Self::LeCoded => write!(f, "LE Coded"),
+        }
+    }
+}
 
 #[derive(Clone, Debug)]
 pub struct WhiteningState {
@@ -208,5 +245,12 @@ mod tests {
             frequency_hz_from_channel_index(40),
             Err(BleParseError::InvalidChannel(40))
         ));
+    }
+
+    #[test]
+    fn reports_phy_symbol_rates() {
+        assert_eq!(BlePhy::Le1M.symbol_rate_hz(), 1.0e6);
+        assert_eq!(BlePhy::Le2M.symbol_rate_hz(), 2.0e6);
+        assert_eq!(BlePhy::LeCoded.symbol_rate_hz(), 1.0e6);
     }
 }

--- a/examples/bluetooth/src/ble_phy.rs
+++ b/examples/bluetooth/src/ble_phy.rs
@@ -1,0 +1,213 @@
+use crate::ble_protocol::BleAdvPduType;
+use crate::ble_protocol::BleParseError;
+
+pub const BLE_ACCESS_ADDRESS: u32 = 0x8E89_BED6;
+pub const BLE_ADV_CRC_INIT: u32 = 0x55_55_55;
+pub const BLE_MAX_ADV_PAYLOAD_LEN: usize = 37;
+
+#[derive(Clone, Debug)]
+pub struct WhiteningState {
+    lfsr: u8,
+}
+
+impl WhiteningState {
+    pub fn new(channel_index: u8) -> Result<Self, BleParseError> {
+        if channel_index >= 40 {
+            return Err(BleParseError::InvalidChannel(channel_index));
+        }
+
+        Ok(Self {
+            lfsr: whitening_seed(channel_index),
+        })
+    }
+
+    pub fn apply_byte(&mut self, byte: u8) -> u8 {
+        let mut out = 0u8;
+        for bit_index in 0..8 {
+            let whitening_bit = self.lfsr & 1;
+            let input_bit = (byte >> bit_index) & 1;
+            out |= (input_bit ^ whitening_bit) << bit_index;
+
+            let feedback = ((self.lfsr >> 4) ^ self.lfsr) & 1;
+            self.lfsr = (self.lfsr >> 1) | (feedback << 6);
+        }
+        out
+    }
+}
+
+fn whitening_seed(channel_index: u8) -> u8 {
+    let bit = |n| (channel_index >> n) & 1u8;
+
+    bit(0)
+        | (bit(1) << 1)
+        | (bit(2) << 2)
+        | ((bit(0) ^ bit(3)) << 3)
+        | ((bit(1) ^ bit(4)) << 4)
+        | ((bit(2) ^ bit(5)) << 5)
+        | ((1u8 ^ bit(0) ^ bit(3)) << 6)
+}
+
+pub fn apply_whitening(channel_index: u8, bytes: &[u8]) -> Result<Vec<u8>, BleParseError> {
+    let mut whitening = WhiteningState::new(channel_index)?;
+    Ok(bytes
+        .iter()
+        .map(|&byte| whitening.apply_byte(byte))
+        .collect())
+}
+
+pub fn crc24_ble(data: &[u8], init: u32) -> u32 {
+    let mut crc = reverse_bits(init & 0x00ff_ffff, 24);
+
+    for &byte in data {
+        crc ^= byte as u32;
+        for _ in 0..8 {
+            if crc & 1 != 0 {
+                crc = (crc >> 1) ^ 0x00da_6000;
+            } else {
+                crc >>= 1;
+            }
+        }
+    }
+
+    crc & 0x00ff_ffff
+}
+
+pub fn frequency_hz_from_channel_index(channel_index: u8) -> Result<f64, BleParseError> {
+    let mhz = match channel_index {
+        37 => 2402,
+        38 => 2426,
+        39 => 2480,
+        0..=10 => 2404 + channel_index as u32 * 2,
+        11..=36 => 2428 + (channel_index as u32 - 11) * 2,
+        _ => return Err(BleParseError::InvalidChannel(channel_index)),
+    };
+
+    Ok(mhz as f64 * 1.0e6)
+}
+
+pub fn generate_ble_packet_bits(channel_index: u8) -> Vec<u8> {
+    let adv_a = [0x11, 0x22, 0x33, 0x44, 0x55, 0x66];
+    let adv_data = [0x02, 0x01, 0x06];
+    let whitened_pdu_crc = build_advertising_pdu_crc(
+        channel_index,
+        BleAdvPduType::AdvNonconnInd,
+        &adv_a,
+        &adv_data,
+    );
+
+    let mut bits = Vec::new();
+    push_byte_bits_lsb_first(&mut bits, 0xaa);
+    push_u32_bits_lsb_first(&mut bits, BLE_ACCESS_ADDRESS);
+    for byte in whitened_pdu_crc {
+        push_byte_bits_lsb_first(&mut bits, byte);
+    }
+    bits.extend(std::iter::repeat_n(0, 500));
+    bits
+}
+
+pub fn build_advertising_pdu_crc(
+    channel_index: u8,
+    pdu_type: BleAdvPduType,
+    adv_a: &[u8; 6],
+    adv_data: &[u8],
+) -> Vec<u8> {
+    let pdu_type = match pdu_type {
+        BleAdvPduType::AdvInd => 0,
+        BleAdvPduType::AdvDirectInd => 1,
+        BleAdvPduType::AdvNonconnInd => 2,
+        BleAdvPduType::ScanReq => 3,
+        BleAdvPduType::ScanRsp => 4,
+        BleAdvPduType::ConnectInd => 5,
+        BleAdvPduType::AdvScanInd => 6,
+        BleAdvPduType::AdvExtInd => 7,
+        BleAdvPduType::Reserved(_) => 2,
+    };
+
+    let payload_len = adv_a.len() + adv_data.len();
+    assert!(payload_len <= BLE_MAX_ADV_PAYLOAD_LEN);
+
+    let mut pdu = Vec::with_capacity(2 + payload_len + 3);
+    pdu.push(pdu_type);
+    pdu.push(payload_len as u8);
+    pdu.extend_from_slice(adv_a);
+    pdu.extend_from_slice(adv_data);
+
+    let crc = crc24_ble(&pdu, BLE_ADV_CRC_INIT);
+    pdu.push((crc & 0xff) as u8);
+    pdu.push(((crc >> 8) & 0xff) as u8);
+    pdu.push(((crc >> 16) & 0xff) as u8);
+
+    apply_whitening(channel_index, &pdu).expect("valid test BLE channel")
+}
+
+fn reverse_bits(mut value: u32, bits: usize) -> u32 {
+    let mut out = 0u32;
+    for _ in 0..bits {
+        out = (out << 1) | (value & 1);
+        value >>= 1;
+    }
+    out
+}
+
+fn push_byte_bits_lsb_first(bits: &mut Vec<u8>, byte: u8) {
+    for bit_index in 0..8 {
+        bits.push((byte >> bit_index) & 1);
+    }
+}
+
+fn push_u32_bits_lsb_first(bits: &mut Vec<u8>, value: u32) {
+    for bit_index in 0..32 {
+        bits.push(((value >> bit_index) & 1) as u8);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn crc24_matches_ble_check_value() {
+        assert_eq!(crc24_ble(b"123456789", BLE_ADV_CRC_INIT), 0xC25A56);
+    }
+
+    #[test]
+    fn whitening_round_trips() {
+        let input = [
+            0x02, 0x09, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x02, 0x01, 0x06,
+        ];
+        let whitened = apply_whitening(37, &input).unwrap();
+        let dewhitened = apply_whitening(37, &whitened).unwrap();
+        assert_eq!(dewhitened, input);
+    }
+
+    #[test]
+    fn whitening_matches_ble_advertising_channels() {
+        assert_eq!(
+            apply_whitening(37, &[0x00, 0x00, 0x00, 0x00]).unwrap(),
+            [0x8D, 0xD2, 0x57, 0xA1]
+        );
+        assert_eq!(
+            apply_whitening(38, &[0x00, 0x00, 0x00, 0x00]).unwrap(),
+            [0xD6, 0xC5, 0x44, 0x20]
+        );
+        assert_eq!(
+            apply_whitening(39, &[0x00, 0x00, 0x00, 0x00]).unwrap(),
+            [0x1F, 0x37, 0x4A, 0x5F]
+        );
+    }
+
+    #[test]
+    fn maps_ble_channels_to_frequencies() {
+        assert_eq!(frequency_hz_from_channel_index(37).unwrap(), 2.402e9);
+        assert_eq!(frequency_hz_from_channel_index(38).unwrap(), 2.426e9);
+        assert_eq!(frequency_hz_from_channel_index(39).unwrap(), 2.480e9);
+        assert_eq!(frequency_hz_from_channel_index(0).unwrap(), 2.404e9);
+        assert_eq!(frequency_hz_from_channel_index(10).unwrap(), 2.424e9);
+        assert_eq!(frequency_hz_from_channel_index(11).unwrap(), 2.428e9);
+        assert_eq!(frequency_hz_from_channel_index(36).unwrap(), 2.478e9);
+        assert!(matches!(
+            frequency_hz_from_channel_index(40),
+            Err(BleParseError::InvalidChannel(40))
+        ));
+    }
+}

--- a/examples/bluetooth/src/ble_phy.rs
+++ b/examples/bluetooth/src/ble_phy.rs
@@ -101,7 +101,6 @@ pub fn generate_ble_packet_bits(channel_index: u8) -> Vec<u8> {
     for byte in whitened_pdu_crc {
         push_byte_bits_lsb_first(&mut bits, byte);
     }
-    bits.extend(std::iter::repeat_n(0, 500));
     bits
 }
 

--- a/examples/bluetooth/src/ble_protocol.rs
+++ b/examples/bluetooth/src/ble_protocol.rs
@@ -1,0 +1,632 @@
+use std::error::Error;
+use std::fmt;
+
+pub use crate::ble_ad::format_ad_structures;
+pub use crate::ble_ad::parse_ad_structures;
+pub use crate::ble_phy::BLE_ACCESS_ADDRESS;
+pub use crate::ble_phy::BLE_ADV_CRC_INIT;
+pub use crate::ble_phy::BLE_MAX_ADV_PAYLOAD_LEN;
+pub use crate::ble_phy::apply_whitening;
+pub use crate::ble_phy::crc24_ble;
+pub use crate::ble_phy::frequency_hz_from_channel_index;
+pub use crate::ble_phy::generate_ble_packet_bits;
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum BleAdvPduType {
+    AdvInd,
+    AdvDirectInd,
+    AdvNonconnInd,
+    ScanReq,
+    ScanRsp,
+    ConnectInd,
+    AdvScanInd,
+    AdvExtInd,
+    Reserved(u8),
+}
+
+impl BleAdvPduType {
+    fn from_header(header: u8) -> Self {
+        match header & 0x0f {
+            0 => Self::AdvInd,
+            1 => Self::AdvDirectInd,
+            2 => Self::AdvNonconnInd,
+            3 => Self::ScanReq,
+            4 => Self::ScanRsp,
+            5 => Self::ConnectInd,
+            6 => Self::AdvScanInd,
+            7 => Self::AdvExtInd,
+            x => Self::Reserved(x),
+        }
+    }
+}
+
+impl fmt::Display for BleAdvPduType {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::AdvInd => write!(f, "ADV_IND"),
+            Self::AdvDirectInd => write!(f, "ADV_DIRECT_IND"),
+            Self::AdvNonconnInd => write!(f, "ADV_NONCONN_IND"),
+            Self::ScanReq => write!(f, "SCAN_REQ"),
+            Self::ScanRsp => write!(f, "SCAN_RSP"),
+            Self::ConnectInd => write!(f, "CONNECT_IND"),
+            Self::AdvScanInd => write!(f, "ADV_SCAN_IND"),
+            Self::AdvExtInd => write!(f, "ADV_EXT_IND"),
+            Self::Reserved(x) => write!(f, "RESERVED({x})"),
+        }
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct BlePacket {
+    pub access_address: u32,
+    pub channel_index: u8,
+    pub pdu_type: BleAdvPduType,
+    pub tx_add: bool,
+    pub rx_add: bool,
+    pub payload_len: usize,
+    pub payload: Vec<u8>,
+    pub pdu: Vec<u8>,
+    pub crc: u32,
+    pub crc_valid: bool,
+}
+
+impl BlePacket {
+    pub fn advertiser_address(&self) -> Option<[u8; 6]> {
+        match self.pdu_type {
+            BleAdvPduType::AdvInd
+            | BleAdvPduType::AdvDirectInd
+            | BleAdvPduType::AdvNonconnInd
+            | BleAdvPduType::ScanRsp
+            | BleAdvPduType::AdvScanInd => self.payload.get(0..6).map(slice_to_addr),
+            BleAdvPduType::ScanReq | BleAdvPduType::ConnectInd => {
+                self.payload.get(6..12).map(slice_to_addr)
+            }
+            BleAdvPduType::AdvExtInd | BleAdvPduType::Reserved(_) => None,
+        }
+    }
+
+    pub fn scanner_address(&self) -> Option<[u8; 6]> {
+        match self.pdu_type {
+            BleAdvPduType::ScanReq => self.payload.get(0..6).map(slice_to_addr),
+            _ => None,
+        }
+    }
+
+    pub fn initiator_address(&self) -> Option<[u8; 6]> {
+        match self.pdu_type {
+            BleAdvPduType::ConnectInd => self.payload.get(0..6).map(slice_to_addr),
+            _ => None,
+        }
+    }
+
+    pub fn target_address(&self) -> Option<[u8; 6]> {
+        match self.pdu_type {
+            BleAdvPduType::AdvDirectInd => self.payload.get(6..12).map(slice_to_addr),
+            _ => None,
+        }
+    }
+
+    pub fn advertising_data(&self) -> Option<&[u8]> {
+        match self.pdu_type {
+            BleAdvPduType::AdvInd
+            | BleAdvPduType::AdvNonconnInd
+            | BleAdvPduType::ScanRsp
+            | BleAdvPduType::AdvScanInd => self.payload.get(6..),
+            BleAdvPduType::AdvDirectInd
+            | BleAdvPduType::ScanReq
+            | BleAdvPduType::ConnectInd
+            | BleAdvPduType::AdvExtInd
+            | BleAdvPduType::Reserved(_) => None,
+        }
+    }
+
+    pub fn extended_advertising_header(&self) -> Option<BleExtAdvHeader> {
+        if self.pdu_type != BleAdvPduType::AdvExtInd {
+            return None;
+        }
+
+        BleExtAdvHeader::parse(&self.payload)
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum BleExtAdvMode {
+    NonConnectableNonScannable,
+    Connectable,
+    Scannable,
+    Reserved(u8),
+}
+
+impl fmt::Display for BleExtAdvMode {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::NonConnectableNonScannable => write!(f, "nonconn_nonscan"),
+            Self::Connectable => write!(f, "connectable"),
+            Self::Scannable => write!(f, "scannable"),
+            Self::Reserved(x) => write!(f, "reserved({x})"),
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum BleExtAdvPhy {
+    Le1M,
+    Le2M,
+    LeCoded,
+    Reserved(u8),
+}
+
+impl fmt::Display for BleExtAdvPhy {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Le1M => write!(f, "1M"),
+            Self::Le2M => write!(f, "2M"),
+            Self::LeCoded => write!(f, "coded"),
+            Self::Reserved(x) => write!(f, "reserved({x})"),
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct BleAuxPtr {
+    pub channel: u8,
+    pub offset_usec: u32,
+    pub phy: BleExtAdvPhy,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct BleExtAdvHeader {
+    pub mode: BleExtAdvMode,
+    pub adv_a: Option<[u8; 6]>,
+    pub target_a: Option<[u8; 6]>,
+    pub adi: Option<u16>,
+    pub aux_ptr: Option<BleAuxPtr>,
+    pub tx_power: Option<i8>,
+}
+
+impl BleExtAdvHeader {
+    fn parse(payload: &[u8]) -> Option<Self> {
+        if payload.len() < 2 {
+            return None;
+        }
+
+        let ext_header_len = (payload[0] & 0x3f) as usize;
+        let mode = match (payload[0] >> 6) & 0x03 {
+            0 => BleExtAdvMode::NonConnectableNonScannable,
+            1 => BleExtAdvMode::Connectable,
+            2 => BleExtAdvMode::Scannable,
+            x => BleExtAdvMode::Reserved(x),
+        };
+
+        if ext_header_len < 1 || payload.len() < 1 + ext_header_len {
+            return None;
+        }
+
+        let flags = payload[1];
+        let end = 1 + ext_header_len;
+        let mut pos = 2usize;
+
+        let adv_a = if flags & 0x01 != 0 {
+            read_addr(payload, &mut pos, end)?
+        } else {
+            None
+        };
+
+        let target_a = if flags & 0x02 != 0 {
+            read_addr(payload, &mut pos, end)?
+        } else {
+            None
+        };
+
+        if flags & 0x04 != 0 {
+            skip_bytes(&mut pos, end, 1)?;
+        }
+
+        let adi = if flags & 0x08 != 0 {
+            let bytes = read_bytes(payload, &mut pos, end, 2)?;
+            Some(u16::from_le_bytes([bytes[0], bytes[1]]))
+        } else {
+            None
+        };
+
+        let aux_ptr = if flags & 0x10 != 0 {
+            let bytes = read_bytes(payload, &mut pos, end, 3)?;
+            parse_aux_ptr(bytes)?
+        } else {
+            None
+        };
+
+        if flags & 0x20 != 0 {
+            skip_bytes(&mut pos, end, 18)?;
+        }
+
+        let tx_power = if flags & 0x40 != 0 {
+            let bytes = read_bytes(payload, &mut pos, end, 1)?;
+            Some(bytes[0] as i8)
+        } else {
+            None
+        };
+
+        Some(Self {
+            mode,
+            adv_a,
+            target_a,
+            adi,
+            aux_ptr,
+            tx_power,
+        })
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum BleParseError {
+    InvalidChannel(u8),
+    TooShort { actual: usize },
+    PayloadTooLong { len: usize },
+    Truncated { needed: usize, actual: usize },
+    InvalidCrc { expected: u32, received: u32 },
+}
+
+impl fmt::Display for BleParseError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::InvalidChannel(ch) => write!(f, "invalid BLE channel index {ch}"),
+            Self::TooShort { actual } => write!(f, "BLE packet too short ({actual} bytes)"),
+            Self::PayloadTooLong { len } => {
+                write!(f, "BLE advertising payload too long ({len} bytes)")
+            }
+            Self::Truncated { needed, actual } => {
+                write!(f, "truncated BLE packet: need {needed} bytes, got {actual}")
+            }
+            Self::InvalidCrc { expected, received } => write!(
+                f,
+                "invalid BLE CRC: expected 0x{expected:06X}, received 0x{received:06X}"
+            ),
+        }
+    }
+}
+
+impl Error for BleParseError {}
+
+pub fn parse_advertising_pdu(
+    channel_index: u8,
+    whitened_pdu_crc: &[u8],
+) -> Result<BlePacket, BleParseError> {
+    if whitened_pdu_crc.len() < 5 {
+        return Err(BleParseError::TooShort {
+            actual: whitened_pdu_crc.len(),
+        });
+    }
+
+    let pdu_crc = apply_whitening(channel_index, whitened_pdu_crc)?;
+    let payload_len = (pdu_crc[1] & 0x3f) as usize;
+    if payload_len > BLE_MAX_ADV_PAYLOAD_LEN {
+        return Err(BleParseError::PayloadTooLong { len: payload_len });
+    }
+
+    let needed = 2 + payload_len + 3;
+    if pdu_crc.len() < needed {
+        return Err(BleParseError::Truncated {
+            needed,
+            actual: pdu_crc.len(),
+        });
+    }
+
+    let pdu = pdu_crc[0..2 + payload_len].to_vec();
+    let crc_bytes = &pdu_crc[2 + payload_len..needed];
+    let received_crc =
+        crc_bytes[0] as u32 | ((crc_bytes[1] as u32) << 8) | ((crc_bytes[2] as u32) << 16);
+    let expected_crc = crc24_ble(&pdu, BLE_ADV_CRC_INIT);
+
+    if expected_crc != received_crc {
+        return Err(BleParseError::InvalidCrc {
+            expected: expected_crc,
+            received: received_crc,
+        });
+    }
+
+    Ok(BlePacket {
+        access_address: BLE_ACCESS_ADDRESS,
+        channel_index,
+        pdu_type: BleAdvPduType::from_header(pdu[0]),
+        tx_add: pdu[0] & 0x40 != 0,
+        rx_add: pdu[0] & 0x80 != 0,
+        payload_len,
+        payload: pdu[2..].to_vec(),
+        pdu,
+        crc: received_crc,
+        crc_valid: true,
+    })
+}
+
+pub fn format_addr(addr: &[u8; 6]) -> String {
+    format!(
+        "{:02X}:{:02X}:{:02X}:{:02X}:{:02X}:{:02X}",
+        addr[5], addr[4], addr[3], addr[2], addr[1], addr[0]
+    )
+}
+
+pub fn format_packet_summary(packet: &BlePacket) -> String {
+    let mut fields = vec![
+        format!("ch={}", packet.channel_index),
+        format!("type={}", packet.pdu_type),
+        format!("len={}", packet.payload_len),
+    ];
+
+    append_address_fields(packet, &mut fields);
+
+    if let Some(ad_data) = packet.advertising_data() {
+        match parse_ad_structures(ad_data) {
+            Ok(ad_structures) if !ad_structures.is_empty() => {
+                fields.push(format!("ad=[{}]", format_ad_structures(&ad_structures)));
+            }
+            Ok(_) => {}
+            Err(err) => fields.push(format!("ad_error={err}")),
+        }
+    }
+
+    if let Some(ext_header) = packet.extended_advertising_header() {
+        fields.push(format!("ext=[{}]", format_ext_adv_header(&ext_header)));
+    }
+
+    fields.join(" ")
+}
+
+fn append_address_fields(packet: &BlePacket, fields: &mut Vec<String>) {
+    match packet.pdu_type {
+        BleAdvPduType::AdvInd
+        | BleAdvPduType::AdvNonconnInd
+        | BleAdvPduType::ScanRsp
+        | BleAdvPduType::AdvScanInd => {
+            if let Some(addr) = packet.advertiser_address() {
+                fields.push(format!("adv_a={}", format_addr(&addr)));
+            }
+        }
+        BleAdvPduType::AdvDirectInd => {
+            if let Some(addr) = packet.advertiser_address() {
+                fields.push(format!("adv_a={}", format_addr(&addr)));
+            }
+            if let Some(addr) = packet.target_address() {
+                fields.push(format!("target_a={}", format_addr(&addr)));
+            }
+        }
+        BleAdvPduType::ScanReq => {
+            if let Some(addr) = packet.scanner_address() {
+                fields.push(format!("scan_a={}", format_addr(&addr)));
+            }
+            if let Some(addr) = packet.advertiser_address() {
+                fields.push(format!("adv_a={}", format_addr(&addr)));
+            }
+        }
+        BleAdvPduType::ConnectInd => {
+            if let Some(addr) = packet.initiator_address() {
+                fields.push(format!("init_a={}", format_addr(&addr)));
+            }
+            if let Some(addr) = packet.advertiser_address() {
+                fields.push(format!("adv_a={}", format_addr(&addr)));
+            }
+        }
+        BleAdvPduType::AdvExtInd => {
+            if let Some(ext_header) = packet.extended_advertising_header() {
+                if let Some(addr) = ext_header.adv_a {
+                    fields.push(format!("adv_a={}", format_addr(&addr)));
+                }
+                if let Some(addr) = ext_header.target_a {
+                    fields.push(format!("target_a={}", format_addr(&addr)));
+                }
+            }
+        }
+        BleAdvPduType::Reserved(_) => {}
+    }
+}
+
+fn format_ext_adv_header(header: &BleExtAdvHeader) -> String {
+    let mut fields = vec![format!("mode={}", header.mode)];
+
+    if let Some(adi) = header.adi {
+        fields.push(format!("adi=0x{adi:04X}"));
+    }
+
+    if let Some(aux_ptr) = header.aux_ptr {
+        fields.push(format!(
+            "aux_ch={} aux_offset={}us aux_phy={}",
+            aux_ptr.channel, aux_ptr.offset_usec, aux_ptr.phy
+        ));
+    }
+
+    if let Some(tx_power) = header.tx_power {
+        fields.push(format!("tx_power={tx_power}dBm"));
+    }
+
+    fields.join(" ")
+}
+
+fn read_addr(payload: &[u8], pos: &mut usize, end: usize) -> Option<Option<[u8; 6]>> {
+    let bytes = read_bytes(payload, pos, end, 6)?;
+    let mut addr = [0u8; 6];
+    addr.copy_from_slice(bytes);
+    Some(Some(addr))
+}
+
+fn read_bytes<'a>(
+    payload: &'a [u8],
+    pos: &mut usize,
+    end: usize,
+    count: usize,
+) -> Option<&'a [u8]> {
+    if *pos + count > end || *pos + count > payload.len() {
+        return None;
+    }
+
+    let bytes = &payload[*pos..*pos + count];
+    *pos += count;
+    Some(bytes)
+}
+
+fn skip_bytes(pos: &mut usize, end: usize, count: usize) -> Option<()> {
+    if *pos + count > end {
+        return None;
+    }
+
+    *pos += count;
+    Some(())
+}
+
+fn parse_aux_ptr(bytes: &[u8]) -> Option<Option<BleAuxPtr>> {
+    let raw = bytes[0] as u32 | ((bytes[1] as u32) << 8) | ((bytes[2] as u32) << 16);
+    let channel = (raw & 0x3f) as u8;
+    if channel > 39 {
+        return None;
+    }
+
+    let offset_units = (raw >> 7) & 0x01;
+    let aux_offset = (raw >> 8) & 0x1fff;
+    let phy = match (raw >> 21) & 0x07 {
+        0 => BleExtAdvPhy::Le1M,
+        1 => BleExtAdvPhy::Le2M,
+        2 => BleExtAdvPhy::LeCoded,
+        x => BleExtAdvPhy::Reserved(x as u8),
+    };
+    let offset_usec = aux_offset * if offset_units == 0 { 30 } else { 300 };
+
+    Some(Some(BleAuxPtr {
+        channel,
+        offset_usec,
+        phy,
+    }))
+}
+
+fn slice_to_addr(slice: &[u8]) -> [u8; 6] {
+    let mut addr = [0u8; 6];
+    addr.copy_from_slice(slice);
+    addr
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::ble_phy::apply_whitening;
+    use crate::ble_phy::build_advertising_pdu_crc;
+
+    #[test]
+    fn parses_valid_advertising_packet() {
+        let adv_a = [0x11, 0x22, 0x33, 0x44, 0x55, 0x66];
+        let adv_data = [0x02, 0x01, 0x06];
+        let whitened =
+            build_advertising_pdu_crc(37, BleAdvPduType::AdvNonconnInd, &adv_a, &adv_data);
+        let packet = parse_advertising_pdu(37, &whitened).unwrap();
+
+        assert_eq!(packet.access_address, BLE_ACCESS_ADDRESS);
+        assert_eq!(packet.channel_index, 37);
+        assert_eq!(packet.pdu_type, BleAdvPduType::AdvNonconnInd);
+        assert_eq!(packet.payload_len, 9);
+        assert_eq!(packet.advertiser_address(), Some(adv_a));
+        assert_eq!(packet.payload[6..], adv_data);
+        assert!(packet.crc_valid);
+    }
+
+    #[test]
+    fn packet_summary_includes_advertising_data() {
+        let adv_a = [0x11, 0x22, 0x33, 0x44, 0x55, 0x66];
+        let adv_data = [0x02, 0x01, 0x06, 0x05, 0x09, b'F', b'S', b'D', b'R'];
+        let whitened = build_advertising_pdu_crc(37, BleAdvPduType::AdvInd, &adv_a, &adv_data);
+        let packet = parse_advertising_pdu(37, &whitened).unwrap();
+
+        assert_eq!(
+            format_packet_summary(&packet),
+            "ch=37 type=ADV_IND len=15 adv_a=66:55:44:33:22:11 ad=[flags=0x06, name=\"FSDR\"]"
+        );
+    }
+
+    #[test]
+    fn packet_summary_labels_scan_request_addresses() {
+        let scan_a = [0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff];
+        let adv_a = [0x11, 0x22, 0x33, 0x44, 0x55, 0x66];
+        let whitened = build_advertising_pdu_crc(37, BleAdvPduType::ScanReq, &scan_a, &adv_a);
+        let packet = parse_advertising_pdu(37, &whitened).unwrap();
+
+        assert_eq!(packet.scanner_address(), Some(scan_a));
+        assert_eq!(packet.advertiser_address(), Some(adv_a));
+        assert_eq!(
+            format_packet_summary(&packet),
+            "ch=37 type=SCAN_REQ len=12 scan_a=FF:EE:DD:CC:BB:AA adv_a=66:55:44:33:22:11"
+        );
+    }
+
+    #[test]
+    fn rejects_bad_crc() {
+        let adv_a = [0x11, 0x22, 0x33, 0x44, 0x55, 0x66];
+        let adv_data = [0x02, 0x01, 0x06];
+        let mut whitened =
+            build_advertising_pdu_crc(37, BleAdvPduType::AdvNonconnInd, &adv_a, &adv_data);
+        let last = whitened.len() - 1;
+        whitened[last] ^= 0x01;
+
+        assert!(matches!(
+            parse_advertising_pdu(37, &whitened),
+            Err(BleParseError::InvalidCrc { .. })
+        ));
+    }
+
+    #[test]
+    fn packet_summary_includes_extended_advertising_header() {
+        let adv_a = [0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff];
+        let aux_ptr = build_aux_ptr(5, 100, false, BleExtAdvPhy::Le1M);
+        let payload = [
+            11,   // extended header length: flags + AdvA + AuxPtr + TxPower
+            0x51, // AdvA + AuxPtr + TxPower
+            adv_a[0], adv_a[1], adv_a[2], adv_a[3], adv_a[4], adv_a[5], aux_ptr[0], aux_ptr[1],
+            aux_ptr[2], 0xf8,
+        ];
+        let whitened = build_raw_pdu_crc(37, BleAdvPduType::AdvExtInd, &payload);
+        let packet = parse_advertising_pdu(37, &whitened).unwrap();
+
+        assert_eq!(
+            format_packet_summary(&packet),
+            "ch=37 type=ADV_EXT_IND len=12 adv_a=FF:EE:DD:CC:BB:AA ext=[mode=nonconn_nonscan aux_ch=5 aux_offset=3000us aux_phy=1M tx_power=-8dBm]"
+        );
+    }
+
+    fn build_raw_pdu_crc(channel_index: u8, pdu_type: BleAdvPduType, payload: &[u8]) -> Vec<u8> {
+        let pdu_type = match pdu_type {
+            BleAdvPduType::AdvInd => 0,
+            BleAdvPduType::AdvDirectInd => 1,
+            BleAdvPduType::AdvNonconnInd => 2,
+            BleAdvPduType::ScanReq => 3,
+            BleAdvPduType::ScanRsp => 4,
+            BleAdvPduType::ConnectInd => 5,
+            BleAdvPduType::AdvScanInd => 6,
+            BleAdvPduType::AdvExtInd => 7,
+            BleAdvPduType::Reserved(x) => x,
+        };
+
+        let mut pdu = vec![pdu_type, payload.len() as u8];
+        pdu.extend_from_slice(payload);
+        let crc = crc24_ble(&pdu, BLE_ADV_CRC_INIT);
+        pdu.push((crc & 0xff) as u8);
+        pdu.push(((crc >> 8) & 0xff) as u8);
+        pdu.push(((crc >> 16) & 0xff) as u8);
+
+        apply_whitening(channel_index, &pdu).unwrap()
+    }
+
+    fn build_aux_ptr(
+        channel: u8,
+        aux_offset: u32,
+        offset_units_300us: bool,
+        phy: BleExtAdvPhy,
+    ) -> [u8; 3] {
+        let phy = match phy {
+            BleExtAdvPhy::Le1M => 0,
+            BleExtAdvPhy::Le2M => 1,
+            BleExtAdvPhy::LeCoded => 2,
+            BleExtAdvPhy::Reserved(x) => x as u32,
+        };
+        let raw = channel as u32
+            | ((offset_units_300us as u32) << 7)
+            | ((aux_offset & 0x1fff) << 8)
+            | (phy << 21);
+
+        [raw as u8, (raw >> 8) as u8, (raw >> 16) as u8]
+    }
+}

--- a/examples/bluetooth/src/ble_protocol.rs
+++ b/examples/bluetooth/src/ble_protocol.rs
@@ -6,6 +6,7 @@ pub use crate::ble_ad::parse_ad_structures;
 pub use crate::ble_phy::BLE_ACCESS_ADDRESS;
 pub use crate::ble_phy::BLE_ADV_CRC_INIT;
 pub use crate::ble_phy::BLE_MAX_ADV_PAYLOAD_LEN;
+pub use crate::ble_phy::BlePhy;
 pub use crate::ble_phy::apply_whitening;
 pub use crate::ble_phy::crc24_ble;
 pub use crate::ble_phy::frequency_hz_from_channel_index;
@@ -60,14 +61,15 @@ impl fmt::Display for BleAdvPduType {
 pub struct BlePacket {
     pub access_address: u32,
     pub channel_index: u8,
+    pub phy: BlePhy,
     pub pdu_type: BleAdvPduType,
+    pub channel_selection_2: bool,
     pub tx_add: bool,
     pub rx_add: bool,
     pub payload_len: usize,
     pub payload: Vec<u8>,
     pub pdu: Vec<u8>,
     pub crc: u32,
-    pub crc_valid: bool,
 }
 
 impl BlePacket {
@@ -243,13 +245,25 @@ pub enum BleExtAdvPhy {
     Reserved(u8),
 }
 
+impl BleExtAdvPhy {
+    pub fn as_ble_phy(self) -> Option<BlePhy> {
+        match self {
+            Self::Le1M => Some(BlePhy::Le1M),
+            Self::Le2M => Some(BlePhy::Le2M),
+            Self::LeCoded => Some(BlePhy::LeCoded),
+            Self::Reserved(_) => None,
+        }
+    }
+}
+
 impl fmt::Display for BleExtAdvPhy {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        if let Some(phy) = self.as_ble_phy() {
+            return f.write_str(phy.short_name());
+        }
         match self {
-            Self::Le1M => write!(f, "1M"),
-            Self::Le2M => write!(f, "2M"),
-            Self::LeCoded => write!(f, "coded"),
             Self::Reserved(x) => write!(f, "reserved({x})"),
+            _ => unreachable!(),
         }
     }
 }
@@ -415,14 +429,15 @@ pub fn parse_advertising_pdu(
     Ok(BlePacket {
         access_address: BLE_ACCESS_ADDRESS,
         channel_index,
+        phy: BlePhy::Le1M,
         pdu_type: BleAdvPduType::from_header(pdu[0]),
+        channel_selection_2: pdu[0] & 0x20 != 0,
         tx_add: pdu[0] & 0x40 != 0,
         rx_add: pdu[0] & 0x80 != 0,
         payload_len,
         payload: pdu[2..].to_vec(),
         pdu,
         crc: received_crc,
-        crc_valid: true,
     })
 }
 
@@ -436,8 +451,9 @@ pub fn format_addr(addr: &[u8; 6]) -> String {
 pub fn format_packet_summary(packet: &BlePacket) -> String {
     let mut fields = vec![
         format!("ch={}", packet.channel_index),
-        format!("type={}", packet.pdu_type),
-        format!("len={}", packet.payload_len),
+        format!("phy={}", packet.phy.short_name()),
+        format!("pdu={}", packet.pdu_type),
+        format!("payload_len={}", packet.payload_len),
     ];
 
     append_address_fields(packet, &mut fields);
@@ -457,6 +473,10 @@ pub fn format_packet_summary(packet: &BlePacket) -> String {
     }
 
     if let Some(conn) = packet.connection_request() {
+        fields.push(format!(
+            "csa={}",
+            if packet.channel_selection_2 { 2 } else { 1 }
+        ));
         fields.push(format!("conn=[{}]", format_connection_request(&conn)));
     }
 
@@ -470,45 +490,65 @@ fn append_address_fields(packet: &BlePacket, fields: &mut Vec<String>) {
         | BleAdvPduType::ScanRsp
         | BleAdvPduType::AdvScanInd => {
             if let Some(addr) = packet.advertiser_address() {
-                fields.push(format!("adv_a={}", format_addr(&addr)));
+                fields.push(format!("adv_a={}", format_typed_addr(&addr, packet.tx_add)));
             }
         }
         BleAdvPduType::AdvDirectInd => {
             if let Some(addr) = packet.advertiser_address() {
-                fields.push(format!("adv_a={}", format_addr(&addr)));
+                fields.push(format!("adv_a={}", format_typed_addr(&addr, packet.tx_add)));
             }
             if let Some(addr) = packet.target_address() {
-                fields.push(format!("target_a={}", format_addr(&addr)));
+                fields.push(format!(
+                    "target_a={}",
+                    format_typed_addr(&addr, packet.rx_add)
+                ));
             }
         }
         BleAdvPduType::ScanReq => {
             if let Some(addr) = packet.scanner_address() {
-                fields.push(format!("scan_a={}", format_addr(&addr)));
+                fields.push(format!(
+                    "scan_a={}",
+                    format_typed_addr(&addr, packet.tx_add)
+                ));
             }
             if let Some(addr) = packet.advertiser_address() {
-                fields.push(format!("adv_a={}", format_addr(&addr)));
+                fields.push(format!("adv_a={}", format_typed_addr(&addr, packet.rx_add)));
             }
         }
         BleAdvPduType::ConnectInd => {
             if let Some(addr) = packet.initiator_address() {
-                fields.push(format!("init_a={}", format_addr(&addr)));
+                fields.push(format!(
+                    "init_a={}",
+                    format_typed_addr(&addr, packet.tx_add)
+                ));
             }
             if let Some(addr) = packet.advertiser_address() {
-                fields.push(format!("adv_a={}", format_addr(&addr)));
+                fields.push(format!("adv_a={}", format_typed_addr(&addr, packet.rx_add)));
             }
         }
         BleAdvPduType::AdvExtInd => {
             if let Some(ext_header) = packet.extended_advertising_header() {
                 if let Some(addr) = ext_header.adv_a {
-                    fields.push(format!("adv_a={}", format_addr(&addr)));
+                    fields.push(format!("adv_a={}", format_typed_addr(&addr, packet.tx_add)));
                 }
                 if let Some(addr) = ext_header.target_a {
-                    fields.push(format!("target_a={}", format_addr(&addr)));
+                    fields.push(format!(
+                        "target_a={}",
+                        format_typed_addr(&addr, packet.rx_add)
+                    ));
                 }
             }
         }
         BleAdvPduType::Reserved(_) => {}
     }
+}
+
+fn format_typed_addr(addr: &[u8; 6], random: bool) -> String {
+    format!(
+        "{}({})",
+        format_addr(addr),
+        if random { "random" } else { "public" }
+    )
 }
 
 fn format_ext_adv_header(header: &BleExtAdvHeader) -> String {
@@ -629,7 +669,6 @@ mod tests {
         assert_eq!(packet.payload_len, 9);
         assert_eq!(packet.advertiser_address(), Some(adv_a));
         assert_eq!(packet.payload[6..], adv_data);
-        assert!(packet.crc_valid);
     }
 
     #[test]
@@ -641,7 +680,7 @@ mod tests {
 
         assert_eq!(
             format_packet_summary(&packet),
-            "ch=37 type=ADV_IND len=15 adv_a=66:55:44:33:22:11 ad=[flags=0x06, name=\"FSDR\"]"
+            "ch=37 phy=1M pdu=ADV_IND payload_len=15 adv_a=66:55:44:33:22:11(public) ad=[flags=0x06, name=\"FSDR\"]"
         );
     }
 
@@ -656,7 +695,7 @@ mod tests {
         assert_eq!(packet.advertiser_address(), Some(adv_a));
         assert_eq!(
             format_packet_summary(&packet),
-            "ch=37 type=SCAN_REQ len=12 scan_a=FF:EE:DD:CC:BB:AA adv_a=66:55:44:33:22:11"
+            "ch=37 phy=1M pdu=SCAN_REQ payload_len=12 scan_a=FF:EE:DD:CC:BB:AA(public) adv_a=66:55:44:33:22:11(public)"
         );
     }
 
@@ -685,12 +724,12 @@ mod tests {
             adv_a[0], adv_a[1], adv_a[2], adv_a[3], adv_a[4], adv_a[5], aux_ptr[0], aux_ptr[1],
             aux_ptr[2], 0xf8,
         ];
-        let whitened = build_raw_pdu_crc(37, BleAdvPduType::AdvExtInd, &payload);
+        let whitened = build_raw_pdu_crc(37, BleAdvPduType::AdvExtInd, 0, &payload);
         let packet = parse_advertising_pdu(37, &whitened).unwrap();
 
         assert_eq!(
             format_packet_summary(&packet),
-            "ch=37 type=ADV_EXT_IND len=12 adv_a=FF:EE:DD:CC:BB:AA ext=[mode=nonconn_nonscan aux_ch=5 aux_offset=3000us aux_phy=1M tx_power=-8dBm]"
+            "ch=37 phy=1M pdu=ADV_EXT_IND payload_len=12 adv_a=FF:EE:DD:CC:BB:AA(public) ext=[mode=nonconn_nonscan aux_ch=5 aux_offset=3000us aux_phy=1M tx_power=-8dBm]"
         );
     }
 
@@ -711,20 +750,26 @@ mod tests {
         payload.extend_from_slice(&[0xff, 0xff, 0xff, 0xff, 0x1f]);
         payload.push((3 << 5) | 12);
 
-        let whitened = build_raw_pdu_crc(37, BleAdvPduType::ConnectInd, &payload);
+        let whitened = build_raw_pdu_crc(37, BleAdvPduType::ConnectInd, 0x20, &payload);
         let packet = parse_advertising_pdu(37, &whitened).unwrap();
         let conn = packet.connection_request().unwrap();
 
         assert_eq!(conn.access_address, 0xa1b2c3d4);
         assert_eq!(conn.crc_init, 0x123456);
         assert_eq!(conn.used_channel_count(), 37);
+        assert!(packet.channel_selection_2);
         assert_eq!(
             format_packet_summary(&packet),
-            "ch=37 type=CONNECT_IND len=34 init_a=FF:EE:DD:CC:BB:AA adv_a=66:55:44:33:22:11 conn=[aa=0xA1B2C3D4 crc_init=0x123456 win=2.50ms offset=5.00ms interval=30.00ms latency=0 timeout=2000ms hop=12 sca=3 channels=37]"
+            "ch=37 phy=1M pdu=CONNECT_IND payload_len=34 init_a=FF:EE:DD:CC:BB:AA(public) adv_a=66:55:44:33:22:11(public) csa=2 conn=[aa=0xA1B2C3D4 crc_init=0x123456 win=2.50ms offset=5.00ms interval=30.00ms latency=0 timeout=2000ms hop=12 sca=3 channels=37]"
         );
     }
 
-    fn build_raw_pdu_crc(channel_index: u8, pdu_type: BleAdvPduType, payload: &[u8]) -> Vec<u8> {
+    fn build_raw_pdu_crc(
+        channel_index: u8,
+        pdu_type: BleAdvPduType,
+        header_flags: u8,
+        payload: &[u8],
+    ) -> Vec<u8> {
         let pdu_type = match pdu_type {
             BleAdvPduType::AdvInd => 0,
             BleAdvPduType::AdvDirectInd => 1,
@@ -737,7 +782,7 @@ mod tests {
             BleAdvPduType::Reserved(x) => x,
         };
 
-        let mut pdu = vec![pdu_type, payload.len() as u8];
+        let mut pdu = vec![pdu_type | header_flags, payload.len() as u8];
         pdu.extend_from_slice(payload);
         let crc = crc24_ble(&pdu, BLE_ADV_CRC_INIT);
         pdu.push((crc & 0xff) as u8);

--- a/examples/bluetooth/src/ble_protocol.rs
+++ b/examples/bluetooth/src/ble_protocol.rs
@@ -127,6 +127,93 @@ impl BlePacket {
 
         BleExtAdvHeader::parse(&self.payload)
     }
+
+    pub fn connection_request(&self) -> Option<BleConnectionRequest> {
+        if self.pdu_type != BleAdvPduType::ConnectInd {
+            return None;
+        }
+
+        BleConnectionRequest::parse(&self.payload)
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct BleConnectionRequest {
+    pub access_address: u32,
+    pub crc_init: u32,
+    pub window_size_units: u8,
+    pub window_offset_units: u16,
+    pub interval_units: u16,
+    pub latency: u16,
+    pub timeout_units: u16,
+    pub channel_map: [u8; 5],
+    pub hop_increment: u8,
+    pub sca: u8,
+}
+
+impl BleConnectionRequest {
+    fn parse(payload: &[u8]) -> Option<Self> {
+        let ll_data = payload.get(12..34)?;
+
+        let access_address = u32::from_le_bytes([ll_data[0], ll_data[1], ll_data[2], ll_data[3]]);
+        let crc_init = ll_data[4] as u32 | ((ll_data[5] as u32) << 8) | ((ll_data[6] as u32) << 16);
+        let window_size_units = ll_data[7];
+        let window_offset_units = u16::from_le_bytes([ll_data[8], ll_data[9]]);
+        let interval_units = u16::from_le_bytes([ll_data[10], ll_data[11]]);
+        let latency = u16::from_le_bytes([ll_data[12], ll_data[13]]);
+        let timeout_units = u16::from_le_bytes([ll_data[14], ll_data[15]]);
+        let channel_map = [
+            ll_data[16],
+            ll_data[17],
+            ll_data[18],
+            ll_data[19],
+            ll_data[20],
+        ];
+        let hop_sca = ll_data[21];
+
+        Some(Self {
+            access_address,
+            crc_init,
+            window_size_units,
+            window_offset_units,
+            interval_units,
+            latency,
+            timeout_units,
+            channel_map,
+            hop_increment: hop_sca & 0x1f,
+            sca: hop_sca >> 5,
+        })
+    }
+
+    fn window_size_ms(&self) -> f32 {
+        self.window_size_units as f32 * 1.25
+    }
+
+    fn window_offset_ms(&self) -> f32 {
+        self.window_offset_units as f32 * 1.25
+    }
+
+    fn interval_ms(&self) -> f32 {
+        self.interval_units as f32 * 1.25
+    }
+
+    fn timeout_ms(&self) -> u32 {
+        self.timeout_units as u32 * 10
+    }
+
+    fn used_channel_count(&self) -> u32 {
+        self.channel_map
+            .iter()
+            .enumerate()
+            .map(|(byte_index, byte)| {
+                if byte_index == 4 {
+                    (byte & 0x1f).count_ones()
+                } else {
+                    byte.count_ones()
+                }
+            })
+            .sum()
+    }
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -369,6 +456,10 @@ pub fn format_packet_summary(packet: &BlePacket) -> String {
         fields.push(format!("ext=[{}]", format_ext_adv_header(&ext_header)));
     }
 
+    if let Some(conn) = packet.connection_request() {
+        fields.push(format!("conn=[{}]", format_connection_request(&conn)));
+    }
+
     fields.join(" ")
 }
 
@@ -439,6 +530,22 @@ fn format_ext_adv_header(header: &BleExtAdvHeader) -> String {
     }
 
     fields.join(" ")
+}
+
+fn format_connection_request(conn: &BleConnectionRequest) -> String {
+    format!(
+        "aa=0x{:08X} crc_init=0x{:06X} win={:.2}ms offset={:.2}ms interval={:.2}ms latency={} timeout={}ms hop={} sca={} channels={}",
+        conn.access_address,
+        conn.crc_init,
+        conn.window_size_ms(),
+        conn.window_offset_ms(),
+        conn.interval_ms(),
+        conn.latency,
+        conn.timeout_ms(),
+        conn.hop_increment,
+        conn.sca,
+        conn.used_channel_count(),
+    )
 }
 
 fn read_addr(payload: &[u8], pos: &mut usize, end: usize) -> Option<Option<[u8; 6]>> {
@@ -584,6 +691,36 @@ mod tests {
         assert_eq!(
             format_packet_summary(&packet),
             "ch=37 type=ADV_EXT_IND len=12 adv_a=FF:EE:DD:CC:BB:AA ext=[mode=nonconn_nonscan aux_ch=5 aux_offset=3000us aux_phy=1M tx_power=-8dBm]"
+        );
+    }
+
+    #[test]
+    fn packet_summary_includes_connection_request_parameters() {
+        let init_a = [0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff];
+        let adv_a = [0x11, 0x22, 0x33, 0x44, 0x55, 0x66];
+        let mut payload = Vec::new();
+        payload.extend_from_slice(&init_a);
+        payload.extend_from_slice(&adv_a);
+        payload.extend_from_slice(&0xa1b2c3d4u32.to_le_bytes());
+        payload.extend_from_slice(&[0x56, 0x34, 0x12]);
+        payload.push(2);
+        payload.extend_from_slice(&4u16.to_le_bytes());
+        payload.extend_from_slice(&24u16.to_le_bytes());
+        payload.extend_from_slice(&0u16.to_le_bytes());
+        payload.extend_from_slice(&200u16.to_le_bytes());
+        payload.extend_from_slice(&[0xff, 0xff, 0xff, 0xff, 0x1f]);
+        payload.push((3 << 5) | 12);
+
+        let whitened = build_raw_pdu_crc(37, BleAdvPduType::ConnectInd, &payload);
+        let packet = parse_advertising_pdu(37, &whitened).unwrap();
+        let conn = packet.connection_request().unwrap();
+
+        assert_eq!(conn.access_address, 0xa1b2c3d4);
+        assert_eq!(conn.crc_init, 0x123456);
+        assert_eq!(conn.used_channel_count(), 37);
+        assert_eq!(
+            format_packet_summary(&packet),
+            "ch=37 type=CONNECT_IND len=34 init_a=FF:EE:DD:CC:BB:AA adv_a=66:55:44:33:22:11 conn=[aa=0xA1B2C3D4 crc_init=0x123456 win=2.50ms offset=5.00ms interval=30.00ms latency=0 timeout=2000ms hop=12 sca=3 channels=37]"
         );
     }
 

--- a/examples/bluetooth/src/ble_sim.rs
+++ b/examples/bluetooth/src/ble_sim.rs
@@ -6,11 +6,13 @@ pub fn generate_ble_packet_samples(
     channel_index: u8,
 ) -> Vec<Complex32> {
     let bits = super::ble_protocol::generate_ble_packet_bits(channel_index);
-    let silence = samples_per_symbol * 100;
-    let mut samples =
-        Vec::with_capacity((bits.len() * samples_per_symbol + silence) * packet_count);
+    let startup_silence = samples_per_symbol * 600;
+    let packet_gap = samples_per_symbol * 100;
+    let mut samples = Vec::with_capacity(
+        startup_silence + (bits.len() * samples_per_symbol + packet_gap) * packet_count,
+    );
 
-    for _ in 0..silence {
+    for _ in 0..startup_silence {
         samples.push(Complex32::new(0.0, 0.0));
     }
 
@@ -34,7 +36,7 @@ pub fn generate_ble_packet_samples(
             }
         }
 
-        for _ in 0..silence {
+        for _ in 0..packet_gap {
             samples.push(Complex32::new(0.0, 0.0));
         }
     }

--- a/examples/bluetooth/src/ble_sim.rs
+++ b/examples/bluetooth/src/ble_sim.rs
@@ -1,0 +1,41 @@
+use futuresdr::num_complex::Complex32;
+
+pub fn generate_ble_packet_samples(
+    samples_per_symbol: usize,
+    packet_count: usize,
+    channel_index: u8,
+) -> Vec<Complex32> {
+    let bits = super::ble_protocol::generate_ble_packet_bits(channel_index);
+    let mut samples = Vec::with_capacity((bits.len() * samples_per_symbol + 100) * packet_count);
+
+    for _ in 0..(samples_per_symbol * 4) {
+        samples.push(Complex32::new(1.0, 0.0));
+    }
+
+    let mut current_phase = 0.0f32;
+    let phase_step = (std::f32::consts::PI * 0.5) / samples_per_symbol as f32;
+
+    for _ in 0..packet_count {
+        for &bit in &bits {
+            let symbol = if bit == 1 { 1.0 } else { -1.0 };
+            for _ in 0..samples_per_symbol {
+                current_phase += symbol * phase_step;
+
+                while current_phase <= -std::f32::consts::PI {
+                    current_phase += 2.0 * std::f32::consts::PI;
+                }
+                while current_phase > std::f32::consts::PI {
+                    current_phase -= 2.0 * std::f32::consts::PI;
+                }
+
+                samples.push(Complex32::from_polar(1.0, current_phase));
+            }
+        }
+
+        for _ in 0..100 {
+            samples.push(Complex32::from_polar(1.0, current_phase));
+        }
+    }
+
+    samples
+}

--- a/examples/bluetooth/src/ble_sim.rs
+++ b/examples/bluetooth/src/ble_sim.rs
@@ -6,10 +6,12 @@ pub fn generate_ble_packet_samples(
     channel_index: u8,
 ) -> Vec<Complex32> {
     let bits = super::ble_protocol::generate_ble_packet_bits(channel_index);
-    let mut samples = Vec::with_capacity((bits.len() * samples_per_symbol + 100) * packet_count);
+    let silence = samples_per_symbol * 100;
+    let mut samples =
+        Vec::with_capacity((bits.len() * samples_per_symbol + silence) * packet_count);
 
-    for _ in 0..(samples_per_symbol * 4) {
-        samples.push(Complex32::new(1.0, 0.0));
+    for _ in 0..silence {
+        samples.push(Complex32::new(0.0, 0.0));
     }
 
     let mut current_phase = 0.0f32;
@@ -32,8 +34,8 @@ pub fn generate_ble_packet_samples(
             }
         }
 
-        for _ in 0..100 {
-            samples.push(Complex32::from_polar(1.0, current_phase));
+        for _ in 0..silence {
+            samples.push(Complex32::new(0.0, 0.0));
         }
     }
 

--- a/examples/bluetooth/src/ble_slicer.rs
+++ b/examples/bluetooth/src/ble_slicer.rs
@@ -1,0 +1,86 @@
+const DC_ALPHA: f32 = 1.0 / 4096.0;
+const LEVEL_ALPHA: f32 = 1.0 / 1024.0;
+const MIN_DEVIATION: f32 = 0.02;
+
+pub(crate) struct SymbolSlicer {
+    dc_estimate: f32,
+    pos_level: f32,
+    neg_level: f32,
+    threshold: f32,
+    last_bit: u8,
+    normalize_levels: bool,
+}
+
+impl SymbolSlicer {
+    pub(crate) fn new(threshold: f32, normalize_levels: bool) -> Self {
+        Self {
+            dc_estimate: 0.0,
+            pos_level: 0.25,
+            neg_level: -0.25,
+            threshold: threshold.max(0.0),
+            last_bit: 0,
+            normalize_levels,
+        }
+    }
+
+    pub(crate) fn slice(&mut self, sample: f32) -> u8 {
+        self.dc_estimate += DC_ALPHA * (sample - self.dc_estimate);
+        let dc_centered = sample - self.dc_estimate;
+
+        let sliced = if self.normalize_levels {
+            if dc_centered > 0.0 {
+                self.pos_level += LEVEL_ALPHA * (dc_centered - self.pos_level);
+            } else if dc_centered < 0.0 {
+                self.neg_level += LEVEL_ALPHA * (dc_centered - self.neg_level);
+            }
+
+            let cfo_estimate = (self.pos_level + self.neg_level) * 0.5;
+            let deviation = ((self.pos_level - self.neg_level) * 0.5).abs();
+            if deviation > MIN_DEVIATION {
+                (dc_centered - cfo_estimate) / deviation
+            } else {
+                dc_centered - cfo_estimate
+            }
+        } else {
+            dc_centered
+        };
+
+        let bit = if sliced > self.threshold {
+            1
+        } else if sliced < -self.threshold {
+            0
+        } else {
+            self.last_bit
+        };
+
+        self.last_bit = bit;
+        bit
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::SymbolSlicer;
+
+    #[test]
+    fn slicer_tracks_slow_dc_offset() {
+        let mut slicer = SymbolSlicer::new(0.0, false);
+
+        for _ in 0..20_000 {
+            slicer.slice(0.35);
+        }
+
+        assert_eq!(slicer.slice(0.55), 1);
+        assert_eq!(slicer.slice(0.15), 0);
+    }
+
+    #[test]
+    fn slicer_holds_last_bit_inside_threshold() {
+        let mut slicer = SymbolSlicer::new(0.1, false);
+
+        assert_eq!(slicer.slice(0.2), 1);
+        assert_eq!(slicer.slice(0.02), 1);
+        assert_eq!(slicer.slice(-0.2), 0);
+        assert_eq!(slicer.slice(-0.02), 0);
+    }
+}

--- a/examples/bluetooth/src/ble_slicer.rs
+++ b/examples/bluetooth/src/ble_slicer.rs
@@ -1,25 +1,15 @@
 const DC_ALPHA: f32 = 1.0 / 4096.0;
-const LEVEL_ALPHA: f32 = 1.0 / 1024.0;
-const MIN_DEVIATION: f32 = 0.02;
 
 pub(crate) struct SymbolSlicer {
     dc_estimate: f32,
-    pos_level: f32,
-    neg_level: f32,
-    threshold: f32,
     last_bit: u8,
-    normalize_levels: bool,
 }
 
 impl SymbolSlicer {
-    pub(crate) fn new(threshold: f32, normalize_levels: bool) -> Self {
+    pub(crate) fn new() -> Self {
         Self {
             dc_estimate: 0.0,
-            pos_level: 0.25,
-            neg_level: -0.25,
-            threshold: threshold.max(0.0),
             last_bit: 0,
-            normalize_levels,
         }
     }
 
@@ -27,27 +17,9 @@ impl SymbolSlicer {
         self.dc_estimate += DC_ALPHA * (sample - self.dc_estimate);
         let dc_centered = sample - self.dc_estimate;
 
-        let sliced = if self.normalize_levels {
-            if dc_centered > 0.0 {
-                self.pos_level += LEVEL_ALPHA * (dc_centered - self.pos_level);
-            } else if dc_centered < 0.0 {
-                self.neg_level += LEVEL_ALPHA * (dc_centered - self.neg_level);
-            }
-
-            let cfo_estimate = (self.pos_level + self.neg_level) * 0.5;
-            let deviation = ((self.pos_level - self.neg_level) * 0.5).abs();
-            if deviation > MIN_DEVIATION {
-                (dc_centered - cfo_estimate) / deviation
-            } else {
-                dc_centered - cfo_estimate
-            }
-        } else {
-            dc_centered
-        };
-
-        let bit = if sliced > self.threshold {
+        let bit = if dc_centered > 0.0 {
             1
-        } else if sliced < -self.threshold {
+        } else if dc_centered < 0.0 {
             0
         } else {
             self.last_bit
@@ -64,7 +36,7 @@ mod tests {
 
     #[test]
     fn slicer_tracks_slow_dc_offset() {
-        let mut slicer = SymbolSlicer::new(0.0, false);
+        let mut slicer = SymbolSlicer::new();
 
         for _ in 0..20_000 {
             slicer.slice(0.35);
@@ -75,12 +47,14 @@ mod tests {
     }
 
     #[test]
-    fn slicer_holds_last_bit_inside_threshold() {
-        let mut slicer = SymbolSlicer::new(0.1, false);
+    fn slicer_holds_last_bit_at_the_decision_level() {
+        let mut slicer = SymbolSlicer::new();
 
         assert_eq!(slicer.slice(0.2), 1);
-        assert_eq!(slicer.slice(0.02), 1);
+        let decision_level = slicer.dc_estimate;
+        assert_eq!(slicer.slice(decision_level), 1);
         assert_eq!(slicer.slice(-0.2), 0);
-        assert_eq!(slicer.slice(-0.02), 0);
+        let decision_level = slicer.dc_estimate;
+        assert_eq!(slicer.slice(decision_level), 0);
     }
 }

--- a/examples/bluetooth/src/ble_sync.rs
+++ b/examples/bluetooth/src/ble_sync.rs
@@ -1,7 +1,9 @@
 use futuresdr::runtime::dev::prelude::*;
 
-use crate::ble_connection::ConnectionTable;
+use crate::ble_connection::SharedConnectionTable;
 use crate::ble_connection::format_connection_summary;
+use crate::ble_connection_follower::format_planned_events;
+use crate::ble_connection_report::format_tracking_summary;
 use crate::ble_detector::DetectorEvent;
 use crate::ble_detector::DetectorStats;
 use crate::ble_detector::PacketDetector;
@@ -10,9 +12,7 @@ use crate::ble_wireshark;
 
 const CRC_REJECT_GUARD_SYMBOLS: usize = 512;
 
-fn print_diagnostics() -> bool {
-    cfg!(debug_assertions)
-}
+use crate::diagnostics;
 
 struct PendingReject {
     sample_index: usize,
@@ -31,14 +31,16 @@ where
     input: I,
     #[output]
     output: O,
+    channel_index: u8,
     samples_per_symbol: usize,
     initial_delay: usize,
     total_sample_index: usize,
+    print_packets: bool,
     wireshark_output: bool,
     slicer: SymbolSlicer,
     detectors: Vec<PacketDetector>,
     pending_crc_rejects: Vec<PendingReject>,
-    connections: ConnectionTable,
+    connections: SharedConnectionTable,
 }
 
 impl<I, O> BleSyncBlock<I, O>
@@ -48,15 +50,11 @@ where
 {
     #[cfg(test)]
     fn with_channel_and_phase(
-        threshold: f32,
-        normalize_levels: bool,
         samples_per_symbol: usize,
         channel_index: u8,
         initial_delay: usize,
     ) -> Self {
         Self::with_channel_phase_packet_and_wireshark_output(
-            threshold,
-            normalize_levels,
             samples_per_symbol,
             channel_index,
             initial_delay,
@@ -66,8 +64,6 @@ where
     }
 
     pub fn with_channel_phase_packet_and_wireshark_output(
-        threshold: f32,
-        normalize_levels: bool,
         samples_per_symbol: usize,
         channel_index: u8,
         initial_delay: usize,
@@ -82,15 +78,22 @@ where
         Self {
             input: I::default(),
             output: O::default(),
+            channel_index,
             samples_per_symbol,
             initial_delay,
             total_sample_index: 0,
+            print_packets,
             wireshark_output,
-            slicer: SymbolSlicer::new(threshold, normalize_levels),
+            slicer: SymbolSlicer::new(),
             detectors,
             pending_crc_rejects: Vec::new(),
-            connections: ConnectionTable::default(),
+            connections: SharedConnectionTable::default(),
         }
+    }
+
+    pub(crate) fn with_connections(mut self, connections: SharedConnectionTable) -> Self {
+        self.connections = connections;
+        self
     }
 
     fn aggregate_stats(&self) -> DetectorStats {
@@ -100,25 +103,46 @@ where
     fn print_stats(&self) {
         let stats = self.aggregate_stats();
         println!(
-            "BLE stats: packets={} connect_ind={} connections={} aa_candidates={} aa_per_packet={:.2} header_rejects={} pdu_attempts={} crc_rejects={} duplicate_crc_rejects={} raw_crc_rejects={} crc_reject_rate={:.1}%",
+            "BLE summary: ch={} mode=continuous packets={} connect_ind={} crc_passes={} crc_checks={} crc_pass_rate={:.1}%",
+            self.channel_index,
             stats.packets,
             stats.connect_ind_packets,
-            self.connections.len(),
-            stats.aa_candidates,
-            stats.aa_per_packet(),
-            stats.header_rejects,
+            stats.packets,
             stats.pdu_attempts(),
-            stats.crc_rejects,
-            stats.duplicate_crc_rejects,
-            stats.raw_crc_rejects(),
-            stats.crc_reject_rate()
+            stats.crc_pass_rate()
         );
-        for connection in self.connections.iter() {
+        if self.print_packets && diagnostics::enabled() {
             println!(
-                "BLE connection: ch={} {}",
-                connection.last_channel,
-                format_connection_summary(connection)
+                "BLE detector diagnostics: ch={} aa_candidates={} aa_per_packet={:.2} header_rejects={} duplicate_crc_rejects={} raw_crc_rejects={}",
+                self.channel_index,
+                stats.aa_candidates,
+                stats.aa_per_packet(),
+                stats.header_rejects,
+                stats.duplicate_crc_rejects,
+                stats.raw_crc_rejects(),
             );
+        }
+        if self.connections.finish_reporter() {
+            if self.print_packets && diagnostics::enabled() {
+                for connection in self.connections.snapshot() {
+                    println!(
+                        "BLE connection: ch={} {}",
+                        connection.first_channel,
+                        format_connection_summary(&connection)
+                    );
+                }
+                for plan in self.connections.follow_plans(8) {
+                    println!(
+                        "BLE follow plan: aa=0x{:08X} next_events=[{}]",
+                        plan.access_address,
+                        format_planned_events(&plan.events)
+                    );
+                }
+            }
+            let summary = self.connections.tracking_summary();
+            if summary.connect_ind_seen > 0 {
+                println!("BLE tracking summary: {}", format_tracking_summary(summary));
+            }
         }
     }
 
@@ -187,7 +211,7 @@ where
             }
 
             self.detectors[phase].add_crc_reject();
-            if print_diagnostics() {
+            if self.print_packets && diagnostics::enabled() {
                 if duplicates == 0 {
                     println!("BLE candidate rejected: phase={phase} {reason}");
                 } else {
@@ -295,7 +319,7 @@ mod tests {
     fn crc_guard_marks_nearby_reject_as_duplicate() {
         let mut block =
             BleSyncBlock::<DefaultCpuReader<f32>, DefaultCpuWriter<u8>>::with_channel_and_phase(
-                0.0, false, 2, 37, 0,
+                2, 37, 0,
             );
 
         block.total_sample_index = 100;
@@ -312,7 +336,7 @@ mod tests {
     fn crc_guard_flushes_expired_reject() {
         let mut block =
             BleSyncBlock::<DefaultCpuReader<f32>, DefaultCpuWriter<u8>>::with_channel_and_phase(
-                0.0, false, 2, 37, 0,
+                2, 37, 0,
             );
 
         block.total_sample_index = 100;
@@ -329,7 +353,7 @@ mod tests {
     fn crc_guard_groups_nearby_expired_rejects() {
         let mut block =
             BleSyncBlock::<DefaultCpuReader<f32>, DefaultCpuWriter<u8>>::with_channel_and_phase(
-                0.0, false, 2, 37, 0,
+                2, 37, 0,
             );
 
         block.total_sample_index = 100;

--- a/examples/bluetooth/src/ble_sync.rs
+++ b/examples/bluetooth/src/ble_sync.rs
@@ -6,6 +6,7 @@ use crate::ble_detector::DetectorEvent;
 use crate::ble_detector::DetectorStats;
 use crate::ble_detector::PacketDetector;
 use crate::ble_slicer::SymbolSlicer;
+use crate::ble_wireshark;
 
 const CRC_REJECT_GUARD_SYMBOLS: usize = 512;
 
@@ -20,6 +21,7 @@ struct PendingReject {
 }
 
 #[derive(Block)]
+#[message_outputs(wireshark)]
 pub struct BleSyncBlock<I = DefaultCpuReader<f32>, O = DefaultCpuWriter<u8>>
 where
     I: CpuBufferReader<Item = f32>,
@@ -32,6 +34,7 @@ where
     samples_per_symbol: usize,
     initial_delay: usize,
     total_sample_index: usize,
+    wireshark_output: bool,
     slicer: SymbolSlicer,
     detectors: Vec<PacketDetector>,
     pending_crc_rejects: Vec<PendingReject>,
@@ -51,23 +54,25 @@ where
         channel_index: u8,
         initial_delay: usize,
     ) -> Self {
-        Self::with_channel_phase_and_packet_output(
+        Self::with_channel_phase_packet_and_wireshark_output(
             threshold,
             normalize_levels,
             samples_per_symbol,
             channel_index,
             initial_delay,
             true,
+            false,
         )
     }
 
-    pub fn with_channel_phase_and_packet_output(
+    pub fn with_channel_phase_packet_and_wireshark_output(
         threshold: f32,
         normalize_levels: bool,
         samples_per_symbol: usize,
         channel_index: u8,
         initial_delay: usize,
         print_packets: bool,
+        wireshark_output: bool,
     ) -> Self {
         let samples_per_symbol = std::cmp::max(1, samples_per_symbol);
         let detectors = (0..samples_per_symbol)
@@ -80,6 +85,7 @@ where
             samples_per_symbol,
             initial_delay,
             total_sample_index: 0,
+            wireshark_output,
             slicer: SymbolSlicer::new(threshold, normalize_levels),
             detectors,
             pending_crc_rejects: Vec::new(),
@@ -208,6 +214,9 @@ where
         let n = self.input.slice().len();
 
         if n == 0 {
+            if self.input.finished() {
+                _io.finished = true;
+            }
             return Ok(());
         }
 
@@ -226,6 +235,13 @@ where
                 DetectorEvent::None | DetectorEvent::HeaderRejected => {}
                 DetectorEvent::ValidPacket { packet } => {
                     self.connections.observe_packet(&packet);
+                    if self.wireshark_output {
+                        _mo.post(
+                            "wireshark",
+                            Pmt::Blob(ble_wireshark::packet_to_udp_payload(&packet)),
+                        )
+                        .await?;
+                    }
                     self.suppress_duplicate_crc_rejects();
                     for detector in &mut self.detectors {
                         detector.reset_to_search();
@@ -249,6 +265,9 @@ where
 
     async fn deinit(&mut self, _mo: &mut MessageOutputs, _meta: &mut BlockMeta) -> Result<()> {
         self.flush_all_crc_rejects();
+        if self.wireshark_output {
+            _mo.post("wireshark", Pmt::Finished).await?;
+        }
         self.print_stats();
 
         Ok(())

--- a/examples/bluetooth/src/ble_sync.rs
+++ b/examples/bluetooth/src/ble_sync.rs
@@ -1,5 +1,7 @@
 use futuresdr::runtime::dev::prelude::*;
 
+use crate::ble_connection::ConnectionTable;
+use crate::ble_connection::format_connection_summary;
 use crate::ble_detector::DetectorEvent;
 use crate::ble_detector::DetectorStats;
 use crate::ble_detector::PacketDetector;
@@ -33,6 +35,7 @@ where
     slicer: SymbolSlicer,
     detectors: Vec<PacketDetector>,
     pending_crc_rejects: Vec<PendingReject>,
+    connections: ConnectionTable,
 }
 
 impl<I, O> BleSyncBlock<I, O>
@@ -40,16 +43,35 @@ where
     I: CpuBufferReader<Item = f32>,
     O: CpuBufferWriter<Item = u8>,
 {
-    pub fn with_channel_and_phase(
+    #[cfg(test)]
+    fn with_channel_and_phase(
         threshold: f32,
         normalize_levels: bool,
         samples_per_symbol: usize,
         channel_index: u8,
         initial_delay: usize,
     ) -> Self {
+        Self::with_channel_phase_and_packet_output(
+            threshold,
+            normalize_levels,
+            samples_per_symbol,
+            channel_index,
+            initial_delay,
+            true,
+        )
+    }
+
+    pub fn with_channel_phase_and_packet_output(
+        threshold: f32,
+        normalize_levels: bool,
+        samples_per_symbol: usize,
+        channel_index: u8,
+        initial_delay: usize,
+        print_packets: bool,
+    ) -> Self {
         let samples_per_symbol = std::cmp::max(1, samples_per_symbol);
         let detectors = (0..samples_per_symbol)
-            .map(|phase| PacketDetector::new(phase, channel_index))
+            .map(|phase| PacketDetector::with_packet_output(phase, channel_index, print_packets))
             .collect();
 
         Self {
@@ -61,27 +83,21 @@ where
             slicer: SymbolSlicer::new(threshold, normalize_levels),
             detectors,
             pending_crc_rejects: Vec::new(),
+            connections: ConnectionTable::default(),
         }
     }
 
     fn aggregate_stats(&self) -> DetectorStats {
-        self.detectors.iter().map(PacketDetector::stats).fold(
-            DetectorStats::default(),
-            |acc, stats| DetectorStats {
-                aa_candidates: acc.aa_candidates + stats.aa_candidates,
-                header_rejects: acc.header_rejects + stats.header_rejects,
-                packets: acc.packets + stats.packets,
-                crc_rejects: acc.crc_rejects + stats.crc_rejects,
-                duplicate_crc_rejects: acc.duplicate_crc_rejects + stats.duplicate_crc_rejects,
-            },
-        )
+        aggregate_stats(self.detectors.iter().map(PacketDetector::stats))
     }
 
     fn print_stats(&self) {
         let stats = self.aggregate_stats();
         println!(
-            "BLE stats: packets={} aa_candidates={} aa_per_packet={:.2} header_rejects={} pdu_attempts={} crc_rejects={} duplicate_crc_rejects={} raw_crc_rejects={} crc_reject_rate={:.1}%",
+            "BLE stats: packets={} connect_ind={} connections={} aa_candidates={} aa_per_packet={:.2} header_rejects={} pdu_attempts={} crc_rejects={} duplicate_crc_rejects={} raw_crc_rejects={} crc_reject_rate={:.1}%",
             stats.packets,
+            stats.connect_ind_packets,
+            self.connections.len(),
             stats.aa_candidates,
             stats.aa_per_packet(),
             stats.header_rejects,
@@ -91,6 +107,13 @@ where
             stats.raw_crc_rejects(),
             stats.crc_reject_rate()
         );
+        for connection in self.connections.iter() {
+            println!(
+                "BLE connection: ch={} {}",
+                connection.last_channel,
+                format_connection_summary(connection)
+            );
+        }
     }
 
     fn crc_reject_guard_samples(&self) -> usize {
@@ -201,7 +224,8 @@ where
             let bit = self.slicer.slice(sample);
             match self.detectors[phase].process_symbol(bit) {
                 DetectorEvent::None | DetectorEvent::HeaderRejected => {}
-                DetectorEvent::ValidPacket => {
+                DetectorEvent::ValidPacket { packet } => {
+                    self.connections.observe_packet(&packet);
                     self.suppress_duplicate_crc_rejects();
                     for detector in &mut self.detectors {
                         detector.reset_to_search();
@@ -229,6 +253,17 @@ where
 
         Ok(())
     }
+}
+
+fn aggregate_stats(stats: impl Iterator<Item = DetectorStats>) -> DetectorStats {
+    stats.fold(DetectorStats::default(), |acc, stats| DetectorStats {
+        aa_candidates: acc.aa_candidates + stats.aa_candidates,
+        header_rejects: acc.header_rejects + stats.header_rejects,
+        packets: acc.packets + stats.packets,
+        crc_rejects: acc.crc_rejects + stats.crc_rejects,
+        duplicate_crc_rejects: acc.duplicate_crc_rejects + stats.duplicate_crc_rejects,
+        connect_ind_packets: acc.connect_ind_packets + stats.connect_ind_packets,
+    })
 }
 
 #[cfg(test)]

--- a/examples/bluetooth/src/ble_sync.rs
+++ b/examples/bluetooth/src/ble_sync.rs
@@ -1,0 +1,293 @@
+use futuresdr::runtime::dev::prelude::*;
+
+use crate::ble_detector::DetectorEvent;
+use crate::ble_detector::DetectorStats;
+use crate::ble_detector::PacketDetector;
+use crate::ble_slicer::SymbolSlicer;
+
+const CRC_REJECT_GUARD_SYMBOLS: usize = 512;
+
+fn print_diagnostics() -> bool {
+    cfg!(debug_assertions)
+}
+
+struct PendingReject {
+    sample_index: usize,
+    phase: usize,
+    reason: String,
+}
+
+#[derive(Block)]
+pub struct BleSyncBlock<I = DefaultCpuReader<f32>, O = DefaultCpuWriter<u8>>
+where
+    I: CpuBufferReader<Item = f32>,
+    O: CpuBufferWriter<Item = u8>,
+{
+    #[input]
+    input: I,
+    #[output]
+    output: O,
+    samples_per_symbol: usize,
+    initial_delay: usize,
+    total_sample_index: usize,
+    slicer: SymbolSlicer,
+    detectors: Vec<PacketDetector>,
+    pending_crc_rejects: Vec<PendingReject>,
+}
+
+impl<I, O> BleSyncBlock<I, O>
+where
+    I: CpuBufferReader<Item = f32>,
+    O: CpuBufferWriter<Item = u8>,
+{
+    pub fn with_channel_and_phase(
+        threshold: f32,
+        normalize_levels: bool,
+        samples_per_symbol: usize,
+        channel_index: u8,
+        initial_delay: usize,
+    ) -> Self {
+        let samples_per_symbol = std::cmp::max(1, samples_per_symbol);
+        let detectors = (0..samples_per_symbol)
+            .map(|phase| PacketDetector::new(phase, channel_index))
+            .collect();
+
+        Self {
+            input: I::default(),
+            output: O::default(),
+            samples_per_symbol,
+            initial_delay,
+            total_sample_index: 0,
+            slicer: SymbolSlicer::new(threshold, normalize_levels),
+            detectors,
+            pending_crc_rejects: Vec::new(),
+        }
+    }
+
+    fn aggregate_stats(&self) -> DetectorStats {
+        self.detectors.iter().map(PacketDetector::stats).fold(
+            DetectorStats::default(),
+            |acc, stats| DetectorStats {
+                aa_candidates: acc.aa_candidates + stats.aa_candidates,
+                header_rejects: acc.header_rejects + stats.header_rejects,
+                packets: acc.packets + stats.packets,
+                crc_rejects: acc.crc_rejects + stats.crc_rejects,
+                duplicate_crc_rejects: acc.duplicate_crc_rejects + stats.duplicate_crc_rejects,
+            },
+        )
+    }
+
+    fn print_stats(&self) {
+        let stats = self.aggregate_stats();
+        println!(
+            "BLE stats: packets={} aa_candidates={} aa_per_packet={:.2} header_rejects={} pdu_attempts={} crc_rejects={} duplicate_crc_rejects={} raw_crc_rejects={} crc_reject_rate={:.1}%",
+            stats.packets,
+            stats.aa_candidates,
+            stats.aa_per_packet(),
+            stats.header_rejects,
+            stats.pdu_attempts(),
+            stats.crc_rejects,
+            stats.duplicate_crc_rejects,
+            stats.raw_crc_rejects(),
+            stats.crc_reject_rate()
+        );
+    }
+
+    fn crc_reject_guard_samples(&self) -> usize {
+        self.samples_per_symbol
+            .saturating_mul(CRC_REJECT_GUARD_SYMBOLS)
+    }
+
+    fn record_crc_reject(&mut self, phase: usize, reason: String) {
+        self.pending_crc_rejects.push(PendingReject {
+            sample_index: self.total_sample_index,
+            phase,
+            reason,
+        });
+    }
+
+    fn suppress_duplicate_crc_rejects(&mut self) {
+        let guard_samples = self.crc_reject_guard_samples();
+        let now = self.total_sample_index;
+        let mut kept = Vec::with_capacity(self.pending_crc_rejects.len());
+
+        for reject in self.pending_crc_rejects.drain(..) {
+            if now.saturating_sub(reject.sample_index) <= guard_samples {
+                self.detectors[reject.phase].add_duplicate_crc_reject();
+            } else {
+                kept.push(reject);
+            }
+        }
+
+        self.pending_crc_rejects = kept;
+    }
+
+    fn flush_expired_crc_rejects(&mut self) {
+        self.flush_crc_rejects(false);
+    }
+
+    fn flush_all_crc_rejects(&mut self) {
+        self.flush_crc_rejects(true);
+    }
+
+    fn flush_crc_rejects(&mut self, force: bool) {
+        let guard_samples = self.crc_reject_guard_samples();
+        let now = self.total_sample_index;
+        let pending = std::mem::take(&mut self.pending_crc_rejects);
+        let mut pending = pending.into_iter().peekable();
+
+        while let Some(reject) = pending.next() {
+            if !force && now.saturating_sub(reject.sample_index) <= guard_samples {
+                self.pending_crc_rejects.push(reject);
+                self.pending_crc_rejects.extend(pending);
+                break;
+            }
+
+            let window_start = reject.sample_index;
+            let phase = reject.phase;
+            let reason = reject.reason;
+            let mut duplicates = 0u64;
+
+            while pending
+                .peek()
+                .is_some_and(|next| next.sample_index.saturating_sub(window_start) <= guard_samples)
+            {
+                let duplicate = pending.next().expect("peeked pending reject");
+                self.detectors[duplicate.phase].add_duplicate_crc_reject();
+                duplicates += 1;
+            }
+
+            self.detectors[phase].add_crc_reject();
+            if print_diagnostics() {
+                if duplicates == 0 {
+                    println!("BLE candidate rejected: phase={phase} {reason}");
+                } else {
+                    println!(
+                        "BLE candidate window rejected: phase={phase} duplicate_rejects={duplicates} {reason}"
+                    );
+                }
+            }
+        }
+    }
+}
+
+impl<I, O> Kernel for BleSyncBlock<I, O>
+where
+    I: CpuBufferReader<Item = f32>,
+    O: CpuBufferWriter<Item = u8>,
+{
+    async fn work(
+        &mut self,
+        _io: &mut WorkIo,
+        _mo: &mut MessageOutputs,
+        _meta: &mut BlockMeta,
+    ) -> Result<()> {
+        let n = self.input.slice().len();
+
+        if n == 0 {
+            return Ok(());
+        }
+
+        let input_samples = self.input.slice()[..n].to_vec();
+
+        for sample in input_samples {
+            if self.initial_delay > 0 {
+                self.initial_delay -= 1;
+                self.total_sample_index += 1;
+                continue;
+            }
+
+            let phase = self.total_sample_index % self.samples_per_symbol;
+            let bit = self.slicer.slice(sample);
+            match self.detectors[phase].process_symbol(bit) {
+                DetectorEvent::None | DetectorEvent::HeaderRejected => {}
+                DetectorEvent::ValidPacket => {
+                    self.suppress_duplicate_crc_rejects();
+                    for detector in &mut self.detectors {
+                        detector.reset_to_search();
+                    }
+                }
+                DetectorEvent::CrcRejected { reason } => {
+                    self.record_crc_reject(phase, reason);
+                }
+            }
+
+            self.flush_expired_crc_rejects();
+            self.total_sample_index += 1;
+        }
+
+        self.input.consume(n);
+        if self.input.finished() {
+            _io.finished = true;
+        }
+        Ok(())
+    }
+
+    async fn deinit(&mut self, _mo: &mut MessageOutputs, _meta: &mut BlockMeta) -> Result<()> {
+        self.flush_all_crc_rejects();
+        self.print_stats();
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::BleSyncBlock;
+    use super::DefaultCpuReader;
+    use super::DefaultCpuWriter;
+
+    #[test]
+    fn crc_guard_marks_nearby_reject_as_duplicate() {
+        let mut block =
+            BleSyncBlock::<DefaultCpuReader<f32>, DefaultCpuWriter<u8>>::with_channel_and_phase(
+                0.0, false, 2, 37, 0,
+            );
+
+        block.total_sample_index = 100;
+        block.record_crc_reject(0, "invalid BLE CRC".to_string());
+        block.total_sample_index += block.crc_reject_guard_samples();
+        block.suppress_duplicate_crc_rejects();
+
+        assert_eq!(block.detectors[0].stats().crc_rejects, 0);
+        assert_eq!(block.detectors[0].stats().duplicate_crc_rejects, 1);
+        assert!(block.pending_crc_rejects.is_empty());
+    }
+
+    #[test]
+    fn crc_guard_flushes_expired_reject() {
+        let mut block =
+            BleSyncBlock::<DefaultCpuReader<f32>, DefaultCpuWriter<u8>>::with_channel_and_phase(
+                0.0, false, 2, 37, 0,
+            );
+
+        block.total_sample_index = 100;
+        block.record_crc_reject(0, "invalid BLE CRC".to_string());
+        block.total_sample_index += block.crc_reject_guard_samples() + 1;
+        block.flush_expired_crc_rejects();
+
+        assert_eq!(block.detectors[0].stats().crc_rejects, 1);
+        assert_eq!(block.detectors[0].stats().duplicate_crc_rejects, 0);
+        assert!(block.pending_crc_rejects.is_empty());
+    }
+
+    #[test]
+    fn crc_guard_groups_nearby_expired_rejects() {
+        let mut block =
+            BleSyncBlock::<DefaultCpuReader<f32>, DefaultCpuWriter<u8>>::with_channel_and_phase(
+                0.0, false, 2, 37, 0,
+            );
+
+        block.total_sample_index = 100;
+        block.record_crc_reject(0, "first invalid BLE CRC".to_string());
+        block.total_sample_index += 10;
+        block.record_crc_reject(1, "second invalid BLE CRC".to_string());
+        block.total_sample_index = 100 + block.crc_reject_guard_samples() + 1;
+        block.flush_expired_crc_rejects();
+
+        assert_eq!(block.detectors[0].stats().crc_rejects, 1);
+        assert_eq!(block.detectors[1].stats().crc_rejects, 0);
+        assert_eq!(block.detectors[1].stats().duplicate_crc_rejects, 1);
+        assert!(block.pending_crc_rejects.is_empty());
+    }
+}

--- a/examples/bluetooth/src/ble_timing_recovery.rs
+++ b/examples/bluetooth/src/ble_timing_recovery.rs
@@ -1,0 +1,175 @@
+use crate::ble_channel_selection::BleChannelSelectionAlgorithm;
+use crate::ble_channel_selection::BleChannelSelector;
+
+const MAX_RECOVERY_OBSERVATIONS: usize = 32;
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+struct TimingRecoveryObservation {
+    sample_index: u64,
+    channel_index: u8,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) struct TimingRecovery {
+    observations: Vec<TimingRecoveryObservation>,
+    candidates: Vec<u16>,
+    counter_hint: Option<u16>,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) struct TimingRecoveryResolution {
+    pub(crate) event_counter: u16,
+    pub(crate) counter_exact: bool,
+}
+
+impl TimingRecovery {
+    pub(crate) fn new(counter_hint: Option<u16>) -> Self {
+        Self {
+            observations: Vec::new(),
+            candidates: Vec::new(),
+            counter_hint,
+        }
+    }
+
+    pub(crate) fn observe(
+        &mut self,
+        channel_selector: &BleChannelSelector,
+        interval_samples: u64,
+        sample_index: u64,
+        channel_index: u8,
+    ) -> Option<TimingRecoveryResolution> {
+        let observation = TimingRecoveryObservation {
+            sample_index,
+            channel_index,
+        };
+        if !self.observations.contains(&observation) {
+            self.observations.push(observation);
+            self.observations
+                .sort_unstable_by_key(|observation| observation.sample_index);
+            if self.observations.len() > MAX_RECOVERY_OBSERVATIONS {
+                self.observations.remove(0);
+            }
+        }
+
+        self.recompute_candidates(channel_selector, interval_samples);
+        if self.candidates.is_empty() {
+            self.observations.clear();
+            self.observations.push(observation);
+            self.recompute_candidates(channel_selector, interval_samples);
+        }
+
+        let reference_sample = self.observations.first()?.sample_index;
+        let event_delta = event_delta(reference_sample, sample_index, interval_samples)?;
+        match channel_selector.algorithm() {
+            BleChannelSelectionAlgorithm::Csa1 => {
+                let mut phases = self
+                    .candidates
+                    .iter()
+                    .map(|candidate| candidate % 37)
+                    .collect::<Vec<_>>();
+                phases.sort_unstable();
+                phases.dedup();
+                if phases.len() != 1 {
+                    return None;
+                }
+                let base_counter = self.closest_candidate_to_hint()?;
+                Some(TimingRecoveryResolution {
+                    event_counter: base_counter.wrapping_add(event_delta as u16),
+                    counter_exact: self.candidates.len() == 1,
+                })
+            }
+            BleChannelSelectionAlgorithm::Csa2 => {
+                let base_counter = *self.candidates.first()?;
+                (self.candidates.len() == 1).then_some(TimingRecoveryResolution {
+                    event_counter: base_counter.wrapping_add(event_delta as u16),
+                    counter_exact: true,
+                })
+            }
+        }
+    }
+
+    pub(crate) fn candidate_count(&self) -> usize {
+        self.candidates.len()
+    }
+
+    fn recompute_candidates(
+        &mut self,
+        channel_selector: &BleChannelSelector,
+        interval_samples: u64,
+    ) {
+        let Some(reference_sample) = self
+            .observations
+            .first()
+            .map(|observation| observation.sample_index)
+        else {
+            self.candidates.clear();
+            return;
+        };
+        self.candidates = (0..=u16::MAX)
+            .filter(|base_counter| {
+                self.observations.iter().all(|observation| {
+                    let Some(delta) =
+                        event_delta(reference_sample, observation.sample_index, interval_samples)
+                    else {
+                        return false;
+                    };
+                    let event_counter = base_counter.wrapping_add(delta as u16);
+                    channel_selector.channel_for_event(event_counter) == observation.channel_index
+                })
+            })
+            .collect();
+    }
+
+    fn closest_candidate_to_hint(&self) -> Option<u16> {
+        match self.counter_hint {
+            Some(hint) => self
+                .candidates
+                .iter()
+                .copied()
+                .min_by_key(|candidate| candidate.wrapping_sub(hint)),
+            None => self.candidates.first().copied(),
+        }
+    }
+}
+
+fn event_delta(reference_sample: u64, sample_index: u64, interval_samples: u64) -> Option<u64> {
+    (interval_samples > 0 && sample_index >= reference_sample)
+        .then(|| (sample_index - reference_sample + interval_samples / 2) / interval_samples)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn csa2_recovery_narrows_to_an_exact_event_counter() {
+        let selector = BleChannelSelector::new(
+            BleChannelSelectionAlgorithm::Csa2,
+            0x8e89_bed6,
+            0,
+            [0xff, 0xff, 0xff, 0xff, 0x1f],
+        )
+        .unwrap();
+        let mut recovery = TimingRecovery::new(None);
+        let reference_counter = 12_345u16;
+        let reference_sample = 1_000_000;
+        let interval_samples = 60_000;
+        let mut resolution = None;
+
+        for delta in 0..256u64 {
+            let event_counter = reference_counter.wrapping_add(delta as u16);
+            resolution = recovery.observe(
+                &selector,
+                interval_samples,
+                reference_sample + delta * interval_samples,
+                selector.channel_for_event(event_counter),
+            );
+            if resolution.is_some() {
+                break;
+            }
+        }
+
+        let resolution = resolution.expect("CSA#2 observations should identify one counter");
+        assert!(resolution.counter_exact);
+    }
+}

--- a/examples/bluetooth/src/ble_wireshark.rs
+++ b/examples/bluetooth/src/ble_wireshark.rs
@@ -1,0 +1,89 @@
+use crate::ble_protocol::BlePacket;
+
+const RFTAP_VERSION: u16 = 3;
+const RFTAP_PACKET_TYPE: u16 = 1;
+const DLT_BLUETOOTH_LE_LL_WITH_PHDR: u32 = 256;
+
+const LE_DEWHITENED: u16 = 0x0001;
+const LE_CRC_CHECKED: u16 = 0x0400;
+const LE_CRC_VALID: u16 = 0x0800;
+const LE_PHY_1M: u16 = 0x0000;
+
+pub(crate) fn packet_to_udp_payload(packet: &BlePacket) -> Vec<u8> {
+    let ble_packet_len = 4 + packet.pdu.len() + 3;
+    let mut payload = Vec::with_capacity(12 + 10 + ble_packet_len);
+
+    payload.extend_from_slice(b"RFta");
+    payload.extend_from_slice(&RFTAP_VERSION.to_le_bytes());
+    payload.extend_from_slice(&RFTAP_PACKET_TYPE.to_le_bytes());
+    payload.extend_from_slice(&DLT_BLUETOOTH_LE_LL_WITH_PHDR.to_le_bytes());
+
+    payload.push(rf_channel(packet.channel_index));
+    payload.push(0);
+    payload.push(0);
+    payload.push(0);
+    payload.extend_from_slice(&0u32.to_le_bytes());
+    payload.extend_from_slice(
+        &(LE_DEWHITENED | LE_CRC_CHECKED | LE_CRC_VALID | LE_PHY_1M).to_le_bytes(),
+    );
+
+    payload.extend_from_slice(&packet.access_address.to_le_bytes());
+    payload.extend_from_slice(&packet.pdu);
+    payload.push((packet.crc & 0xff) as u8);
+    payload.push(((packet.crc >> 8) & 0xff) as u8);
+    payload.push(((packet.crc >> 16) & 0xff) as u8);
+    payload
+}
+
+fn rf_channel(channel_index: u8) -> u8 {
+    match channel_index {
+        37 => 0,
+        38 => 12,
+        39 => 39,
+        0..=10 => channel_index + 1,
+        11..=36 => channel_index + 2,
+        _ => 0,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::ble_phy::build_advertising_pdu_crc;
+    use crate::ble_protocol;
+    use crate::ble_protocol::BLE_ACCESS_ADDRESS;
+    use crate::ble_protocol::BleAdvPduType;
+
+    #[test]
+    fn builds_rftap_btle_udp_payload() {
+        let adv_a = [0x11, 0x22, 0x33, 0x44, 0x55, 0x66];
+        let adv_data = [0x02, 0x01, 0x06];
+        let whitened =
+            build_advertising_pdu_crc(37, BleAdvPduType::AdvNonconnInd, &adv_a, &adv_data);
+        let packet = ble_protocol::parse_advertising_pdu(37, &whitened).unwrap();
+
+        let payload = packet_to_udp_payload(&packet);
+
+        assert_eq!(&payload[0..4], b"RFta");
+        assert_eq!(&payload[4..6], &RFTAP_VERSION.to_le_bytes());
+        assert_eq!(
+            &payload[8..12],
+            &DLT_BLUETOOTH_LE_LL_WITH_PHDR.to_le_bytes()
+        );
+        assert_eq!(payload[12], 0);
+        assert_eq!(&payload[22..26], &BLE_ACCESS_ADDRESS.to_le_bytes());
+        assert_eq!(&payload[26..26 + packet.pdu.len()], packet.pdu.as_slice());
+        assert_eq!(payload.len(), 12 + 10 + 4 + packet.pdu.len() + 3);
+    }
+
+    #[test]
+    fn maps_ble_channel_to_rf_channel() {
+        assert_eq!(rf_channel(37), 0);
+        assert_eq!(rf_channel(38), 12);
+        assert_eq!(rf_channel(39), 39);
+        assert_eq!(rf_channel(0), 1);
+        assert_eq!(rf_channel(10), 11);
+        assert_eq!(rf_channel(11), 13);
+        assert_eq!(rf_channel(36), 38);
+    }
+}

--- a/examples/bluetooth/src/ble_wireshark.rs
+++ b/examples/bluetooth/src/ble_wireshark.rs
@@ -1,4 +1,6 @@
+use crate::ble_data::BleDataPacket;
 use crate::ble_protocol::BlePacket;
+use crate::ble_protocol::BlePhy;
 
 const RFTAP_VERSION: u16 = 3;
 const RFTAP_PACKET_TYPE: u16 = 1;
@@ -8,9 +10,37 @@ const LE_DEWHITENED: u16 = 0x0001;
 const LE_CRC_CHECKED: u16 = 0x0400;
 const LE_CRC_VALID: u16 = 0x0800;
 const LE_PHY_1M: u16 = 0x0000;
+const LE_PHY_2M: u16 = 0x4000;
+const LE_PHY_CODED: u16 = 0x8000;
 
 pub(crate) fn packet_to_udp_payload(packet: &BlePacket) -> Vec<u8> {
-    let ble_packet_len = 4 + packet.pdu.len() + 3;
+    build_udp_payload(
+        packet.channel_index,
+        packet.phy,
+        packet.access_address,
+        &packet.pdu,
+        packet.crc,
+    )
+}
+
+pub(crate) fn data_packet_to_udp_payload(packet: &BleDataPacket) -> Vec<u8> {
+    build_udp_payload(
+        packet.channel_index,
+        packet.phy,
+        packet.access_address,
+        &packet.pdu,
+        packet.crc,
+    )
+}
+
+fn build_udp_payload(
+    channel_index: u8,
+    phy: BlePhy,
+    access_address: u32,
+    pdu: &[u8],
+    crc: u32,
+) -> Vec<u8> {
+    let ble_packet_len = 4 + pdu.len() + 3;
     let mut payload = Vec::with_capacity(12 + 10 + ble_packet_len);
 
     payload.extend_from_slice(b"RFta");
@@ -18,21 +48,29 @@ pub(crate) fn packet_to_udp_payload(packet: &BlePacket) -> Vec<u8> {
     payload.extend_from_slice(&RFTAP_PACKET_TYPE.to_le_bytes());
     payload.extend_from_slice(&DLT_BLUETOOTH_LE_LL_WITH_PHDR.to_le_bytes());
 
-    payload.push(rf_channel(packet.channel_index));
+    payload.push(rf_channel(channel_index));
     payload.push(0);
     payload.push(0);
     payload.push(0);
     payload.extend_from_slice(&0u32.to_le_bytes());
     payload.extend_from_slice(
-        &(LE_DEWHITENED | LE_CRC_CHECKED | LE_CRC_VALID | LE_PHY_1M).to_le_bytes(),
+        &(LE_DEWHITENED | LE_CRC_CHECKED | LE_CRC_VALID | phy_flags(phy)).to_le_bytes(),
     );
 
-    payload.extend_from_slice(&packet.access_address.to_le_bytes());
-    payload.extend_from_slice(&packet.pdu);
-    payload.push((packet.crc & 0xff) as u8);
-    payload.push(((packet.crc >> 8) & 0xff) as u8);
-    payload.push(((packet.crc >> 16) & 0xff) as u8);
+    payload.extend_from_slice(&access_address.to_le_bytes());
+    payload.extend_from_slice(pdu);
+    payload.push((crc & 0xff) as u8);
+    payload.push(((crc >> 8) & 0xff) as u8);
+    payload.push(((crc >> 16) & 0xff) as u8);
     payload
+}
+
+fn phy_flags(phy: BlePhy) -> u16 {
+    match phy {
+        BlePhy::Le1M => LE_PHY_1M,
+        BlePhy::Le2M => LE_PHY_2M,
+        BlePhy::LeCoded => LE_PHY_CODED,
+    }
 }
 
 fn rf_channel(channel_index: u8) -> u8 {
@@ -49,6 +87,8 @@ fn rf_channel(channel_index: u8) -> u8 {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::ble_data::build_data_pdu_crc;
+    use crate::ble_data::parse_data_pdu;
     use crate::ble_phy::build_advertising_pdu_crc;
     use crate::ble_protocol;
     use crate::ble_protocol::BLE_ACCESS_ADDRESS;
@@ -85,5 +125,26 @@ mod tests {
         assert_eq!(rf_channel(10), 11);
         assert_eq!(rf_channel(11), 13);
         assert_eq!(rf_channel(36), 38);
+    }
+
+    #[test]
+    fn builds_rftap_payload_for_connection_data() {
+        let access_address = 0x1234_5678;
+        let crc_init = 0x00ab_cdef;
+        let whitened = build_data_pdu_crc(0, crc_init, 0x02, &[0x01, 0x02]);
+        let packet = parse_data_pdu(0, BlePhy::Le1M, access_address, crc_init, &whitened).unwrap();
+
+        let payload = data_packet_to_udp_payload(&packet);
+
+        assert_eq!(&payload[22..26], &access_address.to_le_bytes());
+        assert_eq!(&payload[26..26 + packet.pdu.len()], packet.pdu.as_slice());
+        assert_eq!(payload.len(), 12 + 10 + 4 + packet.pdu.len() + 3);
+    }
+
+    #[test]
+    fn maps_ble_phy_to_rftap_flags() {
+        assert_eq!(phy_flags(BlePhy::Le1M), LE_PHY_1M);
+        assert_eq!(phy_flags(BlePhy::Le2M), LE_PHY_2M);
+        assert_eq!(phy_flags(BlePhy::LeCoded), LE_PHY_CODED);
     }
 }

--- a/examples/bluetooth/src/channelizer.rs
+++ b/examples/bluetooth/src/channelizer.rs
@@ -1,0 +1,317 @@
+use anyhow::Result;
+use anyhow::bail;
+use futuredsp::firdes::remez;
+
+use crate::ble_protocol;
+
+pub(crate) const BLE_CHANNEL_SPACING_HZ: f64 = 2.0e6;
+const MULTI_CHANNEL_GUARD_BINS: usize = 1;
+
+pub(crate) fn pfb_channelizer_taps(pfb_channels: usize) -> Vec<f32> {
+    let transition_bw = 0.5;
+    remez::low_pass(
+        1.0,
+        pfb_channels,
+        0.5 - transition_bw / 2.0,
+        0.5 + transition_bw / 2.0,
+        0.1,
+        100.0,
+        None,
+    )
+    .into_iter()
+    .map(|tap| tap as f32)
+    .collect()
+}
+
+pub(crate) fn pfb_channels_from_sample_rate(sample_rate: f64) -> Result<usize> {
+    let channels = sample_rate / BLE_CHANNEL_SPACING_HZ;
+    let rounded = channels.round();
+
+    if (channels - rounded).abs() > 1e-6 {
+        bail!(
+            "multi-channel sample rate must be an integer multiple of 2 MHz, got {:.3} MS/s",
+            sample_rate / 1.0e6
+        );
+    }
+
+    let channels = rounded as usize;
+    if channels <= 2 {
+        bail!("multi-channel mode needs at least 4 MHz sample rate");
+    }
+
+    Ok(channels)
+}
+
+pub(crate) fn center_frequency_for_channels(channels: &[u8]) -> Result<f64> {
+    let frequencies_mhz: Vec<i32> = channels
+        .iter()
+        .map(|&channel| {
+            ble_protocol::frequency_hz_from_channel_index(channel)
+                .map(|freq| (freq / BLE_CHANNEL_SPACING_HZ).round() as i32)
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+
+    let min_bin = frequencies_mhz.iter().min().copied().unwrap_or(1201);
+    let max_bin = frequencies_mhz.iter().max().copied().unwrap_or(min_bin);
+    let center_bin = min_bin + (max_bin - min_bin + 1) / 2;
+
+    Ok(center_bin as f64 * BLE_CHANNEL_SPACING_HZ)
+}
+
+pub(crate) fn auto_multi_channel_sample_rate(
+    channels: &[u8],
+    center_frequency: f64,
+) -> Result<f64> {
+    let max_offset_bins = channels
+        .iter()
+        .map(|&channel| {
+            ble_protocol::frequency_hz_from_channel_index(channel).map(|freq| {
+                ((freq - center_frequency) / BLE_CHANNEL_SPACING_HZ)
+                    .round()
+                    .abs() as usize
+            })
+        })
+        .collect::<Result<Vec<_>, _>>()?
+        .into_iter()
+        .max()
+        .unwrap_or(0);
+
+    let pfb_channels = ((max_offset_bins + MULTI_CHANNEL_GUARD_BINS) * 2).max(4);
+    Ok(pfb_channels as f64 * BLE_CHANNEL_SPACING_HZ)
+}
+
+pub(crate) fn pfb_port_for_frequency(
+    frequency: f64,
+    center_frequency: f64,
+    pfb_channels: usize,
+) -> Result<usize> {
+    let offset_bins = (frequency - center_frequency) / BLE_CHANNEL_SPACING_HZ;
+    let rounded = offset_bins.round();
+
+    if (offset_bins - rounded).abs() > 1e-6 {
+        bail!(
+            "frequency {:.3} MHz does not align with the 2 MHz PFB grid around center {:.3} MHz",
+            frequency / 1.0e6,
+            center_frequency / 1.0e6,
+        );
+    }
+
+    let offset_bins = rounded as isize;
+    let half = (pfb_channels / 2) as isize;
+    if offset_bins.abs() >= half {
+        bail!(
+            "frequency {:.3} MHz is outside the usable PFB span for center {:.3} MHz and {} channels",
+            frequency / 1.0e6,
+            center_frequency / 1.0e6,
+            pfb_channels,
+        );
+    }
+
+    if offset_bins >= 0 {
+        Ok(offset_bins as usize)
+    } else {
+        Ok(pfb_channels - (-offset_bins as usize))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use anyhow::Result;
+    use futuresdr::blocks::PfbChannelizer;
+    use futuresdr::blocks::VectorSink;
+    use futuresdr::blocks::VectorSource;
+    use futuresdr::num_complex::Complex32;
+    use futuresdr::prelude::*;
+    use futuresdr::runtime::dev::DefaultCpuReader;
+    use futuresdr::runtime::dev::DefaultCpuWriter;
+
+    use super::*;
+
+    #[test]
+    fn multi_channel_center_keeps_ble_grid_alignment() {
+        let center = center_frequency_for_channels(&[37, 38]).unwrap();
+
+        assert_eq!(center, 2.414e9);
+    }
+
+    #[test]
+    fn pfb_ports_map_positive_and_negative_offsets() {
+        let center = 2.414e9;
+
+        assert_eq!(
+            pfb_port_for_frequency(
+                ble_protocol::frequency_hz_from_channel_index(37).unwrap(),
+                center,
+                16
+            )
+            .unwrap(),
+            10
+        );
+        assert_eq!(
+            pfb_port_for_frequency(
+                ble_protocol::frequency_hz_from_channel_index(38).unwrap(),
+                center,
+                16
+            )
+            .unwrap(),
+            6
+        );
+    }
+
+    #[test]
+    fn auto_sample_rate_leaves_guard_bins() {
+        let center = center_frequency_for_channels(&[37, 38]).unwrap();
+
+        assert_eq!(
+            auto_multi_channel_sample_rate(&[37, 38], center).unwrap(),
+            28.0e6
+        );
+    }
+
+    #[test]
+    fn adjacent_advertising_and_data_channel_fit_in_lower_rate() {
+        let center = center_frequency_for_channels(&[37, 0]).unwrap();
+
+        assert_eq!(center, 2.404e9);
+        assert_eq!(
+            auto_multi_channel_sample_rate(&[37, 0], center).unwrap(),
+            8.0e6
+        );
+        assert_eq!(
+            pfb_port_for_frequency(
+                ble_protocol::frequency_hz_from_channel_index(37).unwrap(),
+                center,
+                4
+            )
+            .unwrap(),
+            3
+        );
+        assert_eq!(
+            pfb_port_for_frequency(
+                ble_protocol::frequency_hz_from_channel_index(0).unwrap(),
+                center,
+                4
+            )
+            .unwrap(),
+            0
+        );
+    }
+
+    #[test]
+    fn pfb_routes_synthetic_ble_channel_tones() -> Result<()> {
+        let pfb_channels = 14;
+        let sample_count = 16_384;
+        let taps = pfb_channelizer_taps(pfb_channels);
+        let center = center_frequency_for_channels(&[37, 38])?;
+
+        let ch37_port = pfb_port_for_frequency(
+            ble_protocol::frequency_hz_from_channel_index(37)?,
+            center,
+            pfb_channels,
+        )?;
+        let ch38_port = pfb_port_for_frequency(
+            ble_protocol::frequency_hz_from_channel_index(38)?,
+            center,
+            pfb_channels,
+        )?;
+
+        let ch37_powers = pfb_output_powers_db(
+            tone_at_pfb_bin(-6, pfb_channels, sample_count),
+            pfb_channels,
+            &taps,
+        )?;
+        let ch38_powers = pfb_output_powers_db(
+            tone_at_pfb_bin(6, pfb_channels, sample_count),
+            pfb_channels,
+            &taps,
+        )?;
+
+        assert_eq!(strongest_output(&ch37_powers), ch37_port);
+        assert_eq!(strongest_output(&ch38_powers), ch38_port);
+
+        assert!(
+            neighbor_leakage_db(&ch37_powers, ch37_port) < -30.0,
+            "ch37 neighbor leakage {:.1} dB, powers {:?}",
+            neighbor_leakage_db(&ch37_powers, ch37_port),
+            ch37_powers
+        );
+        assert!(
+            neighbor_leakage_db(&ch38_powers, ch38_port) < -30.0,
+            "ch38 neighbor leakage {:.1} dB, powers {:?}",
+            neighbor_leakage_db(&ch38_powers, ch38_port),
+            ch38_powers
+        );
+
+        Ok(())
+    }
+
+    fn tone_at_pfb_bin(bin: isize, pfb_channels: usize, sample_count: usize) -> Vec<Complex32> {
+        let phase_step = 2.0 * std::f64::consts::PI * bin as f64 / pfb_channels as f64;
+        (0..sample_count)
+            .map(|index| {
+                let phase = phase_step * index as f64;
+                Complex32::new(phase.cos() as f32, phase.sin() as f32)
+            })
+            .collect()
+    }
+
+    fn pfb_output_powers_db(
+        input: Vec<Complex32>,
+        pfb_channels: usize,
+        taps: &[f32],
+    ) -> Result<Vec<f64>> {
+        let mut fg = Flowgraph::new();
+        let src = fg.add(VectorSource::<Complex32>::new(input));
+        let channelizer = fg.add(PfbChannelizer::<
+            DefaultCpuReader<Complex32>,
+            DefaultCpuWriter<Complex32>,
+        >::new(pfb_channels, taps, 1.0));
+        fg.stream_dyn(src, "output", channelizer, "input")?;
+
+        let mut sinks = Vec::with_capacity(pfb_channels);
+        for port in 0..pfb_channels {
+            let sink = fg.add(VectorSink::<Complex32>::new(2048));
+            fg.stream_dyn(channelizer, format!("outputs[{port}]"), sink, "input")?;
+            sinks.push(sink);
+        }
+
+        let fg = Runtime::new().run(fg)?;
+        let powers = sinks
+            .iter()
+            .map(|sink| {
+                let sink = fg.block(sink)?;
+                Ok(mean_power_db(sink.items()))
+            })
+            .collect::<Result<Vec<_>>>()?;
+
+        Ok(powers)
+    }
+
+    fn mean_power_db(samples: &[Complex32]) -> f64 {
+        let skip = samples.len().min(16);
+        let samples = &samples[skip..];
+        let mean_power = samples
+            .iter()
+            .map(|sample| sample.norm_sqr() as f64)
+            .sum::<f64>()
+            / samples.len().max(1) as f64;
+
+        10.0 * mean_power.max(1.0e-20).log10()
+    }
+
+    fn strongest_output(powers_db: &[f64]) -> usize {
+        powers_db
+            .iter()
+            .enumerate()
+            .max_by(|(_, a), (_, b)| a.total_cmp(b))
+            .map(|(index, _)| index)
+            .unwrap()
+    }
+
+    fn neighbor_leakage_db(powers_db: &[f64], main_port: usize) -> f64 {
+        let main_power = powers_db[main_port];
+        let lower = powers_db[(main_port + powers_db.len() - 1) % powers_db.len()] - main_power;
+        let upper = powers_db[(main_port + 1) % powers_db.len()] - main_power;
+        lower.max(upper)
+    }
+}

--- a/examples/bluetooth/src/cli.rs
+++ b/examples/bluetooth/src/cli.rs
@@ -1,0 +1,153 @@
+use std::path::PathBuf;
+
+use anyhow::Result;
+use anyhow::bail;
+use clap::Parser;
+use clap::ValueEnum;
+
+use crate::ble_protocol;
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, ValueEnum)]
+pub(crate) enum DecoderMode {
+    Continuous,
+    Burst,
+}
+
+#[derive(Parser, Debug)]
+#[command(version)]
+pub(crate) struct Args {
+    #[arg(short, long, default_value = "")]
+    pub(crate) args: String,
+    #[arg(short, long, value_delimiter = ',', default_value = "37")]
+    pub(crate) channels: Vec<u8>,
+    #[arg(short, long, default_value_t = 2.0e6)]
+    pub(crate) sample_rate: f64,
+    #[arg(short, long, default_value_t = 30.0)]
+    pub(crate) gain: f64,
+    #[arg(long)]
+    pub(crate) antenna: Option<String>,
+    #[arg(long, value_enum)]
+    pub(crate) decoder: Option<DecoderMode>,
+    #[arg(long, default_value_t = false)]
+    pub(crate) follow_connections: bool,
+    #[arg(long, allow_hyphen_values = true)]
+    pub(crate) squelch_db: Option<f32>,
+    #[arg(long, default_value_t = 13.0)]
+    pub(crate) squelch_margin_db: f32,
+    #[arg(long, default_value_t = false)]
+    pub(crate) quiet: bool,
+    #[arg(long, default_value_t = false)]
+    pub(crate) wireshark: bool,
+    #[arg(long, default_value = "127.0.0.1:55556")]
+    pub(crate) wireshark_addr: String,
+    #[arg(long, default_value_t = false)]
+    pub(crate) simulate: bool,
+    #[arg(long, default_value_t = 1)]
+    pub(crate) simulate_packets: usize,
+    #[arg(long)]
+    pub(crate) iq_file: Option<PathBuf>,
+    #[arg(long)]
+    pub(crate) duration: Option<f64>,
+}
+
+impl Args {
+    pub(crate) fn is_multi_channel(&self) -> bool {
+        let mut channels = self.channels.clone();
+        channels.sort_unstable();
+        channels.dedup();
+        channels.len() > 1
+    }
+
+    pub(crate) fn decoder_mode(&self) -> DecoderMode {
+        self.decoder.unwrap_or(if self.is_multi_channel() {
+            DecoderMode::Burst
+        } else {
+            DecoderMode::Continuous
+        })
+    }
+}
+
+pub(crate) fn validate(args: &Args) -> Result<()> {
+    if args.simulate && args.iq_file.is_some() {
+        bail!("--simulate and --iq-file cannot be used together");
+    }
+    if args.follow_connections && args.decoder_mode() != DecoderMode::Burst {
+        bail!("--follow-connections requires --decoder burst");
+    }
+    if args.follow_connections && !args.is_multi_channel() {
+        bail!("--follow-connections requires at least two --channels values");
+    }
+    if !args.sample_rate.is_finite() || args.sample_rate <= 0.0 {
+        bail!("--sample-rate must be a positive finite value");
+    }
+    if !args.squelch_margin_db.is_finite() || args.squelch_margin_db <= 0.0 {
+        bail!("--squelch-margin-db must be a positive finite value");
+    }
+    if args.squelch_db.is_some_and(|value| !value.is_finite()) {
+        bail!("--squelch-db must be finite");
+    }
+
+    Ok(())
+}
+
+pub(crate) fn selected_channels(args: &Args) -> Result<Vec<u8>> {
+    let mut channels = args.channels.clone();
+
+    channels.sort_unstable();
+    channels.dedup();
+
+    for &channel in &channels {
+        ble_protocol::frequency_hz_from_channel_index(channel)?;
+    }
+
+    Ok(channels)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn single_channel_defaults_to_continuous_decoder() {
+        let args = Args::try_parse_from(["sniffer"]).unwrap();
+
+        assert!(!args.is_multi_channel());
+        assert_eq!(args.decoder_mode(), DecoderMode::Continuous);
+        assert_eq!(selected_channels(&args).unwrap(), vec![37]);
+    }
+
+    #[test]
+    fn one_explicit_channel_selects_single_channel_mode() {
+        let args = Args::try_parse_from(["sniffer", "--channels", "38"]).unwrap();
+
+        assert!(!args.is_multi_channel());
+        assert_eq!(args.decoder_mode(), DecoderMode::Continuous);
+        assert_eq!(selected_channels(&args).unwrap(), vec![38]);
+    }
+
+    #[test]
+    fn channel_list_selects_multi_channel_burst_mode() {
+        let args = Args::try_parse_from(["sniffer", "--channels", "37,38"]).unwrap();
+
+        assert!(args.is_multi_channel());
+        assert_eq!(args.decoder_mode(), DecoderMode::Burst);
+        assert_eq!(selected_channels(&args).unwrap(), vec![37, 38]);
+    }
+
+    #[test]
+    fn multi_channel_decoder_can_be_overridden() {
+        let args =
+            Args::try_parse_from(["sniffer", "--channels", "37,38", "--decoder", "continuous"])
+                .unwrap();
+
+        assert_eq!(args.decoder_mode(), DecoderMode::Continuous);
+    }
+
+    #[test]
+    fn duplicate_channels_still_select_single_channel_mode() {
+        let args = Args::try_parse_from(["sniffer", "--channels", "37,37"]).unwrap();
+
+        assert!(!args.is_multi_channel());
+        assert_eq!(selected_channels(&args).unwrap(), vec![37]);
+    }
+}

--- a/examples/bluetooth/src/diagnostics.rs
+++ b/examples/bluetooth/src/diagnostics.rs
@@ -1,0 +1,3 @@
+pub(crate) const fn enabled() -> bool {
+    cfg!(debug_assertions)
+}

--- a/examples/bluetooth/src/flowgraph.rs
+++ b/examples/bluetooth/src/flowgraph.rs
@@ -1,0 +1,322 @@
+use anyhow::Result;
+use anyhow::bail;
+use futuresdr::blocks::Apply;
+use futuresdr::blocks::BlobToUdp;
+use futuresdr::blocks::FileSource;
+use futuresdr::blocks::FirBuilder;
+use futuresdr::blocks::NullSink;
+use futuresdr::blocks::PfbChannelizer;
+use futuresdr::blocks::VectorSource;
+use futuresdr::blocks::seify::Builder;
+use futuresdr::num_complex::Complex32;
+use futuresdr::prelude::*;
+use futuresdr::runtime::BlockId;
+use futuresdr::runtime::dev::DefaultCpuReader;
+use futuresdr::runtime::dev::DefaultCpuWriter;
+
+use crate::ble_connection::SharedConnectionTable;
+use crate::ble_iq_burst;
+use crate::ble_protocol;
+use crate::ble_protocol::BlePhy;
+use crate::ble_sim;
+use crate::ble_sync;
+use crate::channelizer::BLE_CHANNEL_SPACING_HZ;
+use crate::channelizer::center_frequency_for_channels;
+use crate::channelizer::pfb_channelizer_taps;
+use crate::channelizer::pfb_channels_from_sample_rate;
+use crate::channelizer::pfb_port_for_frequency;
+use crate::cli::Args;
+use crate::cli::DecoderMode;
+use crate::gmsk_demod;
+
+pub(crate) fn build_single_channel_flowgraph(
+    mut fg: &mut Flowgraph,
+    args: &Args,
+    sample_rate: f64,
+) -> Result<()> {
+    let phy = BlePhy::Le1M;
+    let channel_index = args.channels[0];
+    let connections = SharedConnectionTable::with_monitored_channels(&[channel_index]);
+    let symbol_rate = phy.symbol_rate_hz();
+    let samples_per_symbol = (sample_rate / symbol_rate).round().max(1.0) as usize;
+    let symbol_rate_ratio = sample_rate / symbol_rate;
+    if (symbol_rate_ratio - samples_per_symbol as f64).abs() > 0.05 {
+        println!(
+            "Sample rate {:.3} MS/s is not close to an integer multiple of the BLE 1 Msym/s symbol rate; symbol slicing may be less reliable",
+            sample_rate / 1.0e6
+        );
+    }
+
+    let frequency = ble_protocol::frequency_hz_from_channel_index(channel_index)?;
+    println!(
+        "Using BLE channel {channel_index} ({:.3} MHz)",
+        frequency / 1.0e6
+    );
+    if args.decoder_mode() == DecoderMode::Burst {
+        match args.squelch_db {
+            Some(threshold_db) => println!(
+                "Using IQ burst decoder with fixed squelch threshold {threshold_db:.1} dB."
+            ),
+            None => println!(
+                "Using IQ burst decoder with adaptive squelch margin {:.1} dB.",
+                args.squelch_margin_db
+            ),
+        }
+    } else {
+        println!("Using continuous packet decoder.");
+    }
+
+    let rx_taps = gmsk_demod::gmsk_rx_taps(samples_per_symbol)?;
+    println!("GMSK receive filter configured.");
+    let snk = NullSink::<u8>::new();
+
+    if args.decoder_mode() == DecoderMode::Burst {
+        let ble_burst = ble_iq_burst::BleIqBurstBlock::<
+            DefaultCpuReader<Complex32>,
+            DefaultCpuWriter<u8>,
+        >::with_packet_and_wireshark_output(
+            phy,
+            samples_per_symbol,
+            channel_index,
+            rx_taps,
+            burst_squelch(args),
+            ble_iq_burst::BleIqBurstOptions {
+                print_packets: !args.quiet,
+                wireshark_output: args.wireshark,
+                follow_connections: args.follow_connections,
+            },
+        )?
+        .with_connections(connections.clone());
+
+        if args.simulate {
+            println!("Simulation mode: Testing full GMSK demodulator DSP chain");
+            let simulated_samples = ble_sim::generate_ble_packet_samples(
+                samples_per_symbol,
+                args.simulate_packets,
+                channel_index,
+            );
+            let src = VectorSource::<Complex32>::new(simulated_samples);
+            connect!(fg, src > ble_burst > snk);
+            connect_wireshark(fg, ble_burst, args)?;
+        } else if let Some(iq_file) = &args.iq_file {
+            println!(
+                "File mode: Reading interleaved f32 IQ samples from {}",
+                iq_file.display()
+            );
+            let src = FileSource::<Complex32>::new(iq_file, false);
+            connect!(fg, src > ble_burst > snk);
+            connect_wireshark(fg, ble_burst, args)?;
+        } else {
+            println!("Hardware mode: Deploying Seify source live SDR chain");
+            let src = Builder::new(args.args.clone())?
+                .frequency(frequency)
+                .sample_rate(sample_rate)
+                .gain(args.gain)
+                .antenna(args.antenna.clone())
+                .build_source()?;
+            connect!(fg, src.outputs[0] > ble_burst > snk);
+            fg.message(src, "overflow", ble_burst, "rx_overflow")?;
+            connect_wireshark(fg, ble_burst, args)?;
+        }
+    } else {
+        let gmsk_filter = FirBuilder::fir::<Complex32, Complex32, _>(rx_taps);
+        let ble_sync = ble_sync::BleSyncBlock::<DefaultCpuReader<f32>, DefaultCpuWriter<u8>>::with_channel_phase_packet_and_wireshark_output(
+            samples_per_symbol,
+            channel_index,
+            0,
+            !args.quiet,
+            args.wireshark,
+        )
+        .with_connections(connections);
+        let discriminator = discriminator_block();
+
+        if args.simulate {
+            println!("Simulation mode: Testing full GMSK demodulator DSP chain");
+            let simulated_samples = ble_sim::generate_ble_packet_samples(
+                samples_per_symbol,
+                args.simulate_packets,
+                channel_index,
+            );
+            let src = VectorSource::<Complex32>::new(simulated_samples);
+            connect!(fg, src > gmsk_filter > discriminator > ble_sync > snk);
+            connect_wireshark(fg, ble_sync, args)?;
+        } else if let Some(iq_file) = &args.iq_file {
+            println!(
+                "File mode: Reading interleaved f32 IQ samples from {}",
+                iq_file.display()
+            );
+            let src = FileSource::<Complex32>::new(iq_file, false);
+            connect!(fg, src > gmsk_filter > discriminator > ble_sync > snk);
+            connect_wireshark(fg, ble_sync, args)?;
+        } else {
+            println!("Hardware mode: Deploying Seify source live SDR chain");
+            let src = Builder::new(args.args.clone())?
+                .frequency(frequency)
+                .sample_rate(sample_rate)
+                .gain(args.gain)
+                .antenna(args.antenna.clone())
+                .build_source()?;
+            connect!(fg, src.outputs[0] > gmsk_filter > discriminator > ble_sync > snk);
+            connect_wireshark(fg, ble_sync, args)?;
+        }
+    }
+
+    Ok(())
+}
+
+pub(crate) fn build_multi_channel_flowgraph(
+    mut fg: &mut Flowgraph,
+    args: &Args,
+    sample_rate: f64,
+    decode_channels: &[u8],
+) -> Result<()> {
+    let pfb_channels = pfb_channels_from_sample_rate(sample_rate)?;
+    let center_frequency = center_frequency_for_channels(decode_channels)?;
+    let channel_rate = sample_rate / pfb_channels as f64;
+    let phy = BlePhy::Le1M;
+    let connections = SharedConnectionTable::with_monitored_channels(decode_channels);
+    let samples_per_symbol = (channel_rate / phy.symbol_rate_hz()).round() as usize;
+
+    if (channel_rate - BLE_CHANNEL_SPACING_HZ).abs() > 1.0 {
+        bail!(
+            "multi-channel output rate must be 2 MS/s per channel, got {:.3} MS/s",
+            channel_rate / 1.0e6
+        );
+    }
+
+    println!(
+        "Multi-channel mode: center={:.3} MHz sample_rate={:.3} MS/s pfb_channels={} channel_rate={:.3} MS/s channels={:?}",
+        center_frequency / 1.0e6,
+        sample_rate / 1.0e6,
+        pfb_channels,
+        channel_rate / 1.0e6,
+        decode_channels,
+    );
+    if args.follow_connections {
+        println!(
+            "Connection follower enabled: gating locked data contexts around predicted event windows."
+        );
+    }
+
+    let src = Builder::new(args.args.clone())?
+        .frequency(center_frequency)
+        .sample_rate(sample_rate)
+        .gain(args.gain)
+        .antenna(args.antenna.clone())
+        .build_source()?;
+
+    let taps = pfb_channelizer_taps(pfb_channels);
+    let channelizer: PfbChannelizer = PfbChannelizer::new(pfb_channels, &taps, 1.0);
+    connect!(fg, src.outputs[0] > channelizer);
+
+    let mut channel_ports = Vec::with_capacity(decode_channels.len());
+    for &channel in decode_channels {
+        let channel_frequency = ble_protocol::frequency_hz_from_channel_index(channel)?;
+        let port = pfb_port_for_frequency(channel_frequency, center_frequency, pfb_channels)?;
+        channel_ports.push((channel, channel_frequency, port));
+    }
+    let selected_ports: Vec<usize> = channel_ports.iter().map(|(_, _, port)| *port).collect();
+
+    for port in 0..pfb_channels {
+        if !selected_ports.contains(&port) {
+            let snk = fg.add(NullSink::<Complex32>::new());
+            fg.stream_dyn(channelizer, format!("outputs[{port}]"), snk, "input")?;
+        }
+    }
+
+    let mut overflow_receiver_connected = false;
+    for (channel, channel_frequency, port) in channel_ports {
+        let port_name = format!("outputs[{port}]");
+        println!(
+            "connecting BLE channel {channel} ({:.3} MHz) to PFB output {port_name}",
+            channel_frequency / 1.0e6
+        );
+
+        let rx_taps = gmsk_demod::gmsk_rx_taps(samples_per_symbol)?;
+        let snk = fg.add(NullSink::<u8>::new());
+
+        if args.decoder_mode() == DecoderMode::Burst {
+            let ble_burst =
+                fg.add(
+                    ble_iq_burst::BleIqBurstBlock::<
+                        DefaultCpuReader<Complex32>,
+                        DefaultCpuWriter<u8>,
+                    >::with_packet_and_wireshark_output(
+                        phy,
+                        samples_per_symbol,
+                        channel,
+                        rx_taps,
+                        burst_squelch(args),
+                        ble_iq_burst::BleIqBurstOptions {
+                            print_packets: !args.quiet,
+                            wireshark_output: args.wireshark,
+                            follow_connections: args.follow_connections,
+                        },
+                    )?
+                    .with_connections(connections.clone()),
+                );
+            fg.stream_dyn(channelizer, port_name, ble_burst, "input")?;
+            connect!(fg, ble_burst > snk);
+            if !overflow_receiver_connected {
+                fg.message(src, "overflow", ble_burst, "rx_overflow")?;
+                overflow_receiver_connected = true;
+            }
+            connect_wireshark(fg, ble_burst, args)?;
+        } else {
+            let gmsk_filter = fg.add(FirBuilder::fir::<Complex32, Complex32, _>(rx_taps));
+            let ble_sync = fg.add(ble_sync::BleSyncBlock::<
+                DefaultCpuReader<f32>,
+                DefaultCpuWriter<u8>,
+            >::with_channel_phase_packet_and_wireshark_output(
+                samples_per_symbol,
+                channel,
+                0,
+                !args.quiet,
+                args.wireshark,
+            )
+            .with_connections(connections.clone()));
+            let discriminator = fg.add(discriminator_block());
+            fg.stream_dyn(channelizer, port_name, gmsk_filter, "input")?;
+            connect!(fg, gmsk_filter > discriminator > ble_sync > snk);
+            connect_wireshark(fg, ble_sync, args)?;
+        }
+    }
+
+    Ok(())
+}
+
+fn burst_squelch(args: &Args) -> ble_iq_burst::SquelchConfig {
+    match args.squelch_db {
+        Some(threshold_db) => ble_iq_burst::SquelchConfig::fixed(threshold_db),
+        None => ble_iq_burst::SquelchConfig::adaptive(args.squelch_margin_db),
+    }
+}
+
+fn connect_wireshark(fg: &mut Flowgraph, source: impl Into<BlockId>, args: &Args) -> Result<()> {
+    if !args.wireshark {
+        return Ok(());
+    }
+
+    let udp = fg.add(BlobToUdp::new(&args.wireshark_addr));
+    fg.message(source.into(), "wireshark", udp, "in")?;
+    println!(
+        "Streaming BLE LL packets to Wireshark UDP endpoint {}.",
+        args.wireshark_addr
+    );
+    Ok(())
+}
+
+fn discriminator_block() -> Apply<impl FnMut(&Complex32) -> f32 + Send + 'static, Complex32, f32> {
+    let mut last = Complex32::new(1.0, 0.0);
+    Apply::new(move |v: &Complex32| {
+        let mut phase = (v * last.conj()).arg();
+        while phase <= -std::f32::consts::PI {
+            phase += 2.0 * std::f32::consts::PI;
+        }
+        while phase > std::f32::consts::PI {
+            phase -= 2.0 * std::f32::consts::PI;
+        }
+        last = *v;
+        phase
+    })
+}

--- a/examples/bluetooth/src/gmsk_demod.rs
+++ b/examples/bluetooth/src/gmsk_demod.rs
@@ -1,0 +1,15 @@
+use anyhow::Result;
+use yagi::filter::fir_design_gmskrx;
+
+/// Create receive filter taps for a GMSK signal.
+///
+/// `samples_per_symbol` is the number of ADC samples per BLE/GFSK symbol.
+pub fn gmsk_rx_taps(samples_per_symbol: usize) -> Result<Vec<f32>> {
+    // BLE uses a Gaussian BT of 0.5 and a filter span of about 3 symbols.
+    let beta = 0.5;
+    let symbol_delay = 3;
+    let dt = 0.0;
+
+    let taps = fir_design_gmskrx(samples_per_symbol, symbol_delay, beta, dt)?;
+    Ok(taps)
+}

--- a/examples/bluetooth/src/main.rs
+++ b/examples/bluetooth/src/main.rs
@@ -1,8 +1,11 @@
 use anyhow::Result;
+use anyhow::bail;
 use clap::Parser;
+use futuredsp::firdes::remez;
 use futuresdr::blocks::Apply;
 use futuresdr::blocks::FirBuilder;
 use futuresdr::blocks::NullSink;
+use futuresdr::blocks::PfbChannelizer;
 use futuresdr::blocks::VectorSource;
 use futuresdr::blocks::seify::Builder;
 use futuresdr::num_complex::Complex32;
@@ -13,8 +16,13 @@ use futuresdr::runtime::dev::DefaultCpuWriter;
 use std::sync::mpsc;
 use std::time::Duration;
 
+const BLE_CHANNEL_SPACING_HZ: f64 = 2.0e6;
+const MULTI_CHANNEL_GUARD_BINS: usize = 1;
+
 mod ble_ad;
+mod ble_connection;
 mod ble_detector;
+mod ble_iq_burst;
 mod ble_phy;
 mod ble_protocol;
 mod ble_sim;
@@ -29,6 +37,12 @@ struct Args {
     args: String,
     #[arg(short, long, default_value_t = 37)]
     channel: u8,
+    #[arg(long, value_delimiter = ',')]
+    channels: Vec<u8>,
+    #[arg(long, value_delimiter = ',')]
+    passive_channels: Vec<u8>,
+    #[arg(long, default_value_t = false)]
+    multi_channel: bool,
     #[arg(short, long, default_value_t = 2.0e6)]
     sample_rate: f64,
     #[arg(short, long, default_value_t = 30.0)]
@@ -39,6 +53,12 @@ struct Args {
     threshold: f32,
     #[arg(long, default_value_t = false)]
     normalize_levels: bool,
+    #[arg(long, default_value_t = false)]
+    burst: bool,
+    #[arg(long, default_value_t = -50.0)]
+    squelch_db: f32,
+    #[arg(long, default_value_t = false)]
+    quiet: bool,
     #[arg(long, default_value_t = false)]
     simulate: bool,
     #[arg(long, default_value_t = 1)]
@@ -53,69 +73,33 @@ fn main() -> Result<()> {
 
     println!("Starting Bluetooth GMSK sniffer example");
     let mut fg = Flowgraph::new();
-    let samples_per_symbol = (args.sample_rate / 1e6).round().max(1.0) as usize;
-    let symbol_rate_ratio = args.sample_rate / 1e6;
-    if (symbol_rate_ratio - samples_per_symbol as f64).abs() > 0.05 {
+    let selected_channels = selected_channels(&args)?;
+    let capture_channels = capture_channels(&args, &selected_channels)?;
+    let mut sample_rate = args.sample_rate;
+
+    if args.multi_channel && (sample_rate - 2.0e6).abs() < f64::EPSILON {
+        let center_frequency = center_frequency_for_channels(&capture_channels)?;
+        sample_rate = auto_multi_channel_sample_rate(&capture_channels, center_frequency)?;
         println!(
-            "Sample rate {:.3} MS/s is not close to an integer multiple of the BLE 1 Msym/s symbol rate; symbol slicing may be less reliable",
-            args.sample_rate / 1.0e6
+            "Auto-selected {:.3} MS/s for multi-channel capture. Override with --sample-rate if needed.",
+            sample_rate / 1.0e6
         );
     }
-    let snk = NullSink::<u8>::new();
-    let channel_index = args.channel;
-    let frequency = ble_protocol::frequency_hz_from_channel_index(channel_index)?;
-    println!(
-        "Using BLE channel {channel_index} ({:.3} MHz)",
-        frequency / 1.0e6
-    );
 
-    let rx_taps = gmsk_demod::gmsk_rx_taps(samples_per_symbol)?;
-    println!("GMSK receive filter configured.");
-    let initial_delay = 0;
-
-    let ble_sync = ble_sync::BleSyncBlock::<DefaultCpuReader<f32>, DefaultCpuWriter<u8>>::with_channel_and_phase(
-        args.threshold,
-        args.normalize_levels,
-        samples_per_symbol,
-        channel_index,
-        initial_delay,
-    );
-
-    let gmsk_filter = FirBuilder::fir::<Complex32, Complex32, _>(rx_taps);
-
-    let mut last = Complex32::new(1.0, 0.0);
-    let discriminator = Apply::new(move |v: &Complex32| {
-        let mut phase = (v * last.conj()).arg();
-        while phase <= -std::f32::consts::PI {
-            phase += 2.0 * std::f32::consts::PI;
+    if args.multi_channel {
+        if args.simulate {
+            bail!("--multi-channel simulation is not implemented yet");
         }
-        while phase > std::f32::consts::PI {
-            phase -= 2.0 * std::f32::consts::PI;
-        }
-        last = *v;
-        phase
-    });
-
-    if args.simulate {
-        println!("Simulation mode: Testing full GMSK demodulator DSP chain");
-        let simulated_samples = ble_sim::generate_ble_packet_samples(
-            samples_per_symbol,
-            args.simulate_packets,
-            channel_index,
-        );
-        let src = VectorSource::<Complex32>::new(simulated_samples);
-
-        connect!(fg, src > gmsk_filter > discriminator > ble_sync > snk);
+        build_multi_channel_flowgraph(
+            &mut fg,
+            &args,
+            sample_rate,
+            &selected_channels,
+            &capture_channels,
+            args.burst,
+        )?;
     } else {
-        println!("Hardware mode: Deploying Seify source live SDR chain");
-        let src = Builder::new(args.args)?
-            .frequency(frequency)
-            .sample_rate(args.sample_rate)
-            .gain(args.gain)
-            .antenna(args.antenna)
-            .build_source()?;
-
-        connect!(fg, src.outputs[0] > gmsk_filter > discriminator > ble_sync > snk);
+        build_single_channel_flowgraph(&mut fg, &args, sample_rate)?;
     }
 
     let rt = Runtime::new();
@@ -158,4 +142,553 @@ fn main() -> Result<()> {
 
     println!("Runtime stopped.");
     Ok(())
+}
+
+fn build_single_channel_flowgraph(
+    mut fg: &mut Flowgraph,
+    args: &Args,
+    sample_rate: f64,
+) -> Result<()> {
+    let samples_per_symbol = (sample_rate / 1e6).round().max(1.0) as usize;
+    let symbol_rate_ratio = sample_rate / 1e6;
+    if (symbol_rate_ratio - samples_per_symbol as f64).abs() > 0.05 {
+        println!(
+            "Sample rate {:.3} MS/s is not close to an integer multiple of the BLE 1 Msym/s symbol rate; symbol slicing may be less reliable",
+            sample_rate / 1.0e6
+        );
+    }
+
+    let channel_index = args.channel;
+    let frequency = ble_protocol::frequency_hz_from_channel_index(channel_index)?;
+    println!(
+        "Using BLE channel {channel_index} ({:.3} MHz)",
+        frequency / 1.0e6
+    );
+    if args.burst {
+        println!(
+            "Using IQ burst decoder with squelch threshold {:.1} dB.",
+            args.squelch_db
+        );
+    } else {
+        println!("Using continuous packet decoder.");
+    }
+
+    let rx_taps = gmsk_demod::gmsk_rx_taps(samples_per_symbol)?;
+    println!("GMSK receive filter configured.");
+    let gmsk_filter = FirBuilder::fir::<Complex32, Complex32, _>(rx_taps);
+    let snk = NullSink::<u8>::new();
+
+    if args.burst {
+        let ble_burst = ble_iq_burst::BleIqBurstBlock::<
+            DefaultCpuReader<Complex32>,
+            DefaultCpuWriter<u8>,
+        >::with_packet_output(
+            samples_per_symbol,
+            channel_index,
+            args.squelch_db,
+            !args.quiet,
+        );
+
+        if args.simulate {
+            println!("Simulation mode: Testing full GMSK demodulator DSP chain");
+            let simulated_samples = ble_sim::generate_ble_packet_samples(
+                samples_per_symbol,
+                args.simulate_packets,
+                channel_index,
+            );
+            let src = VectorSource::<Complex32>::new(simulated_samples);
+            connect!(fg, src > gmsk_filter > ble_burst > snk);
+        } else {
+            println!("Hardware mode: Deploying Seify source live SDR chain");
+            let src = Builder::new(args.args.clone())?
+                .frequency(frequency)
+                .sample_rate(sample_rate)
+                .gain(args.gain)
+                .antenna(args.antenna.clone())
+                .build_source()?;
+            connect!(fg, src.outputs[0] > gmsk_filter > ble_burst > snk);
+        }
+    } else {
+        let ble_sync = ble_sync::BleSyncBlock::<DefaultCpuReader<f32>, DefaultCpuWriter<u8>>::with_channel_phase_and_packet_output(
+            args.threshold,
+            args.normalize_levels,
+            samples_per_symbol,
+            channel_index,
+            0,
+            !args.quiet,
+        );
+        let discriminator = discriminator_block();
+
+        if args.simulate {
+            println!("Simulation mode: Testing full GMSK demodulator DSP chain");
+            let simulated_samples = ble_sim::generate_ble_packet_samples(
+                samples_per_symbol,
+                args.simulate_packets,
+                channel_index,
+            );
+            let src = VectorSource::<Complex32>::new(simulated_samples);
+            connect!(fg, src > gmsk_filter > discriminator > ble_sync > snk);
+        } else {
+            println!("Hardware mode: Deploying Seify source live SDR chain");
+            let src = Builder::new(args.args.clone())?
+                .frequency(frequency)
+                .sample_rate(sample_rate)
+                .gain(args.gain)
+                .antenna(args.antenna.clone())
+                .build_source()?;
+            connect!(fg, src.outputs[0] > gmsk_filter > discriminator > ble_sync > snk);
+        }
+    }
+
+    Ok(())
+}
+
+fn selected_channels(args: &Args) -> Result<Vec<u8>> {
+    let mut channels = if args.channels.is_empty() {
+        vec![args.channel]
+    } else {
+        args.channels.clone()
+    };
+
+    channels.sort_unstable();
+    channels.dedup();
+
+    for &channel in &channels {
+        ble_protocol::frequency_hz_from_channel_index(channel)?;
+    }
+
+    Ok(channels)
+}
+
+fn capture_channels(args: &Args, selected_channels: &[u8]) -> Result<Vec<u8>> {
+    let mut channels = selected_channels.to_vec();
+    channels.extend(args.passive_channels.iter().copied());
+    channels.sort_unstable();
+    channels.dedup();
+
+    for &channel in &channels {
+        ble_protocol::frequency_hz_from_channel_index(channel)?;
+    }
+
+    Ok(channels)
+}
+
+fn build_multi_channel_flowgraph(
+    mut fg: &mut Flowgraph,
+    args: &Args,
+    sample_rate: f64,
+    decode_channels: &[u8],
+    capture_channels: &[u8],
+    burst: bool,
+) -> Result<()> {
+    let pfb_channels = pfb_channels_from_sample_rate(sample_rate)?;
+    let center_frequency = center_frequency_for_channels(capture_channels)?;
+    let channel_rate = sample_rate / pfb_channels as f64;
+    let samples_per_symbol = (channel_rate / 1.0e6).round() as usize;
+
+    if (channel_rate - BLE_CHANNEL_SPACING_HZ).abs() > 1.0 {
+        bail!(
+            "multi-channel output rate must be 2 MS/s per channel, got {:.3} MS/s",
+            channel_rate / 1.0e6
+        );
+    }
+
+    println!(
+        "Multi-channel mode: center={:.3} MHz sample_rate={:.3} MS/s pfb_channels={} channel_rate={:.3} MS/s decode_channels={:?} capture_channels={:?}",
+        center_frequency / 1.0e6,
+        sample_rate / 1.0e6,
+        pfb_channels,
+        channel_rate / 1.0e6,
+        decode_channels,
+        capture_channels,
+    );
+
+    let src = Builder::new(args.args.clone())?
+        .frequency(center_frequency)
+        .sample_rate(sample_rate)
+        .gain(args.gain)
+        .antenna(args.antenna.clone())
+        .build_source()?;
+
+    let taps = pfb_channelizer_taps(pfb_channels);
+    let channelizer: PfbChannelizer = PfbChannelizer::new(pfb_channels, &taps, 1.0);
+    connect!(fg, src.outputs[0] > channelizer);
+
+    for &channel in &args.passive_channels {
+        let frequency = ble_protocol::frequency_hz_from_channel_index(channel)?;
+        let port = pfb_port_for_frequency(frequency, center_frequency, pfb_channels)?;
+        println!(
+            "capturing passive BLE channel {channel} ({:.3} MHz) on PFB output outputs[{port}]",
+            frequency / 1.0e6
+        );
+    }
+
+    let mut channel_ports = Vec::with_capacity(decode_channels.len());
+    for &channel in decode_channels {
+        let channel_frequency = ble_protocol::frequency_hz_from_channel_index(channel)?;
+        let port = pfb_port_for_frequency(channel_frequency, center_frequency, pfb_channels)?;
+        channel_ports.push((channel, channel_frequency, port));
+    }
+    let selected_ports: Vec<usize> = channel_ports.iter().map(|(_, _, port)| *port).collect();
+
+    for port in 0..pfb_channels {
+        if !selected_ports.contains(&port) {
+            let snk = fg.add(NullSink::<Complex32>::new());
+            fg.stream_dyn(channelizer, format!("outputs[{port}]"), snk, "input")?;
+        }
+    }
+
+    for (channel, channel_frequency, port) in channel_ports {
+        let port_name = format!("outputs[{port}]");
+        println!(
+            "connecting BLE channel {channel} ({:.3} MHz) to PFB output {port_name}",
+            channel_frequency / 1.0e6
+        );
+
+        let gmsk_filter = fg.add(FirBuilder::fir::<Complex32, Complex32, _>(
+            gmsk_demod::gmsk_rx_taps(samples_per_symbol)?,
+        ));
+        let snk = fg.add(NullSink::<u8>::new());
+
+        fg.stream_dyn(channelizer, port_name, gmsk_filter, "input")?;
+
+        if burst {
+            let ble_burst = fg.add(ble_iq_burst::BleIqBurstBlock::<
+                DefaultCpuReader<Complex32>,
+                DefaultCpuWriter<u8>,
+            >::with_packet_output(
+                samples_per_symbol, channel, args.squelch_db, !args.quiet
+            ));
+            connect!(fg, gmsk_filter > ble_burst > snk);
+        } else {
+            let ble_sync = fg.add(ble_sync::BleSyncBlock::<
+                DefaultCpuReader<f32>,
+                DefaultCpuWriter<u8>,
+            >::with_channel_phase_and_packet_output(
+                args.threshold,
+                args.normalize_levels,
+                samples_per_symbol,
+                channel,
+                0,
+                !args.quiet,
+            ));
+            let discriminator = fg.add(discriminator_block());
+            connect!(fg, gmsk_filter > discriminator > ble_sync > snk);
+        }
+    }
+
+    Ok(())
+}
+
+fn pfb_channelizer_taps(pfb_channels: usize) -> Vec<f32> {
+    let transition_bw = 0.5;
+    remez::low_pass(
+        1.0,
+        pfb_channels,
+        0.5 - transition_bw / 2.0,
+        0.5 + transition_bw / 2.0,
+        0.1,
+        100.0,
+        None,
+    )
+    .into_iter()
+    .map(|tap| tap as f32)
+    .collect()
+}
+
+fn discriminator_block() -> Apply<impl FnMut(&Complex32) -> f32 + Send + 'static, Complex32, f32> {
+    let mut last = Complex32::new(1.0, 0.0);
+    Apply::new(move |v: &Complex32| {
+        let mut phase = (v * last.conj()).arg();
+        while phase <= -std::f32::consts::PI {
+            phase += 2.0 * std::f32::consts::PI;
+        }
+        while phase > std::f32::consts::PI {
+            phase -= 2.0 * std::f32::consts::PI;
+        }
+        last = *v;
+        phase
+    })
+}
+
+fn pfb_channels_from_sample_rate(sample_rate: f64) -> Result<usize> {
+    let channels = sample_rate / BLE_CHANNEL_SPACING_HZ;
+    let rounded = channels.round();
+
+    if (channels - rounded).abs() > 1e-6 {
+        bail!(
+            "multi-channel sample rate must be an integer multiple of 2 MHz, got {:.3} MS/s",
+            sample_rate / 1.0e6
+        );
+    }
+
+    let channels = rounded as usize;
+    if channels <= 2 {
+        bail!("multi-channel mode needs at least 4 MHz sample rate");
+    }
+
+    Ok(channels)
+}
+
+fn center_frequency_for_channels(channels: &[u8]) -> Result<f64> {
+    let frequencies_mhz: Vec<i32> = channels
+        .iter()
+        .map(|&channel| {
+            ble_protocol::frequency_hz_from_channel_index(channel)
+                .map(|freq| (freq / BLE_CHANNEL_SPACING_HZ).round() as i32)
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+
+    let min_bin = frequencies_mhz.iter().min().copied().unwrap_or(1201);
+    let max_bin = frequencies_mhz.iter().max().copied().unwrap_or(min_bin);
+    let center_bin = min_bin + (max_bin - min_bin + 1) / 2;
+
+    Ok(center_bin as f64 * BLE_CHANNEL_SPACING_HZ)
+}
+
+fn auto_multi_channel_sample_rate(channels: &[u8], center_frequency: f64) -> Result<f64> {
+    let max_offset_bins = channels
+        .iter()
+        .map(|&channel| {
+            ble_protocol::frequency_hz_from_channel_index(channel).map(|freq| {
+                ((freq - center_frequency) / BLE_CHANNEL_SPACING_HZ)
+                    .round()
+                    .abs() as usize
+            })
+        })
+        .collect::<Result<Vec<_>, _>>()?
+        .into_iter()
+        .max()
+        .unwrap_or(0);
+
+    let pfb_channels = ((max_offset_bins + MULTI_CHANNEL_GUARD_BINS) * 2).max(4);
+    Ok(pfb_channels as f64 * BLE_CHANNEL_SPACING_HZ)
+}
+
+fn pfb_port_for_frequency(
+    frequency: f64,
+    center_frequency: f64,
+    pfb_channels: usize,
+) -> Result<usize> {
+    let offset_bins = (frequency - center_frequency) / BLE_CHANNEL_SPACING_HZ;
+    let rounded = offset_bins.round();
+
+    if (offset_bins - rounded).abs() > 1e-6 {
+        bail!(
+            "frequency {:.3} MHz does not align with the 2 MHz PFB grid around center {:.3} MHz",
+            frequency / 1.0e6,
+            center_frequency / 1.0e6,
+        );
+    }
+
+    let offset_bins = rounded as isize;
+    let half = (pfb_channels / 2) as isize;
+    if offset_bins.abs() >= half {
+        bail!(
+            "frequency {:.3} MHz is outside the usable PFB span for center {:.3} MHz and {} channels",
+            frequency / 1.0e6,
+            center_frequency / 1.0e6,
+            pfb_channels,
+        );
+    }
+
+    if offset_bins >= 0 {
+        Ok(offset_bins as usize)
+    } else {
+        Ok(pfb_channels - (-offset_bins as usize))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use futuresdr::blocks::VectorSink;
+
+    #[test]
+    fn multi_channel_center_keeps_ble_grid_alignment() {
+        let center = center_frequency_for_channels(&[37, 38]).unwrap();
+
+        assert_eq!(center, 2.414e9);
+    }
+
+    #[test]
+    fn pfb_ports_map_positive_and_negative_offsets() {
+        let center = 2.414e9;
+
+        assert_eq!(
+            pfb_port_for_frequency(
+                ble_protocol::frequency_hz_from_channel_index(37).unwrap(),
+                center,
+                16
+            )
+            .unwrap(),
+            10
+        );
+        assert_eq!(
+            pfb_port_for_frequency(
+                ble_protocol::frequency_hz_from_channel_index(38).unwrap(),
+                center,
+                16
+            )
+            .unwrap(),
+            6
+        );
+    }
+
+    #[test]
+    fn auto_sample_rate_leaves_guard_bins() {
+        let center = center_frequency_for_channels(&[37, 38]).unwrap();
+
+        assert_eq!(
+            auto_multi_channel_sample_rate(&[37, 38], center).unwrap(),
+            28.0e6
+        );
+    }
+
+    #[test]
+    fn adjacent_advertising_and_data_channel_fit_in_lower_rate() {
+        let center = center_frequency_for_channels(&[37, 0]).unwrap();
+
+        assert_eq!(center, 2.404e9);
+        assert_eq!(
+            auto_multi_channel_sample_rate(&[37, 0], center).unwrap(),
+            8.0e6
+        );
+        assert_eq!(
+            pfb_port_for_frequency(
+                ble_protocol::frequency_hz_from_channel_index(37).unwrap(),
+                center,
+                4
+            )
+            .unwrap(),
+            3
+        );
+        assert_eq!(
+            pfb_port_for_frequency(
+                ble_protocol::frequency_hz_from_channel_index(0).unwrap(),
+                center,
+                4
+            )
+            .unwrap(),
+            0
+        );
+    }
+
+    #[test]
+    fn pfb_routes_synthetic_ble_channel_tones() -> Result<()> {
+        let pfb_channels = 14;
+        let sample_count = 16_384;
+        let taps = pfb_channelizer_taps(pfb_channels);
+        let center = center_frequency_for_channels(&[37, 38])?;
+
+        let ch37_port = pfb_port_for_frequency(
+            ble_protocol::frequency_hz_from_channel_index(37)?,
+            center,
+            pfb_channels,
+        )?;
+        let ch38_port = pfb_port_for_frequency(
+            ble_protocol::frequency_hz_from_channel_index(38)?,
+            center,
+            pfb_channels,
+        )?;
+
+        let ch37_powers = pfb_output_powers_db(
+            tone_at_pfb_bin(-6, pfb_channels, sample_count),
+            pfb_channels,
+            &taps,
+        )?;
+        let ch38_powers = pfb_output_powers_db(
+            tone_at_pfb_bin(6, pfb_channels, sample_count),
+            pfb_channels,
+            &taps,
+        )?;
+
+        assert_eq!(strongest_output(&ch37_powers), ch37_port);
+        assert_eq!(strongest_output(&ch38_powers), ch38_port);
+
+        assert!(
+            neighbor_leakage_db(&ch37_powers, ch37_port) < -30.0,
+            "ch37 neighbor leakage {:.1} dB, powers {:?}",
+            neighbor_leakage_db(&ch37_powers, ch37_port),
+            ch37_powers
+        );
+        assert!(
+            neighbor_leakage_db(&ch38_powers, ch38_port) < -30.0,
+            "ch38 neighbor leakage {:.1} dB, powers {:?}",
+            neighbor_leakage_db(&ch38_powers, ch38_port),
+            ch38_powers
+        );
+
+        Ok(())
+    }
+
+    fn tone_at_pfb_bin(bin: isize, pfb_channels: usize, sample_count: usize) -> Vec<Complex32> {
+        let phase_step = 2.0 * std::f64::consts::PI * bin as f64 / pfb_channels as f64;
+        (0..sample_count)
+            .map(|index| {
+                let phase = phase_step * index as f64;
+                Complex32::new(phase.cos() as f32, phase.sin() as f32)
+            })
+            .collect()
+    }
+
+    fn pfb_output_powers_db(
+        input: Vec<Complex32>,
+        pfb_channels: usize,
+        taps: &[f32],
+    ) -> Result<Vec<f64>> {
+        let mut fg = Flowgraph::new();
+        let src = fg.add(VectorSource::<Complex32>::new(input));
+        let channelizer = fg.add(PfbChannelizer::<
+            DefaultCpuReader<Complex32>,
+            DefaultCpuWriter<Complex32>,
+        >::new(pfb_channels, taps, 1.0));
+        fg.stream_dyn(src, "output", channelizer, "input")?;
+
+        let mut sinks = Vec::with_capacity(pfb_channels);
+        for port in 0..pfb_channels {
+            let sink = fg.add(VectorSink::<Complex32>::new(2048));
+            fg.stream_dyn(channelizer, format!("outputs[{port}]"), sink, "input")?;
+            sinks.push(sink);
+        }
+
+        let fg = Runtime::new().run(fg)?;
+        let powers = sinks
+            .iter()
+            .map(|sink| {
+                let sink = fg.block(sink)?;
+                Ok(mean_power_db(sink.items()))
+            })
+            .collect::<Result<Vec<_>>>()?;
+
+        Ok(powers)
+    }
+
+    fn mean_power_db(samples: &[Complex32]) -> f64 {
+        let skip = samples.len().min(16);
+        let samples = &samples[skip..];
+        let mean_power = samples
+            .iter()
+            .map(|sample| sample.norm_sqr() as f64)
+            .sum::<f64>()
+            / samples.len().max(1) as f64;
+
+        10.0 * mean_power.max(1.0e-20).log10()
+    }
+
+    fn strongest_output(powers_db: &[f64]) -> usize {
+        powers_db
+            .iter()
+            .enumerate()
+            .max_by(|(_, a), (_, b)| a.total_cmp(b))
+            .map(|(index, _)| index)
+            .unwrap()
+    }
+
+    fn neighbor_leakage_db(powers_db: &[f64], main_port: usize) -> f64 {
+        let main_power = powers_db[main_port];
+        let lower = powers_db[(main_port + powers_db.len() - 1) % powers_db.len()] - main_power;
+        let upper = powers_db[(main_port + 1) % powers_db.len()] - main_power;
+        lower.max(upper)
+    }
 }

--- a/examples/bluetooth/src/main.rs
+++ b/examples/bluetooth/src/main.rs
@@ -1,0 +1,161 @@
+use anyhow::Result;
+use clap::Parser;
+use futuresdr::blocks::Apply;
+use futuresdr::blocks::FirBuilder;
+use futuresdr::blocks::NullSink;
+use futuresdr::blocks::VectorSource;
+use futuresdr::blocks::seify::Builder;
+use futuresdr::num_complex::Complex32;
+use futuresdr::prelude::*;
+use futuresdr::runtime::Error as RuntimeError;
+use futuresdr::runtime::dev::DefaultCpuReader;
+use futuresdr::runtime::dev::DefaultCpuWriter;
+use std::sync::mpsc;
+use std::time::Duration;
+
+mod ble_ad;
+mod ble_detector;
+mod ble_phy;
+mod ble_protocol;
+mod ble_sim;
+mod ble_slicer;
+mod ble_sync;
+mod gmsk_demod;
+
+#[derive(Parser, Debug)]
+#[command(version)]
+struct Args {
+    #[arg(short, long, default_value = "")]
+    args: String,
+    #[arg(short, long, default_value_t = 37)]
+    channel: u8,
+    #[arg(short, long, default_value_t = 2.0e6)]
+    sample_rate: f64,
+    #[arg(short, long, default_value_t = 30.0)]
+    gain: f64,
+    #[arg(long)]
+    antenna: Option<String>,
+    #[arg(long, default_value_t = 0.0)]
+    threshold: f32,
+    #[arg(long, default_value_t = false)]
+    normalize_levels: bool,
+    #[arg(long, default_value_t = false)]
+    simulate: bool,
+    #[arg(long, default_value_t = 1)]
+    simulate_packets: usize,
+    #[arg(long)]
+    duration: Option<f64>,
+}
+
+fn main() -> Result<()> {
+    futuresdr::runtime::init();
+    let args = Args::parse();
+
+    println!("Starting Bluetooth GMSK sniffer example");
+    let mut fg = Flowgraph::new();
+    let samples_per_symbol = (args.sample_rate / 1e6).round().max(1.0) as usize;
+    let symbol_rate_ratio = args.sample_rate / 1e6;
+    if (symbol_rate_ratio - samples_per_symbol as f64).abs() > 0.05 {
+        println!(
+            "Sample rate {:.3} MS/s is not close to an integer multiple of the BLE 1 Msym/s symbol rate; symbol slicing may be less reliable",
+            args.sample_rate / 1.0e6
+        );
+    }
+    let snk = NullSink::<u8>::new();
+    let channel_index = args.channel;
+    let frequency = ble_protocol::frequency_hz_from_channel_index(channel_index)?;
+    println!(
+        "Using BLE channel {channel_index} ({:.3} MHz)",
+        frequency / 1.0e6
+    );
+
+    let rx_taps = gmsk_demod::gmsk_rx_taps(samples_per_symbol)?;
+    println!("GMSK receive filter configured.");
+    let initial_delay = 0;
+
+    let ble_sync = ble_sync::BleSyncBlock::<DefaultCpuReader<f32>, DefaultCpuWriter<u8>>::with_channel_and_phase(
+        args.threshold,
+        args.normalize_levels,
+        samples_per_symbol,
+        channel_index,
+        initial_delay,
+    );
+
+    let gmsk_filter = FirBuilder::fir::<Complex32, Complex32, _>(rx_taps);
+
+    let mut last = Complex32::new(1.0, 0.0);
+    let discriminator = Apply::new(move |v: &Complex32| {
+        let mut phase = (v * last.conj()).arg();
+        while phase <= -std::f32::consts::PI {
+            phase += 2.0 * std::f32::consts::PI;
+        }
+        while phase > std::f32::consts::PI {
+            phase -= 2.0 * std::f32::consts::PI;
+        }
+        last = *v;
+        phase
+    });
+
+    if args.simulate {
+        println!("Simulation mode: Testing full GMSK demodulator DSP chain");
+        let simulated_samples = ble_sim::generate_ble_packet_samples(
+            samples_per_symbol,
+            args.simulate_packets,
+            channel_index,
+        );
+        let src = VectorSource::<Complex32>::new(simulated_samples);
+
+        connect!(fg, src > gmsk_filter > discriminator > ble_sync > snk);
+    } else {
+        println!("Hardware mode: Deploying Seify source live SDR chain");
+        let src = Builder::new(args.args)?
+            .frequency(frequency)
+            .sample_rate(args.sample_rate)
+            .gain(args.gain)
+            .antenna(args.antenna)
+            .build_source()?;
+
+        connect!(fg, src.outputs[0] > gmsk_filter > discriminator > ble_sync > snk);
+    }
+
+    let rt = Runtime::new();
+    let running = rt.start(fg)?;
+    println!("Runtime started.");
+
+    let (shutdown_tx, shutdown_rx) = mpsc::channel();
+    ctrlc::set_handler(move || {
+        let _ = shutdown_tx.send(());
+    })?;
+
+    if args.simulate && args.duration.is_none() {
+        Runtime::block_on(async move {
+            match running.wait_async().await {
+                Ok(_) | Err(RuntimeError::FlowgraphTerminated) => {}
+                Err(err) => return Err(err.into()),
+            }
+            Ok::<(), anyhow::Error>(())
+        })?;
+    } else {
+        if let Some(duration) = args.duration {
+            let _ = shutdown_rx.recv_timeout(Duration::from_secs_f64(duration));
+        } else {
+            println!("Press Ctrl+C to stop.");
+            shutdown_rx.recv()?;
+        }
+
+        Runtime::block_on(async move {
+            match running.stop().await {
+                Ok(()) | Err(RuntimeError::FlowgraphTerminated) => {}
+                Err(err) => return Err(err.into()),
+            }
+            match running.wait_async().await {
+                Ok(_) | Err(RuntimeError::FlowgraphTerminated) => {}
+                Err(err) => return Err(err.into()),
+            }
+            Ok::<(), anyhow::Error>(())
+        })?;
+    }
+
+    println!("Runtime stopped.");
+    Ok(())
+}

--- a/examples/bluetooth/src/main.rs
+++ b/examples/bluetooth/src/main.rs
@@ -1,30 +1,24 @@
-use anyhow::Result;
-use anyhow::bail;
-use clap::Parser;
-use futuredsp::firdes::remez;
-use futuresdr::blocks::Apply;
-use futuresdr::blocks::BlobToUdp;
-use futuresdr::blocks::FileSource;
-use futuresdr::blocks::FirBuilder;
-use futuresdr::blocks::NullSink;
-use futuresdr::blocks::PfbChannelizer;
-use futuresdr::blocks::VectorSource;
-use futuresdr::blocks::seify::Builder;
-use futuresdr::num_complex::Complex32;
-use futuresdr::prelude::*;
-use futuresdr::runtime::BlockId;
-use futuresdr::runtime::Error as RuntimeError;
-use futuresdr::runtime::dev::DefaultCpuReader;
-use futuresdr::runtime::dev::DefaultCpuWriter;
-use std::path::PathBuf;
 use std::sync::mpsc;
 use std::time::Duration;
 
-const BLE_CHANNEL_SPACING_HZ: f64 = 2.0e6;
-const MULTI_CHANNEL_GUARD_BINS: usize = 1;
+use anyhow::Result;
+use anyhow::bail;
+use clap::Parser;
+use futuresdr::prelude::*;
+use futuresdr::runtime::Error as RuntimeError;
+
+use crate::cli::Args;
 
 mod ble_ad;
+mod ble_burst_catcher;
+mod ble_burst_decoder;
+mod ble_burst_stats;
+mod ble_channel_selection;
 mod ble_connection;
+mod ble_connection_follower;
+mod ble_connection_report;
+mod ble_control;
+mod ble_data;
 mod ble_detector;
 mod ble_iq_burst;
 mod ble_phy;
@@ -32,51 +26,13 @@ mod ble_protocol;
 mod ble_sim;
 mod ble_slicer;
 mod ble_sync;
+mod ble_timing_recovery;
 mod ble_wireshark;
+mod channelizer;
+mod cli;
+mod diagnostics;
+mod flowgraph;
 mod gmsk_demod;
-
-#[derive(Parser, Debug)]
-#[command(version)]
-struct Args {
-    #[arg(short, long, default_value = "")]
-    args: String,
-    #[arg(short, long, default_value_t = 37)]
-    channel: u8,
-    #[arg(long, value_delimiter = ',')]
-    channels: Vec<u8>,
-    #[arg(long, value_delimiter = ',')]
-    passive_channels: Vec<u8>,
-    #[arg(long, default_value_t = false)]
-    multi_channel: bool,
-    #[arg(short, long, default_value_t = 2.0e6)]
-    sample_rate: f64,
-    #[arg(short, long, default_value_t = 30.0)]
-    gain: f64,
-    #[arg(long)]
-    antenna: Option<String>,
-    #[arg(long, default_value_t = 0.0)]
-    threshold: f32,
-    #[arg(long, default_value_t = false)]
-    normalize_levels: bool,
-    #[arg(long, default_value_t = false)]
-    burst: bool,
-    #[arg(long, default_value_t = -50.0)]
-    squelch_db: f32,
-    #[arg(long, default_value_t = false)]
-    quiet: bool,
-    #[arg(long, default_value_t = false)]
-    wireshark: bool,
-    #[arg(long, default_value = "127.0.0.1:55556")]
-    wireshark_addr: String,
-    #[arg(long, default_value_t = false)]
-    simulate: bool,
-    #[arg(long, default_value_t = 1)]
-    simulate_packets: usize,
-    #[arg(long)]
-    iq_file: Option<PathBuf>,
-    #[arg(long)]
-    duration: Option<f64>,
-}
 
 fn main() -> Result<()> {
     futuresdr::runtime::init();
@@ -84,40 +40,31 @@ fn main() -> Result<()> {
 
     println!("Starting Bluetooth GMSK sniffer example");
     let mut fg = Flowgraph::new();
-    let selected_channels = selected_channels(&args)?;
-    let capture_channels = capture_channels(&args, &selected_channels)?;
+    let selected_channels = cli::selected_channels(&args)?;
     let mut sample_rate = args.sample_rate;
 
-    if args.simulate && args.iq_file.is_some() {
-        bail!("--simulate and --iq-file cannot be used together");
-    }
+    cli::validate(&args)?;
 
-    if args.multi_channel && (sample_rate - 2.0e6).abs() < f64::EPSILON {
-        let center_frequency = center_frequency_for_channels(&capture_channels)?;
-        sample_rate = auto_multi_channel_sample_rate(&capture_channels, center_frequency)?;
+    if args.is_multi_channel() && (sample_rate - 2.0e6).abs() < f64::EPSILON {
+        let center_frequency = channelizer::center_frequency_for_channels(&selected_channels)?;
+        sample_rate =
+            channelizer::auto_multi_channel_sample_rate(&selected_channels, center_frequency)?;
         println!(
             "Auto-selected {:.3} MS/s for multi-channel capture. Override with --sample-rate if needed.",
             sample_rate / 1.0e6
         );
     }
 
-    if args.multi_channel {
+    if args.is_multi_channel() {
         if args.simulate {
-            bail!("--multi-channel simulation is not implemented yet");
+            bail!("--channels cannot be combined with --simulate yet");
         }
         if args.iq_file.is_some() {
-            bail!("--multi-channel --iq-file input is not implemented yet");
+            bail!("--channels cannot be combined with --iq-file yet");
         }
-        build_multi_channel_flowgraph(
-            &mut fg,
-            &args,
-            sample_rate,
-            &selected_channels,
-            &capture_channels,
-            args.burst,
-        )?;
+        flowgraph::build_multi_channel_flowgraph(&mut fg, &args, sample_rate, &selected_channels)?;
     } else {
-        build_single_channel_flowgraph(&mut fg, &args, sample_rate)?;
+        flowgraph::build_single_channel_flowgraph(&mut fg, &args, sample_rate)?;
     }
 
     if args.simulate || args.iq_file.is_some() {
@@ -160,596 +107,4 @@ fn main() -> Result<()> {
 
     println!("Runtime stopped.");
     Ok(())
-}
-
-fn build_single_channel_flowgraph(
-    mut fg: &mut Flowgraph,
-    args: &Args,
-    sample_rate: f64,
-) -> Result<()> {
-    let samples_per_symbol = (sample_rate / 1e6).round().max(1.0) as usize;
-    let symbol_rate_ratio = sample_rate / 1e6;
-    if (symbol_rate_ratio - samples_per_symbol as f64).abs() > 0.05 {
-        println!(
-            "Sample rate {:.3} MS/s is not close to an integer multiple of the BLE 1 Msym/s symbol rate; symbol slicing may be less reliable",
-            sample_rate / 1.0e6
-        );
-    }
-
-    let channel_index = args.channel;
-    let frequency = ble_protocol::frequency_hz_from_channel_index(channel_index)?;
-    println!(
-        "Using BLE channel {channel_index} ({:.3} MHz)",
-        frequency / 1.0e6
-    );
-    if args.burst {
-        println!(
-            "Using IQ burst decoder with squelch threshold {:.1} dB.",
-            args.squelch_db
-        );
-    } else {
-        println!("Using continuous packet decoder.");
-    }
-
-    let rx_taps = gmsk_demod::gmsk_rx_taps(samples_per_symbol)?;
-    println!("GMSK receive filter configured.");
-    let gmsk_filter = FirBuilder::fir::<Complex32, Complex32, _>(rx_taps);
-    let snk = NullSink::<u8>::new();
-
-    if args.burst {
-        let ble_burst = ble_iq_burst::BleIqBurstBlock::<
-            DefaultCpuReader<Complex32>,
-            DefaultCpuWriter<u8>,
-        >::with_packet_and_wireshark_output(
-            samples_per_symbol,
-            channel_index,
-            args.squelch_db,
-            !args.quiet,
-            args.wireshark,
-        );
-
-        if args.simulate {
-            println!("Simulation mode: Testing full GMSK demodulator DSP chain");
-            let simulated_samples = ble_sim::generate_ble_packet_samples(
-                samples_per_symbol,
-                args.simulate_packets,
-                channel_index,
-            );
-            let src = VectorSource::<Complex32>::new(simulated_samples);
-            connect!(fg, src > gmsk_filter > ble_burst > snk);
-            connect_wireshark(fg, ble_burst, args)?;
-        } else if let Some(iq_file) = &args.iq_file {
-            println!(
-                "File mode: Reading interleaved f32 IQ samples from {}",
-                iq_file.display()
-            );
-            let src = FileSource::<Complex32>::new(iq_file, false);
-            connect!(fg, src > gmsk_filter > ble_burst > snk);
-            connect_wireshark(fg, ble_burst, args)?;
-        } else {
-            println!("Hardware mode: Deploying Seify source live SDR chain");
-            let src = Builder::new(args.args.clone())?
-                .frequency(frequency)
-                .sample_rate(sample_rate)
-                .gain(args.gain)
-                .antenna(args.antenna.clone())
-                .build_source()?;
-            connect!(fg, src.outputs[0] > gmsk_filter > ble_burst > snk);
-            connect_wireshark(fg, ble_burst, args)?;
-        }
-    } else {
-        let ble_sync = ble_sync::BleSyncBlock::<DefaultCpuReader<f32>, DefaultCpuWriter<u8>>::with_channel_phase_packet_and_wireshark_output(
-            args.threshold,
-            args.normalize_levels,
-            samples_per_symbol,
-            channel_index,
-            0,
-            !args.quiet,
-            args.wireshark,
-        );
-        let discriminator = discriminator_block();
-
-        if args.simulate {
-            println!("Simulation mode: Testing full GMSK demodulator DSP chain");
-            let simulated_samples = ble_sim::generate_ble_packet_samples(
-                samples_per_symbol,
-                args.simulate_packets,
-                channel_index,
-            );
-            let src = VectorSource::<Complex32>::new(simulated_samples);
-            connect!(fg, src > gmsk_filter > discriminator > ble_sync > snk);
-            connect_wireshark(fg, ble_sync, args)?;
-        } else if let Some(iq_file) = &args.iq_file {
-            println!(
-                "File mode: Reading interleaved f32 IQ samples from {}",
-                iq_file.display()
-            );
-            let src = FileSource::<Complex32>::new(iq_file, false);
-            connect!(fg, src > gmsk_filter > discriminator > ble_sync > snk);
-            connect_wireshark(fg, ble_sync, args)?;
-        } else {
-            println!("Hardware mode: Deploying Seify source live SDR chain");
-            let src = Builder::new(args.args.clone())?
-                .frequency(frequency)
-                .sample_rate(sample_rate)
-                .gain(args.gain)
-                .antenna(args.antenna.clone())
-                .build_source()?;
-            connect!(fg, src.outputs[0] > gmsk_filter > discriminator > ble_sync > snk);
-            connect_wireshark(fg, ble_sync, args)?;
-        }
-    }
-
-    Ok(())
-}
-
-fn selected_channels(args: &Args) -> Result<Vec<u8>> {
-    let mut channels = if args.channels.is_empty() {
-        vec![args.channel]
-    } else {
-        args.channels.clone()
-    };
-
-    channels.sort_unstable();
-    channels.dedup();
-
-    for &channel in &channels {
-        ble_protocol::frequency_hz_from_channel_index(channel)?;
-    }
-
-    Ok(channels)
-}
-
-fn capture_channels(args: &Args, selected_channels: &[u8]) -> Result<Vec<u8>> {
-    let mut channels = selected_channels.to_vec();
-    channels.extend(args.passive_channels.iter().copied());
-    channels.sort_unstable();
-    channels.dedup();
-
-    for &channel in &channels {
-        ble_protocol::frequency_hz_from_channel_index(channel)?;
-    }
-
-    Ok(channels)
-}
-
-fn build_multi_channel_flowgraph(
-    mut fg: &mut Flowgraph,
-    args: &Args,
-    sample_rate: f64,
-    decode_channels: &[u8],
-    capture_channels: &[u8],
-    burst: bool,
-) -> Result<()> {
-    let pfb_channels = pfb_channels_from_sample_rate(sample_rate)?;
-    let center_frequency = center_frequency_for_channels(capture_channels)?;
-    let channel_rate = sample_rate / pfb_channels as f64;
-    let samples_per_symbol = (channel_rate / 1.0e6).round() as usize;
-
-    if (channel_rate - BLE_CHANNEL_SPACING_HZ).abs() > 1.0 {
-        bail!(
-            "multi-channel output rate must be 2 MS/s per channel, got {:.3} MS/s",
-            channel_rate / 1.0e6
-        );
-    }
-
-    println!(
-        "Multi-channel mode: center={:.3} MHz sample_rate={:.3} MS/s pfb_channels={} channel_rate={:.3} MS/s decode_channels={:?} capture_channels={:?}",
-        center_frequency / 1.0e6,
-        sample_rate / 1.0e6,
-        pfb_channels,
-        channel_rate / 1.0e6,
-        decode_channels,
-        capture_channels,
-    );
-
-    let src = Builder::new(args.args.clone())?
-        .frequency(center_frequency)
-        .sample_rate(sample_rate)
-        .gain(args.gain)
-        .antenna(args.antenna.clone())
-        .build_source()?;
-
-    let taps = pfb_channelizer_taps(pfb_channels);
-    let channelizer: PfbChannelizer = PfbChannelizer::new(pfb_channels, &taps, 1.0);
-    connect!(fg, src.outputs[0] > channelizer);
-
-    for &channel in &args.passive_channels {
-        let frequency = ble_protocol::frequency_hz_from_channel_index(channel)?;
-        let port = pfb_port_for_frequency(frequency, center_frequency, pfb_channels)?;
-        println!(
-            "capturing passive BLE channel {channel} ({:.3} MHz) on PFB output outputs[{port}]",
-            frequency / 1.0e6
-        );
-    }
-
-    let mut channel_ports = Vec::with_capacity(decode_channels.len());
-    for &channel in decode_channels {
-        let channel_frequency = ble_protocol::frequency_hz_from_channel_index(channel)?;
-        let port = pfb_port_for_frequency(channel_frequency, center_frequency, pfb_channels)?;
-        channel_ports.push((channel, channel_frequency, port));
-    }
-    let selected_ports: Vec<usize> = channel_ports.iter().map(|(_, _, port)| *port).collect();
-
-    for port in 0..pfb_channels {
-        if !selected_ports.contains(&port) {
-            let snk = fg.add(NullSink::<Complex32>::new());
-            fg.stream_dyn(channelizer, format!("outputs[{port}]"), snk, "input")?;
-        }
-    }
-
-    for (channel, channel_frequency, port) in channel_ports {
-        let port_name = format!("outputs[{port}]");
-        println!(
-            "connecting BLE channel {channel} ({:.3} MHz) to PFB output {port_name}",
-            channel_frequency / 1.0e6
-        );
-
-        let gmsk_filter = fg.add(FirBuilder::fir::<Complex32, Complex32, _>(
-            gmsk_demod::gmsk_rx_taps(samples_per_symbol)?,
-        ));
-        let snk = fg.add(NullSink::<u8>::new());
-
-        fg.stream_dyn(channelizer, port_name, gmsk_filter, "input")?;
-
-        if burst {
-            let ble_burst = fg.add(ble_iq_burst::BleIqBurstBlock::<
-                DefaultCpuReader<Complex32>,
-                DefaultCpuWriter<u8>,
-            >::with_packet_and_wireshark_output(
-                samples_per_symbol,
-                channel,
-                args.squelch_db,
-                !args.quiet,
-                args.wireshark,
-            ));
-            connect!(fg, gmsk_filter > ble_burst > snk);
-            connect_wireshark(fg, ble_burst, args)?;
-        } else {
-            let ble_sync = fg.add(ble_sync::BleSyncBlock::<
-                DefaultCpuReader<f32>,
-                DefaultCpuWriter<u8>,
-            >::with_channel_phase_packet_and_wireshark_output(
-                args.threshold,
-                args.normalize_levels,
-                samples_per_symbol,
-                channel,
-                0,
-                !args.quiet,
-                args.wireshark,
-            ));
-            let discriminator = fg.add(discriminator_block());
-            connect!(fg, gmsk_filter > discriminator > ble_sync > snk);
-            connect_wireshark(fg, ble_sync, args)?;
-        }
-    }
-
-    Ok(())
-}
-
-fn connect_wireshark(fg: &mut Flowgraph, source: impl Into<BlockId>, args: &Args) -> Result<()> {
-    if !args.wireshark {
-        return Ok(());
-    }
-
-    let udp = fg.add(BlobToUdp::new(&args.wireshark_addr));
-    fg.message(source.into(), "wireshark", udp, "in")?;
-    println!(
-        "Streaming BLE LL packets to Wireshark UDP endpoint {}.",
-        args.wireshark_addr
-    );
-    Ok(())
-}
-
-fn pfb_channelizer_taps(pfb_channels: usize) -> Vec<f32> {
-    let transition_bw = 0.5;
-    remez::low_pass(
-        1.0,
-        pfb_channels,
-        0.5 - transition_bw / 2.0,
-        0.5 + transition_bw / 2.0,
-        0.1,
-        100.0,
-        None,
-    )
-    .into_iter()
-    .map(|tap| tap as f32)
-    .collect()
-}
-
-fn discriminator_block() -> Apply<impl FnMut(&Complex32) -> f32 + Send + 'static, Complex32, f32> {
-    let mut last = Complex32::new(1.0, 0.0);
-    Apply::new(move |v: &Complex32| {
-        let mut phase = (v * last.conj()).arg();
-        while phase <= -std::f32::consts::PI {
-            phase += 2.0 * std::f32::consts::PI;
-        }
-        while phase > std::f32::consts::PI {
-            phase -= 2.0 * std::f32::consts::PI;
-        }
-        last = *v;
-        phase
-    })
-}
-
-fn pfb_channels_from_sample_rate(sample_rate: f64) -> Result<usize> {
-    let channels = sample_rate / BLE_CHANNEL_SPACING_HZ;
-    let rounded = channels.round();
-
-    if (channels - rounded).abs() > 1e-6 {
-        bail!(
-            "multi-channel sample rate must be an integer multiple of 2 MHz, got {:.3} MS/s",
-            sample_rate / 1.0e6
-        );
-    }
-
-    let channels = rounded as usize;
-    if channels <= 2 {
-        bail!("multi-channel mode needs at least 4 MHz sample rate");
-    }
-
-    Ok(channels)
-}
-
-fn center_frequency_for_channels(channels: &[u8]) -> Result<f64> {
-    let frequencies_mhz: Vec<i32> = channels
-        .iter()
-        .map(|&channel| {
-            ble_protocol::frequency_hz_from_channel_index(channel)
-                .map(|freq| (freq / BLE_CHANNEL_SPACING_HZ).round() as i32)
-        })
-        .collect::<Result<Vec<_>, _>>()?;
-
-    let min_bin = frequencies_mhz.iter().min().copied().unwrap_or(1201);
-    let max_bin = frequencies_mhz.iter().max().copied().unwrap_or(min_bin);
-    let center_bin = min_bin + (max_bin - min_bin + 1) / 2;
-
-    Ok(center_bin as f64 * BLE_CHANNEL_SPACING_HZ)
-}
-
-fn auto_multi_channel_sample_rate(channels: &[u8], center_frequency: f64) -> Result<f64> {
-    let max_offset_bins = channels
-        .iter()
-        .map(|&channel| {
-            ble_protocol::frequency_hz_from_channel_index(channel).map(|freq| {
-                ((freq - center_frequency) / BLE_CHANNEL_SPACING_HZ)
-                    .round()
-                    .abs() as usize
-            })
-        })
-        .collect::<Result<Vec<_>, _>>()?
-        .into_iter()
-        .max()
-        .unwrap_or(0);
-
-    let pfb_channels = ((max_offset_bins + MULTI_CHANNEL_GUARD_BINS) * 2).max(4);
-    Ok(pfb_channels as f64 * BLE_CHANNEL_SPACING_HZ)
-}
-
-fn pfb_port_for_frequency(
-    frequency: f64,
-    center_frequency: f64,
-    pfb_channels: usize,
-) -> Result<usize> {
-    let offset_bins = (frequency - center_frequency) / BLE_CHANNEL_SPACING_HZ;
-    let rounded = offset_bins.round();
-
-    if (offset_bins - rounded).abs() > 1e-6 {
-        bail!(
-            "frequency {:.3} MHz does not align with the 2 MHz PFB grid around center {:.3} MHz",
-            frequency / 1.0e6,
-            center_frequency / 1.0e6,
-        );
-    }
-
-    let offset_bins = rounded as isize;
-    let half = (pfb_channels / 2) as isize;
-    if offset_bins.abs() >= half {
-        bail!(
-            "frequency {:.3} MHz is outside the usable PFB span for center {:.3} MHz and {} channels",
-            frequency / 1.0e6,
-            center_frequency / 1.0e6,
-            pfb_channels,
-        );
-    }
-
-    if offset_bins >= 0 {
-        Ok(offset_bins as usize)
-    } else {
-        Ok(pfb_channels - (-offset_bins as usize))
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use futuresdr::blocks::VectorSink;
-
-    #[test]
-    fn multi_channel_center_keeps_ble_grid_alignment() {
-        let center = center_frequency_for_channels(&[37, 38]).unwrap();
-
-        assert_eq!(center, 2.414e9);
-    }
-
-    #[test]
-    fn pfb_ports_map_positive_and_negative_offsets() {
-        let center = 2.414e9;
-
-        assert_eq!(
-            pfb_port_for_frequency(
-                ble_protocol::frequency_hz_from_channel_index(37).unwrap(),
-                center,
-                16
-            )
-            .unwrap(),
-            10
-        );
-        assert_eq!(
-            pfb_port_for_frequency(
-                ble_protocol::frequency_hz_from_channel_index(38).unwrap(),
-                center,
-                16
-            )
-            .unwrap(),
-            6
-        );
-    }
-
-    #[test]
-    fn auto_sample_rate_leaves_guard_bins() {
-        let center = center_frequency_for_channels(&[37, 38]).unwrap();
-
-        assert_eq!(
-            auto_multi_channel_sample_rate(&[37, 38], center).unwrap(),
-            28.0e6
-        );
-    }
-
-    #[test]
-    fn adjacent_advertising_and_data_channel_fit_in_lower_rate() {
-        let center = center_frequency_for_channels(&[37, 0]).unwrap();
-
-        assert_eq!(center, 2.404e9);
-        assert_eq!(
-            auto_multi_channel_sample_rate(&[37, 0], center).unwrap(),
-            8.0e6
-        );
-        assert_eq!(
-            pfb_port_for_frequency(
-                ble_protocol::frequency_hz_from_channel_index(37).unwrap(),
-                center,
-                4
-            )
-            .unwrap(),
-            3
-        );
-        assert_eq!(
-            pfb_port_for_frequency(
-                ble_protocol::frequency_hz_from_channel_index(0).unwrap(),
-                center,
-                4
-            )
-            .unwrap(),
-            0
-        );
-    }
-
-    #[test]
-    fn pfb_routes_synthetic_ble_channel_tones() -> Result<()> {
-        let pfb_channels = 14;
-        let sample_count = 16_384;
-        let taps = pfb_channelizer_taps(pfb_channels);
-        let center = center_frequency_for_channels(&[37, 38])?;
-
-        let ch37_port = pfb_port_for_frequency(
-            ble_protocol::frequency_hz_from_channel_index(37)?,
-            center,
-            pfb_channels,
-        )?;
-        let ch38_port = pfb_port_for_frequency(
-            ble_protocol::frequency_hz_from_channel_index(38)?,
-            center,
-            pfb_channels,
-        )?;
-
-        let ch37_powers = pfb_output_powers_db(
-            tone_at_pfb_bin(-6, pfb_channels, sample_count),
-            pfb_channels,
-            &taps,
-        )?;
-        let ch38_powers = pfb_output_powers_db(
-            tone_at_pfb_bin(6, pfb_channels, sample_count),
-            pfb_channels,
-            &taps,
-        )?;
-
-        assert_eq!(strongest_output(&ch37_powers), ch37_port);
-        assert_eq!(strongest_output(&ch38_powers), ch38_port);
-
-        assert!(
-            neighbor_leakage_db(&ch37_powers, ch37_port) < -30.0,
-            "ch37 neighbor leakage {:.1} dB, powers {:?}",
-            neighbor_leakage_db(&ch37_powers, ch37_port),
-            ch37_powers
-        );
-        assert!(
-            neighbor_leakage_db(&ch38_powers, ch38_port) < -30.0,
-            "ch38 neighbor leakage {:.1} dB, powers {:?}",
-            neighbor_leakage_db(&ch38_powers, ch38_port),
-            ch38_powers
-        );
-
-        Ok(())
-    }
-
-    fn tone_at_pfb_bin(bin: isize, pfb_channels: usize, sample_count: usize) -> Vec<Complex32> {
-        let phase_step = 2.0 * std::f64::consts::PI * bin as f64 / pfb_channels as f64;
-        (0..sample_count)
-            .map(|index| {
-                let phase = phase_step * index as f64;
-                Complex32::new(phase.cos() as f32, phase.sin() as f32)
-            })
-            .collect()
-    }
-
-    fn pfb_output_powers_db(
-        input: Vec<Complex32>,
-        pfb_channels: usize,
-        taps: &[f32],
-    ) -> Result<Vec<f64>> {
-        let mut fg = Flowgraph::new();
-        let src = fg.add(VectorSource::<Complex32>::new(input));
-        let channelizer = fg.add(PfbChannelizer::<
-            DefaultCpuReader<Complex32>,
-            DefaultCpuWriter<Complex32>,
-        >::new(pfb_channels, taps, 1.0));
-        fg.stream_dyn(src, "output", channelizer, "input")?;
-
-        let mut sinks = Vec::with_capacity(pfb_channels);
-        for port in 0..pfb_channels {
-            let sink = fg.add(VectorSink::<Complex32>::new(2048));
-            fg.stream_dyn(channelizer, format!("outputs[{port}]"), sink, "input")?;
-            sinks.push(sink);
-        }
-
-        let fg = Runtime::new().run(fg)?;
-        let powers = sinks
-            .iter()
-            .map(|sink| {
-                let sink = fg.block(sink)?;
-                Ok(mean_power_db(sink.items()))
-            })
-            .collect::<Result<Vec<_>>>()?;
-
-        Ok(powers)
-    }
-
-    fn mean_power_db(samples: &[Complex32]) -> f64 {
-        let skip = samples.len().min(16);
-        let samples = &samples[skip..];
-        let mean_power = samples
-            .iter()
-            .map(|sample| sample.norm_sqr() as f64)
-            .sum::<f64>()
-            / samples.len().max(1) as f64;
-
-        10.0 * mean_power.max(1.0e-20).log10()
-    }
-
-    fn strongest_output(powers_db: &[f64]) -> usize {
-        powers_db
-            .iter()
-            .enumerate()
-            .max_by(|(_, a), (_, b)| a.total_cmp(b))
-            .map(|(index, _)| index)
-            .unwrap()
-    }
-
-    fn neighbor_leakage_db(powers_db: &[f64], main_port: usize) -> f64 {
-        let main_power = powers_db[main_port];
-        let lower = powers_db[(main_port + powers_db.len() - 1) % powers_db.len()] - main_power;
-        let upper = powers_db[(main_port + 1) % powers_db.len()] - main_power;
-        lower.max(upper)
-    }
 }

--- a/examples/bluetooth/src/main.rs
+++ b/examples/bluetooth/src/main.rs
@@ -3,6 +3,8 @@ use anyhow::bail;
 use clap::Parser;
 use futuredsp::firdes::remez;
 use futuresdr::blocks::Apply;
+use futuresdr::blocks::BlobToUdp;
+use futuresdr::blocks::FileSource;
 use futuresdr::blocks::FirBuilder;
 use futuresdr::blocks::NullSink;
 use futuresdr::blocks::PfbChannelizer;
@@ -10,9 +12,11 @@ use futuresdr::blocks::VectorSource;
 use futuresdr::blocks::seify::Builder;
 use futuresdr::num_complex::Complex32;
 use futuresdr::prelude::*;
+use futuresdr::runtime::BlockId;
 use futuresdr::runtime::Error as RuntimeError;
 use futuresdr::runtime::dev::DefaultCpuReader;
 use futuresdr::runtime::dev::DefaultCpuWriter;
+use std::path::PathBuf;
 use std::sync::mpsc;
 use std::time::Duration;
 
@@ -28,6 +32,7 @@ mod ble_protocol;
 mod ble_sim;
 mod ble_slicer;
 mod ble_sync;
+mod ble_wireshark;
 mod gmsk_demod;
 
 #[derive(Parser, Debug)]
@@ -60,9 +65,15 @@ struct Args {
     #[arg(long, default_value_t = false)]
     quiet: bool,
     #[arg(long, default_value_t = false)]
+    wireshark: bool,
+    #[arg(long, default_value = "127.0.0.1:55556")]
+    wireshark_addr: String,
+    #[arg(long, default_value_t = false)]
     simulate: bool,
     #[arg(long, default_value_t = 1)]
     simulate_packets: usize,
+    #[arg(long)]
+    iq_file: Option<PathBuf>,
     #[arg(long)]
     duration: Option<f64>,
 }
@@ -77,6 +88,10 @@ fn main() -> Result<()> {
     let capture_channels = capture_channels(&args, &selected_channels)?;
     let mut sample_rate = args.sample_rate;
 
+    if args.simulate && args.iq_file.is_some() {
+        bail!("--simulate and --iq-file cannot be used together");
+    }
+
     if args.multi_channel && (sample_rate - 2.0e6).abs() < f64::EPSILON {
         let center_frequency = center_frequency_for_channels(&capture_channels)?;
         sample_rate = auto_multi_channel_sample_rate(&capture_channels, center_frequency)?;
@@ -90,6 +105,9 @@ fn main() -> Result<()> {
         if args.simulate {
             bail!("--multi-channel simulation is not implemented yet");
         }
+        if args.iq_file.is_some() {
+            bail!("--multi-channel --iq-file input is not implemented yet");
+        }
         build_multi_channel_flowgraph(
             &mut fg,
             &args,
@@ -102,6 +120,16 @@ fn main() -> Result<()> {
         build_single_channel_flowgraph(&mut fg, &args, sample_rate)?;
     }
 
+    if args.simulate || args.iq_file.is_some() {
+        if args.duration.is_some() {
+            println!("Finite input mode: ignoring --duration and running until input EOF.");
+        }
+        println!("Runtime started.");
+        Runtime::new().run(fg)?;
+        println!("Runtime stopped.");
+        return Ok(());
+    }
+
     let rt = Runtime::new();
     let running = rt.start(fg)?;
     println!("Runtime started.");
@@ -111,34 +139,24 @@ fn main() -> Result<()> {
         let _ = shutdown_tx.send(());
     })?;
 
-    if args.simulate && args.duration.is_none() {
-        Runtime::block_on(async move {
-            match running.wait_async().await {
-                Ok(_) | Err(RuntimeError::FlowgraphTerminated) => {}
-                Err(err) => return Err(err.into()),
-            }
-            Ok::<(), anyhow::Error>(())
-        })?;
+    if let Some(duration) = args.duration {
+        let _ = shutdown_rx.recv_timeout(Duration::from_secs_f64(duration));
     } else {
-        if let Some(duration) = args.duration {
-            let _ = shutdown_rx.recv_timeout(Duration::from_secs_f64(duration));
-        } else {
-            println!("Press Ctrl+C to stop.");
-            shutdown_rx.recv()?;
-        }
-
-        Runtime::block_on(async move {
-            match running.stop().await {
-                Ok(()) | Err(RuntimeError::FlowgraphTerminated) => {}
-                Err(err) => return Err(err.into()),
-            }
-            match running.wait_async().await {
-                Ok(_) | Err(RuntimeError::FlowgraphTerminated) => {}
-                Err(err) => return Err(err.into()),
-            }
-            Ok::<(), anyhow::Error>(())
-        })?;
+        println!("Press Ctrl+C to stop.");
+        shutdown_rx.recv()?;
     }
+
+    Runtime::block_on(async move {
+        match running.stop().await {
+            Ok(()) | Err(RuntimeError::FlowgraphTerminated) => {}
+            Err(err) => return Err(err.into()),
+        }
+        match running.wait_async().await {
+            Ok(_) | Err(RuntimeError::FlowgraphTerminated) => {}
+            Err(err) => return Err(err.into()),
+        }
+        Ok::<(), anyhow::Error>(())
+    })?;
 
     println!("Runtime stopped.");
     Ok(())
@@ -182,11 +200,12 @@ fn build_single_channel_flowgraph(
         let ble_burst = ble_iq_burst::BleIqBurstBlock::<
             DefaultCpuReader<Complex32>,
             DefaultCpuWriter<u8>,
-        >::with_packet_output(
+        >::with_packet_and_wireshark_output(
             samples_per_symbol,
             channel_index,
             args.squelch_db,
             !args.quiet,
+            args.wireshark,
         );
 
         if args.simulate {
@@ -198,6 +217,15 @@ fn build_single_channel_flowgraph(
             );
             let src = VectorSource::<Complex32>::new(simulated_samples);
             connect!(fg, src > gmsk_filter > ble_burst > snk);
+            connect_wireshark(fg, ble_burst, args)?;
+        } else if let Some(iq_file) = &args.iq_file {
+            println!(
+                "File mode: Reading interleaved f32 IQ samples from {}",
+                iq_file.display()
+            );
+            let src = FileSource::<Complex32>::new(iq_file, false);
+            connect!(fg, src > gmsk_filter > ble_burst > snk);
+            connect_wireshark(fg, ble_burst, args)?;
         } else {
             println!("Hardware mode: Deploying Seify source live SDR chain");
             let src = Builder::new(args.args.clone())?
@@ -207,15 +235,17 @@ fn build_single_channel_flowgraph(
                 .antenna(args.antenna.clone())
                 .build_source()?;
             connect!(fg, src.outputs[0] > gmsk_filter > ble_burst > snk);
+            connect_wireshark(fg, ble_burst, args)?;
         }
     } else {
-        let ble_sync = ble_sync::BleSyncBlock::<DefaultCpuReader<f32>, DefaultCpuWriter<u8>>::with_channel_phase_and_packet_output(
+        let ble_sync = ble_sync::BleSyncBlock::<DefaultCpuReader<f32>, DefaultCpuWriter<u8>>::with_channel_phase_packet_and_wireshark_output(
             args.threshold,
             args.normalize_levels,
             samples_per_symbol,
             channel_index,
             0,
             !args.quiet,
+            args.wireshark,
         );
         let discriminator = discriminator_block();
 
@@ -228,6 +258,15 @@ fn build_single_channel_flowgraph(
             );
             let src = VectorSource::<Complex32>::new(simulated_samples);
             connect!(fg, src > gmsk_filter > discriminator > ble_sync > snk);
+            connect_wireshark(fg, ble_sync, args)?;
+        } else if let Some(iq_file) = &args.iq_file {
+            println!(
+                "File mode: Reading interleaved f32 IQ samples from {}",
+                iq_file.display()
+            );
+            let src = FileSource::<Complex32>::new(iq_file, false);
+            connect!(fg, src > gmsk_filter > discriminator > ble_sync > snk);
+            connect_wireshark(fg, ble_sync, args)?;
         } else {
             println!("Hardware mode: Deploying Seify source live SDR chain");
             let src = Builder::new(args.args.clone())?
@@ -237,6 +276,7 @@ fn build_single_channel_flowgraph(
                 .antenna(args.antenna.clone())
                 .build_source()?;
             connect!(fg, src.outputs[0] > gmsk_filter > discriminator > ble_sync > snk);
+            connect_wireshark(fg, ble_sync, args)?;
         }
     }
 
@@ -356,27 +396,48 @@ fn build_multi_channel_flowgraph(
             let ble_burst = fg.add(ble_iq_burst::BleIqBurstBlock::<
                 DefaultCpuReader<Complex32>,
                 DefaultCpuWriter<u8>,
-            >::with_packet_output(
-                samples_per_symbol, channel, args.squelch_db, !args.quiet
+            >::with_packet_and_wireshark_output(
+                samples_per_symbol,
+                channel,
+                args.squelch_db,
+                !args.quiet,
+                args.wireshark,
             ));
             connect!(fg, gmsk_filter > ble_burst > snk);
+            connect_wireshark(fg, ble_burst, args)?;
         } else {
             let ble_sync = fg.add(ble_sync::BleSyncBlock::<
                 DefaultCpuReader<f32>,
                 DefaultCpuWriter<u8>,
-            >::with_channel_phase_and_packet_output(
+            >::with_channel_phase_packet_and_wireshark_output(
                 args.threshold,
                 args.normalize_levels,
                 samples_per_symbol,
                 channel,
                 0,
                 !args.quiet,
+                args.wireshark,
             ));
             let discriminator = fg.add(discriminator_block());
             connect!(fg, gmsk_filter > discriminator > ble_sync > snk);
+            connect_wireshark(fg, ble_sync, args)?;
         }
     }
 
+    Ok(())
+}
+
+fn connect_wireshark(fg: &mut Flowgraph, source: impl Into<BlockId>, args: &Args) -> Result<()> {
+    if !args.wireshark {
+        return Ok(());
+    }
+
+    let udp = fg.add(BlobToUdp::new(&args.wireshark_addr));
+    fg.message(source.into(), "wireshark", udp, "in")?;
+    println!(
+        "Streaming BLE LL packets to Wireshark UDP endpoint {}.",
+        args.wireshark_addr
+    );
     Ok(())
 }
 

--- a/src/blocks/seify/builder.rs
+++ b/src/blocks/seify/builder.rs
@@ -79,12 +79,18 @@ impl<D: DeviceTrait + Clone> Builder<D> {
             min_input_buffer_size: None,
         }
     }
-    /// Channel
+    /// Channel: sets the hardware channel index 
+    /// #Example
+    /// For USRP B210:  
+    /// - `0`: corresponds to RF A
+    /// - `1`: corresponds to RF B
     pub fn channel(mut self, c: usize) -> Self {
         self.channels = vec![c];
         self
     }
-    /// Channels
+    /// Channels: sets multiple hardware channel indices for MIMO or multi-channel configurations  
+    /// #Example
+    /// For USRP B210: `vec![0, 1]` enables both RF A and RF B
     pub fn channels(mut self, c: Vec<usize>) -> Self {
         self.channels = c;
         self

--- a/src/blocks/seify/source.rs
+++ b/src/blocks/seify/source.rs
@@ -37,7 +37,7 @@ use crate::runtime::dev::prelude::*;
 ///
 /// # Message Outputs
 ///
-/// No message outputs.
+/// `overflow`: `Pmt::U64` cumulative receive overflow count after each overflow.
 ///
 /// # Usage
 /// ```ignore
@@ -52,6 +52,7 @@ use crate::runtime::dev::prelude::*;
 #[derive(Block)]
 #[blocking]
 #[message_inputs(freq, gain, sample_rate, cmd, terminate, config, overflows)]
+#[message_outputs(overflow)]
 #[type_name(SeifySource)]
 pub struct Source<D, OUT = DefaultCpuWriter<Complex32>>
 where
@@ -225,7 +226,7 @@ where
     async fn work(
         &mut self,
         io: &mut WorkIo,
-        _mo: &mut MessageOutputs,
+        mo: &mut MessageOutputs,
         _meta: &mut BlockMeta,
     ) -> Result<()> {
         let mut bufs: Vec<&mut [Complex32]> = self.outputs.iter_mut().map(|b| b.slice()).collect();
@@ -244,6 +245,7 @@ where
             Err(seify::Error::Overflow) => {
                 self.overflows += 1;
                 warn!("Seify Source Overflow");
+                mo.post("overflow", Pmt::U64(self.overflows)).await?;
             }
             Err(e) => {
                 error!("Seify Source Error: {:?}", e);


### PR DESCRIPTION
This PR adds a Bluetooth Low Energy sniffer example to FutureSDR. It receives and decodes BLE 1M packets from SDR hardware, simulation, or offline IQ recordings.

 Features:

- Single-channel continuous and burst decoders
- Adaptive burst detection and frequency-offset correction
- BLE advertising PDU parsing, dewhitening, and CRC validation
- Legacy and extended advertising header summaries
- PFB-based reception of multiple selected BLE channels
- `CONNECT_IND` parsing and connection tracking
- CSA 1 and CSA 2 event and data-channel following
- BLE link-layer control update handling
- Live Wireshark output through UDP/RFTap
- Graceful shutdown with decoder and connection statistics

Validation:

The example was tested with a USRP B210 on BLE advertising channels 37, 38, and 39, including selected multi-channel PFB configurations and monitored data channels. Live advertising and data packets were also verified in Wireshark.

The example includes 69 unit tests covering protocol parsing, CRC and whitening, burst decoding, channel selection, connection timing, PFB channel mapping, and Wireshark encapsulation.