### PR TITLE
seify: update to new API

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -82,7 +82,7 @@ num-complex = "0.4"
 num-integer = "0.1"
 once_cell = "1.21"
 rustfft = "6.4"
-seify = { version = "0.18", default-features = false, optional = true }
+seify = { version = "0.20", default-features = false, optional = true }
 slab = "0.4"
 spin = { version = "0.10", optional = true }
 serde = { version = "1.0", features = ["derive"] }

--- a/crates/types/Cargo.toml
+++ b/crates/types/Cargo.toml
@@ -18,7 +18,7 @@ seify = ["dep:seify"]
 [dependencies]
 dyn-clone = "1.0"
 num-complex = { version = "0.4", features = ["serde"] }
-seify = { version = "0.18", default-features = false, optional = true }
+seify = { version = "0.20", default-features = false, optional = true }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 thiserror = "2.0"

--- a/src/blocks/seify/builder.rs
+++ b/src/blocks/seify/builder.rs
@@ -1,8 +1,6 @@
 use seify::Args;
-use seify::Device;
-use seify::DeviceTrait;
 use seify::Direction;
-use seify::GenericDevice;
+use seify::DynDevice;
 
 use crate::blocks::seify::Config;
 use crate::blocks::seify::Sink;
@@ -35,19 +33,19 @@ impl IntoAntenna for Option<String> {
 }
 
 /// Seify Device builder
-pub struct Builder<D: DeviceTrait + Clone> {
+pub struct Builder {
     channels: Vec<usize>,
     config: Config,
-    dev: Device<D>,
+    dev: DynDevice,
     start_time: Option<i64>,
     min_input_buffer_size: Option<usize>,
 }
 
-impl Builder<GenericDevice> {
+impl Builder {
     /// Create Seify Device builder
     pub fn new<A: TryInto<Args>>(args: A) -> Result<Self, Error> {
         let args = args.try_into().or(Err(Error::SeifyArgsConversionError))?;
-        let dev = Device::from_args(args)?;
+        let dev = DynDevice::from_args(args)?;
         Ok(Self {
             channels: vec![0],
             config: Config::new(),
@@ -58,23 +56,23 @@ impl Builder<GenericDevice> {
     }
 }
 
-impl<D: DeviceTrait + Clone> Builder<D> {
+impl Builder {
     /// Create Seify Device builder
-    pub fn from_device(dev: Device<D>) -> Self {
+    pub fn from_device(dev: impl Into<DynDevice>) -> Self {
         Self {
             channels: vec![0],
             config: Config::new(),
-            dev,
+            dev: dev.into(),
             start_time: None,
             min_input_buffer_size: None,
         }
     }
     /// Seify device
-    pub fn device<D2: DeviceTrait + Clone>(self, dev: Device<D2>) -> Builder<D2> {
+    pub fn device(self, dev: impl Into<DynDevice>) -> Builder {
         Builder {
             channels: self.channels,
             config: self.config,
-            dev,
+            dev: dev.into(),
             start_time: self.start_time,
             min_input_buffer_size: None,
         }
@@ -131,7 +129,7 @@ impl<D: DeviceTrait + Clone> Builder<D> {
         self
     }
     /// Build Typed Seify Source
-    pub fn build_source(self) -> Result<Source<D>, Error> {
+    pub fn build_source(self) -> Result<Source, Error> {
         self.config
             .apply(&self.dev, &self.channels, Direction::Rx)?;
         Ok(Source::new(self.dev, self.channels, self.start_time))
@@ -139,17 +137,13 @@ impl<D: DeviceTrait + Clone> Builder<D> {
     /// Build Typed Seify Source
     pub fn build_source_with_buffer<B: CpuBufferWriter<Item = Complex32>>(
         self,
-    ) -> Result<Source<D, B>, Error> {
+    ) -> Result<Source<B>, Error> {
         self.config
             .apply(&self.dev, &self.channels, Direction::Rx)?;
-        Ok(Source::<D, B>::new(
-            self.dev,
-            self.channels,
-            self.start_time,
-        ))
+        Ok(Source::<B>::new(self.dev, self.channels, self.start_time))
     }
     /// Builder Typed Seify Sink
-    pub fn build_sink(self) -> Result<Sink<D>, Error> {
+    pub fn build_sink(self) -> Result<Sink, Error> {
         self.config
             .apply(&self.dev, &self.channels, Direction::Tx)?;
         Ok(Sink::new(
@@ -162,10 +156,10 @@ impl<D: DeviceTrait + Clone> Builder<D> {
     /// Builder Typed Seify Sink
     pub fn build_sink_with_buffer<B: CpuBufferReader<Item = Complex32>>(
         self,
-    ) -> Result<Sink<D, B>, Error> {
+    ) -> Result<Sink<B>, Error> {
         self.config
             .apply(&self.dev, &self.channels, Direction::Tx)?;
-        Ok(Sink::<D, B>::new(
+        Ok(Sink::<B>::new(
             self.dev,
             self.channels,
             self.start_time,

--- a/src/blocks/seify/config.rs
+++ b/src/blocks/seify/config.rs
@@ -1,6 +1,10 @@
-use seify::Device;
-use seify::DeviceTrait;
+use seify::AntennaControl;
+use seify::BandwidthControl;
 use seify::Direction;
+use seify::DynDevice;
+use seify::FrequencyControl;
+use seify::GainControl;
+use seify::SampleRateControl;
 use std::collections::HashMap;
 
 use crate::runtime::Error;
@@ -59,12 +63,7 @@ impl Config {
     }
 
     /// Apply config to a device
-    pub fn apply<D: DeviceTrait + Clone>(
-        &self,
-        dev: &Device<D>,
-        channels: &[usize],
-        dir: Direction,
-    ) -> Result<(), Error> {
+    pub fn apply(&self, dev: &DynDevice, channels: &[usize], dir: Direction) -> Result<(), Error> {
         if let Some(chan) = self.selected_channel(channels)? {
             self.apply_channel(dev, dir, chan)?;
         } else {
@@ -76,12 +75,7 @@ impl Config {
         Ok(())
     }
 
-    fn apply_channel<D: DeviceTrait + Clone>(
-        &self,
-        dev: &Device<D>,
-        dir: Direction,
-        chan: usize,
-    ) -> Result<(), Error> {
+    fn apply_channel(&self, dev: &DynDevice, dir: Direction, chan: usize) -> Result<(), Error> {
         if let Some(ref a) = self.antenna {
             dev.set_antenna(dir, chan, a)?;
         }
@@ -89,7 +83,7 @@ impl Config {
             dev.set_bandwidth(dir, chan, b)?;
         }
         if let Some(f) = self.freq {
-            dev.set_frequency(dir, chan, f)?;
+            dev.set_frequency(dir, chan, f, Default::default())?;
         }
         if let Some(g) = self.gain {
             dev.set_gain(dir, chan, g)?;
@@ -108,19 +102,14 @@ impl Config {
     }
 
     /// Extracts a [`Config`] from a [`Device`], [`Direction`], and channel id.
-    pub fn from<D: DeviceTrait + Clone>(
-        dev: &Device<D>,
-        dir: Direction,
-        channel: usize,
-    ) -> Result<Self, Error> {
-        let inner = dev.impl_ref::<D>()?;
+    pub fn from(dev: &DynDevice, dir: Direction, channel: usize) -> Result<Self, Error> {
         Ok(Config {
             chan: None,
-            antenna: inner.antenna(dir, channel).ok(),
-            bandwidth: inner.bandwidth(dir, channel).ok(),
-            freq: inner.frequency(dir, channel).ok(),
-            gain: inner.gain(dir, channel).ok().flatten(),
-            sample_rate: inner.sample_rate(dir, channel).ok(),
+            antenna: dev.antenna(dir, channel).ok(),
+            bandwidth: dev.bandwidth(dir, channel).ok(),
+            freq: dev.frequency(dir, channel).ok(),
+            gain: dev.gain(dir, channel).ok().flatten(),
+            sample_rate: dev.sample_rate(dir, channel).ok(),
         })
     }
 }

--- a/src/blocks/seify/sink.rs
+++ b/src/blocks/seify/sink.rs
@@ -1,6 +1,9 @@
-use seify::Device;
-use seify::DeviceTrait;
 use seify::Direction::Tx;
+use seify::DynDevice;
+use seify::DynTxStreamer;
+use seify::FrequencyControl;
+use seify::GainControl;
+use seify::SampleRateControl;
 use seify::TxStreamer;
 use std::time::Duration;
 
@@ -50,27 +53,25 @@ use crate::runtime::dev::prelude::*;
 #[message_inputs(freq, gain, sample_rate, cmd, config)]
 #[message_outputs(terminate_out)]
 #[type_name(SeifySink)]
-pub struct Sink<D, IN = DefaultCpuReader<Complex32>>
+pub struct Sink<IN = DefaultCpuReader<Complex32>>
 where
-    D: DeviceTrait + Clone,
     IN: CpuBufferReader<Item = Complex32>,
 {
     #[input]
     inputs: Vec<IN>,
     channels: Vec<usize>,
-    dev: Device<D>,
-    streamer: Option<D::TxStreamer>,
+    dev: DynDevice,
+    streamer: Option<DynTxStreamer>,
     start_time: Option<i64>,
     max_input_buffer_size_in_samples: usize,
 }
 
-impl<D, IN> Sink<D, IN>
+impl<IN> Sink<IN>
 where
-    D: DeviceTrait + Clone,
     IN: CpuBufferReader<Item = Complex32>,
 {
     pub(super) fn new(
-        dev: Device<D>,
+        dev: DynDevice,
         channels: Vec<usize>,
         start_time: Option<i64>,
         min_buffer_size: Option<usize>,
@@ -120,10 +121,16 @@ where
     ) -> Result<Pmt> {
         for c in &self.channels {
             match &p {
-                Pmt::F32(v) => self.dev.set_frequency(Tx, *c, *v as f64)?,
-                Pmt::F64(v) => self.dev.set_frequency(Tx, *c, *v)?,
-                Pmt::U32(v) => self.dev.set_frequency(Tx, *c, *v as f64)?,
-                Pmt::U64(v) => self.dev.set_frequency(Tx, *c, *v as f64)?,
+                Pmt::F32(v) => self
+                    .dev
+                    .set_frequency(Tx, *c, *v as f64, Default::default())?,
+                Pmt::F64(v) => self.dev.set_frequency(Tx, *c, *v, Default::default())?,
+                Pmt::U32(v) => self
+                    .dev
+                    .set_frequency(Tx, *c, *v as f64, Default::default())?,
+                Pmt::U64(v) => self
+                    .dev
+                    .set_frequency(Tx, *c, *v as f64, Default::default())?,
                 _ => return Ok(Pmt::InvalidValue),
             };
         }
@@ -192,9 +199,8 @@ where
 }
 
 #[doc(hidden)]
-impl<D, IN> Kernel for Sink<D, IN>
+impl<IN> Kernel for Sink<IN>
 where
-    D: DeviceTrait + Clone,
     IN: CpuBufferReader<Item = Complex32>,
 {
     async fn work(

--- a/src/blocks/seify/source.rs
+++ b/src/blocks/seify/source.rs
@@ -1,8 +1,11 @@
 use anyhow::Context;
-use seify::Device;
-use seify::DeviceTrait;
 use seify::Direction::Rx;
+use seify::DynDevice;
+use seify::DynRxStreamer;
+use seify::FrequencyControl;
+use seify::GainControl;
 use seify::RxStreamer;
+use seify::SampleRateControl;
 use std::time::Duration;
 
 use crate::blocks::seify::Config;
@@ -53,26 +56,24 @@ use crate::runtime::dev::prelude::*;
 #[blocking]
 #[message_inputs(freq, gain, sample_rate, cmd, terminate, config, overflows)]
 #[type_name(SeifySource)]
-pub struct Source<D, OUT = DefaultCpuWriter<Complex32>>
+pub struct Source<OUT = DefaultCpuWriter<Complex32>>
 where
-    D: DeviceTrait + Clone,
     OUT: CpuBufferWriter<Item = Complex32>,
 {
     #[output]
     outputs: Vec<OUT>,
     channels: Vec<usize>,
-    dev: Device<D>,
-    streamer: Option<D::RxStreamer>,
+    dev: DynDevice,
+    streamer: Option<DynRxStreamer>,
     start_time: Option<i64>,
     overflows: u64,
 }
 
-impl<D, OUT> Source<D, OUT>
+impl<OUT> Source<OUT>
 where
-    D: DeviceTrait + Clone,
     OUT: CpuBufferWriter<Item = Complex32>,
 {
-    pub(super) fn new(dev: Device<D>, channels: Vec<usize>, start_time: Option<i64>) -> Self {
+    pub(super) fn new(dev: DynDevice, channels: Vec<usize>, start_time: Option<i64>) -> Self {
         assert!(!channels.is_empty());
 
         let mut outputs = Vec::new();
@@ -132,10 +133,16 @@ where
     ) -> Result<Pmt> {
         for c in &self.channels {
             match &p {
-                Pmt::F32(v) => self.dev.set_frequency(Rx, *c, *v as f64)?,
-                Pmt::F64(v) => self.dev.set_frequency(Rx, *c, *v)?,
-                Pmt::U32(v) => self.dev.set_frequency(Rx, *c, *v as f64)?,
-                Pmt::U64(v) => self.dev.set_frequency(Rx, *c, *v as f64)?,
+                Pmt::F32(v) => self
+                    .dev
+                    .set_frequency(Rx, *c, *v as f64, Default::default())?,
+                Pmt::F64(v) => self.dev.set_frequency(Rx, *c, *v, Default::default())?,
+                Pmt::U32(v) => self
+                    .dev
+                    .set_frequency(Rx, *c, *v as f64, Default::default())?,
+                Pmt::U64(v) => self
+                    .dev
+                    .set_frequency(Rx, *c, *v as f64, Default::default())?,
                 Pmt::Null => return Ok(Pmt::F64(self.dev.frequency(Rx, *c)?)),
                 _ => return Ok(Pmt::InvalidValue),
             };
@@ -156,7 +163,9 @@ where
                 Pmt::F64(v) => self.dev.set_gain(Rx, *c, *v)?,
                 Pmt::U32(v) => self.dev.set_gain(Rx, *c, *v as f64)?,
                 Pmt::U64(v) => self.dev.set_gain(Rx, *c, *v as f64)?,
-                Pmt::Null => return Ok(Pmt::F64(self.dev.gain(Rx, *c)?.unwrap_or(f64::NAN))),
+                Pmt::Null => {
+                    return Ok(Pmt::F64(self.dev.gain(Rx, *c)?.unwrap_or(f64::NAN)));
+                }
                 _ => return Ok(Pmt::InvalidValue),
             };
         }
@@ -217,9 +226,8 @@ where
 }
 
 #[doc(hidden)]
-impl<D, OUT> Kernel for Source<D, OUT>
+impl<OUT> Kernel for Source<OUT>
 where
-    D: DeviceTrait + Clone,
     OUT: CpuBufferWriter<Item = Complex32>,
 {
     async fn work(
@@ -241,9 +249,9 @@ where
             Ok(len) => {
                 self.outputs.iter_mut().for_each(|o| o.produce(len));
             }
-            Err(seify::Error::Overflow) => {
+            Err(seify::Error::Overrun) => {
                 self.overflows += 1;
-                warn!("Seify Source Overflow");
+                warn!("Seify Source Overrun");
             }
             Err(e) => {
                 error!("Seify Source Error: {:?}", e);

--- a/tests/seify.rs
+++ b/tests/seify.rs
@@ -57,7 +57,7 @@ fn builder_compat_filter() -> Result<()> {
 fn builder_config() -> Result<()> {
     let mut fg = Flowgraph::new();
 
-    let dev = seify::Device::from_args("driver=dummy")?;
+    let dev = seify::DynDevice::from_args("driver=dummy")?;
     let src = Builder::from_device(dev.clone())
         .channels(vec![0]) //testing, same as default
         .sample_rate(1e6)
@@ -82,7 +82,7 @@ fn config_freq_gain_ports() -> Result<()> {
     futuresdr::runtime::init();
     let mut fg = Flowgraph::new();
 
-    let dev = seify::Device::from_args("driver=dummy")?;
+    let dev = seify::DynDevice::from_args("driver=dummy")?;
     let src = Builder::from_device(dev.clone())
         .sample_rate(1e6)
         .frequency(100e6)
@@ -116,7 +116,7 @@ fn config_freq_gain_ports() -> Result<()> {
 fn src_config_cmd_map() -> Result<()> {
     let mut fg = Flowgraph::new();
 
-    let dev = seify::Device::from_args("driver=dummy")?;
+    let dev = seify::DynDevice::from_args("driver=dummy")?;
 
     let src = Builder::from_device(dev.clone())
         .sample_rate(1e6)
@@ -161,7 +161,7 @@ fn src_config_cmd_map() -> Result<()> {
 fn sink_config_cmd_map() -> Result<()> {
     let mut fg = Flowgraph::new();
 
-    let dev = seify::Device::from_args("driver=dummy")?;
+    let dev = seify::DynDevice::from_args("driver=dummy")?;
 
     let snk = Builder::from_device(dev.clone())
         .sample_rate(1e6)
@@ -203,7 +203,7 @@ fn sink_config_cmd_map() -> Result<()> {
 fn src_config_cmd_invalid_chan() -> Result<()> {
     let mut fg = Flowgraph::new();
 
-    let dev = seify::Device::from_args("driver=dummy")?;
+    let dev = seify::DynDevice::from_args("driver=dummy")?;
     let src = Builder::from_device(dev.clone())
         .sample_rate(1e6)
         .frequency(100e6)


### PR DESCRIPTION
Switches to the new dynamic types (`DynDevice`/`DynRxStreamer`/`DynTxStreamer`), using the `*Control` traits as necessary.

It could also be nice to implement `From<Device<T>> for DynDevice` in Seify so that `Builder::from_device` can take both typed and dynamic devices. Happy to create a PR if you think it's a good idea.